### PR TITLE
Binary extended gcd (+ benchmarks and tests)

### DIFF
--- a/Math/NumberTheory/GCD.hs
+++ b/Math/NumberTheory/GCD.hs
@@ -90,8 +90,14 @@ binaryGCDImpl a b =
           (!zb, !ob) -> gcdOdd (abs oa) (abs ob) `shiftL` min za zb
 
 {-# RULES
-"binaryExtendedGCD/Int"  binaryExtendedGCD = egcdInt
-"binaryExtendedGCD/Word" binaryExtendedGCD = egcdWord
+"binaryExtendedGCD/Int"     binaryExtendedGCD = egcdInt
+"binaryExtendedGCD/Word"    binaryExtendedGCD = egcdWord
+"binaryExtendedGCD/Int8"    binaryExtendedGCD = egi8
+"binaryExtendedGCD/Int16"   binaryExtendedGCD = egi16
+"binaryExtendedGCD/Int32"   binaryExtendedGCD = egi32
+"binaryExtendedGCD/Word8"   binaryExtendedGCD = egw8
+"binaryExtendedGCD/Word16"  binaryExtendedGCD = egw16
+"binaryExtendedGCD/Word32"  binaryExtendedGCD = egw32
   #-}
 #if WORD_SIZE_IN_BITS == 64
 egi64 :: Int64 -> Int64 -> (Int64, Int64, Int64)
@@ -309,3 +315,22 @@ cw16 (W16# x#) (W16# y#) = coprimeWord# x# y#
 
 cw32 :: Word32 -> Word32 -> Bool
 cw32 (W32# x#) (W32# y#) = coprimeWord# x# y#
+
+egi8 :: Int8 -> Int8 -> (Int8, Int8, Int8)
+egi8 (I8# x#) (I8# y#) = (I8# a#, I8# b#, I8# v#) where (# a#, b#, v# #) = egcdInt# x# y#
+
+egi16 :: Int16 -> Int16 -> (Int16, Int16, Int16)
+egi16 (I16# x#) (I16# y#) = (I16# a#, I16# b#, I16# v#) where (# a#, b#, v# #) = egcdInt# x# y#
+
+egi32 :: Int32 -> Int32 -> (Int32, Int32, Int32)
+egi32 (I32# x#) (I32# y#) = (I32# a#, I32# b#, I32# v#) where (# a#, b#, v# #) = egcdInt# x# y#
+
+egw8 :: Word8 -> Word8 -> (Int8, Int8, Word8)
+egw8 (W8# x#) (W8# y#) = (I8# a#, I8# b#, W8# v#) where (# a#, b#, v# #) = egcdWord# x# y#
+
+egw16 :: Word16 -> Word16 -> (Int16, Int16, Word16)
+egw16 (W16# x#) (W16# y#) = (I16# a#, I16# b#, W16# v#) where (# a#, b#, v# #) = egcdWord# x# y#
+
+egw32 :: Word32 -> Word32 -> (Int32, Int32, Word32)
+egw32 (W32# x#) (W32# y#) = (I32# a#, I32# b#, W32# v#) where (# a#, b#, v# #) = egcdWord# x# y#
+

--- a/Math/NumberTheory/GCD.hs
+++ b/Math/NumberTheory/GCD.hs
@@ -101,14 +101,14 @@ binaryGCDImpl a b =
   #-}
 #if WORD_SIZE_IN_BITS == 64
 egi64 :: Int64 -> Int64 -> (Int64, Int64, Int64)
-egi64 (I64# x#) (I64# y#) = (I64# a#, I64# b#, I64# v#)
+egi64 (I64# x#) (I64# y#) = (I64# d#, I64# u#, I64# v#)
   where
-    (# a#, b#, v# #) = egcdInt# x# y#
+    (# d#, u#, v# #) = egcdInt# x# y#
 
-egw64 :: Word64 -> Word64 -> (Int64, Int64, Word64)
-egw64 (W64# x#) (W64# y#) = (I64# a#, I64# b#, W64# v#)
+egw64 :: Word64 -> Word64 -> (Word64, Int64, Int64)
+egw64 (W64# x#) (W64# y#) = (W64# d#, I64# u#, I64# v#)
   where
-    (# a#, b#, v# #) = egcdWord# x# y#
+    (# d#, u#, v# #) = egcdWord# x# y#
 
 {-# RULES
 "binaryExtendedGCD/Int64"   binaryExtendedGCD = egi64
@@ -125,15 +125,15 @@ egw64 (W64# x#) (W64# y#) = (I64# a#, I64# b#, W64# v#)
 --
 --   It is very slow for @'Integer'@ (and probably every type except the abovementioned),
 --   I recommend not using it for those.
-binaryExtendedGCD :: (Integral a, Bits a, Integral c, Bits c) => a -> a -> (c, c, a)
+binaryExtendedGCD :: (Integral a, Bits a, Integral c, Bits c) => a -> a -> (a, c, c)
 binaryExtendedGCD = binaryExtendedGCDImpl
 {-# INLINE [1] binaryExtendedGCD #-}
 
 {-# SPECIALISE binaryExtendedGCDImpl :: Integer -> Integer -> (Integer, Integer, Integer) #-}
-binaryExtendedGCDImpl :: (Integral a, Bits a, Integral c, Bits c) => a -> a -> (c, c, a)
-binaryExtendedGCDImpl 0 y = (0, fromIntegral (signum y), abs y)
-binaryExtendedGCDImpl x 0 = (fromIntegral (signum x), 0, abs x)
-binaryExtendedGCDImpl x y = (ra', rb', rv)
+binaryExtendedGCDImpl :: (Integral a, Bits a, Integral c, Bits c) => a -> a -> (a, c, c)
+binaryExtendedGCDImpl 0 y = (abs y, 0, fromIntegral (signum y))
+binaryExtendedGCDImpl x 0 = (abs x, fromIntegral (signum x), 0)
+binaryExtendedGCDImpl x y = (rv, ra', rb')
   where
     ra' = if x < 0 then negate ra else ra
     rb' = if y < 0 then negate rb else rb
@@ -317,20 +317,20 @@ cw32 :: Word32 -> Word32 -> Bool
 cw32 (W32# x#) (W32# y#) = coprimeWord# x# y#
 
 egi8 :: Int8 -> Int8 -> (Int8, Int8, Int8)
-egi8 (I8# x#) (I8# y#) = (I8# a#, I8# b#, I8# v#) where (# a#, b#, v# #) = egcdInt# x# y#
+egi8 (I8# x#) (I8# y#) = (I8# d#, I8# u#, I8# v#) where (# d#, u#, v# #) = egcdInt# x# y#
 
 egi16 :: Int16 -> Int16 -> (Int16, Int16, Int16)
-egi16 (I16# x#) (I16# y#) = (I16# a#, I16# b#, I16# v#) where (# a#, b#, v# #) = egcdInt# x# y#
+egi16 (I16# x#) (I16# y#) = (I16# d#, I16# u#, I16# v#) where (# d#, u#, v# #) = egcdInt# x# y#
 
 egi32 :: Int32 -> Int32 -> (Int32, Int32, Int32)
-egi32 (I32# x#) (I32# y#) = (I32# a#, I32# b#, I32# v#) where (# a#, b#, v# #) = egcdInt# x# y#
+egi32 (I32# x#) (I32# y#) = (I32# d#, I32# u#, I32# v#) where (# d#, u#, v# #) = egcdInt# x# y#
 
-egw8 :: Word8 -> Word8 -> (Int8, Int8, Word8)
-egw8 (W8# x#) (W8# y#) = (I8# a#, I8# b#, W8# v#) where (# a#, b#, v# #) = egcdWord# x# y#
+egw8 :: Word8 -> Word8 -> (Word8, Int8, Int8)
+egw8 (W8# x#) (W8# y#) = (W8# d#, I8# u#, I8# v#) where (# d#, u#, v# #) = egcdWord# x# y#
 
-egw16 :: Word16 -> Word16 -> (Int16, Int16, Word16)
-egw16 (W16# x#) (W16# y#) = (I16# a#, I16# b#, W16# v#) where (# a#, b#, v# #) = egcdWord# x# y#
+egw16 :: Word16 -> Word16 -> (Word16, Int16, Int16)
+egw16 (W16# x#) (W16# y#) = (W16# d#, I16# u#, I16# v#) where (# d#, u#, v# #) = egcdWord# x# y#
 
-egw32 :: Word32 -> Word32 -> (Int32, Int32, Word32)
-egw32 (W32# x#) (W32# y#) = (I32# a#, I32# b#, W32# v#) where (# a#, b#, v# #) = egcdWord# x# y#
+egw32 :: Word32 -> Word32 -> (Word32, Int32, Int32)
+egw32 (W32# x#) (W32# y#) = (W32# d#, I32# u#, I32# v#) where (# d#, u#, v# #) = egcdWord# x# y#
 

--- a/Math/NumberTheory/GCD/LowLevel.hs
+++ b/Math/NumberTheory/GCD/LowLevel.hs
@@ -111,14 +111,14 @@ absInt# i#
 
 -- | Binary extended GCD for @'Int'@ values.
 egcdInt :: Int -> Int -> (Int, Int, Int)
-egcdInt (I# x#) (I# y#) = (I# a#, I# b#, I# v#)
+egcdInt (I# x#) (I# y#) = (I# d#, I# u#, I# v#)
   where
-    (# a#, b#, v# #) = egcdInt# x# y#
+    (# d#, u#, v# #) = egcdInt# x# y#
 
 egcdInt# :: Int# -> Int# -> (# Int#, Int#, Int# #)
-egcdInt# x# y# = (# mulSign# a# x#, mulSign# b# y#, word2Int# v# #)
+egcdInt# x# y# = (# word2Int# d#, mulSign# u# x#, mulSign# v# y# #)
   where
-    (# a#, b#, v# #) = egcdWord# (int2Word# (absInt# x#)) (int2Word# (absInt# y#))
+    (# d#, u#, v# #) = egcdWord# (int2Word# (absInt# x#)) (int2Word# (absInt# y#))
     mulSign# w# i#
       | isTrue# (i# <# 0#) = negateInt# w#
       | otherwise          = w#
@@ -126,15 +126,15 @@ egcdInt# x# y# = (# mulSign# a# x#, mulSign# b# y#, word2Int# v# #)
 -- | Binary extended GCD for @'Word'@.
 -- Note that linear coefficients returned by @'egcdWord'@ are signed
 -- @'Int'@ values.
-egcdWord :: Word -> Word -> (Int, Int, Word)
-egcdWord (W# x#) (W# y#) = (I# a#, I# b#, W# v#)
+egcdWord :: Word -> Word -> (Word, Int, Int)
+egcdWord (W# x#) (W# y#) = (W# d#, I# u#, I# v#)
   where
-    (# a#, b#, v# #) = egcdWord# x# y#
+    (# d#, u#, v# #) = egcdWord# x# y#
 
-egcdWord# :: Word# -> Word# -> (# Int#, Int#, Word# #)
-egcdWord# 0## y#  = (# 0#, 1#, y# #)
-egcdWord# x#  0## = (# 1#, 0#, x# #)
-egcdWord# x#  y#  = (# ra#, rb#, rv# #)
+egcdWord# :: Word# -> Word# -> (# Word#, Int#, Int# #)
+egcdWord# 0## y#  = (# y#, 0#, 1# #)
+egcdWord# x#  0## = (# x#, 1#, 0# #)
+egcdWord# x#  y#  = (# rv#, ra#, rb# #)
   where
     (# ra#, rb#, rv# #) = loop# x'# y'# 1# 0# 0# 1#
 

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -1,6 +1,6 @@
 name                : arithmoi
 version             : 0.4.1.2
-cabal-version       : >= 1.6
+cabal-version       : >= 1.8
 author              : Daniel Fischer
 copyright           : (c) 2011 Daniel Fischer
 license             : MIT
@@ -83,3 +83,10 @@ library
 source-repository head
   type:     git
   location: https://github.com/cartazio/arithmoi
+
+benchmark criterion
+  build-depends:    base, arithmoi, criterion == 1.*
+  hs-source-dirs:   benchmark
+  main-is:          Bench.hs
+  type:             exitcode-stdio-1.0
+

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -85,7 +85,7 @@ source-repository head
   location: https://github.com/cartazio/arithmoi
 
 benchmark criterion
-  build-depends:    base, arithmoi, criterion == 1.*
+  build-depends:    base, arithmoi, criterion
   hs-source-dirs:   benchmark
   main-is:          Bench.hs
   type:             exitcode-stdio-1.0

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -90,3 +90,10 @@ benchmark criterion
   main-is:          Bench.hs
   type:             exitcode-stdio-1.0
 
+test-suite spec
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       test-suite
+  ghc-options:          -Wall
+  main-is:              Spec.hs
+  build-depends:        base, hspec, arithmoi
+

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -1,0 +1,10 @@
+module Main (main) where
+
+import Criterion.Main (bgroup, defaultMain)
+import qualified BinaryExtendedGcdBench
+
+main :: IO ()
+main = defaultMain
+    [ bgroup "Extended GCD" BinaryExtendedGcdBench.benchmarks
+    ]
+

--- a/benchmark/BinaryExtendedGCDBench.hs
+++ b/benchmark/BinaryExtendedGCDBench.hs
@@ -1,0 +1,26 @@
+module BinaryExtendedGcdBench (benchmarks) where
+
+import Criterion (Benchmark, bench, nf)
+import Math.NumberTheory.GCD (extendedGCD, binaryExtendedGCD)
+
+import Data.Word (Word)
+
+egcdBenchWord :: String -> (Word -> Word -> (Int, Int, Word)) -> Benchmark
+egcdBenchWord name f = bench name (nf (f 19234198273) 98176234001)
+
+egcdBenchInt :: String -> (Int -> Int -> (Int, Int, Int)) -> Benchmark
+egcdBenchInt name f = bench name (nf (f 19234198273) 98176234001)
+
+egcdBenchInteger :: String -> (Integer -> Integer -> (Integer, Integer, Integer)) -> Benchmark
+egcdBenchInteger name f = bench name (nf (f 19234198273) 98176234001)
+
+benchmarks :: [Benchmark]
+benchmarks =
+    [ egcdBenchWord "binaryExtendedGCD/Word" binaryExtendedGCD
+
+    , egcdBenchInt "extendedGCD/Int" extendedGCD
+    , egcdBenchInt "binaryExtendedGCD/Int" binaryExtendedGCD
+
+    , egcdBenchInteger "extendedGCD/Integer" extendedGCD
+    , egcdBenchInteger "binaryExtendedGCD/Integer" binaryExtendedGCD
+    ]

--- a/benchmark/BinaryExtendedGcdBench.hs
+++ b/benchmark/BinaryExtendedGcdBench.hs
@@ -5,7 +5,7 @@ import Math.NumberTheory.GCD (extendedGCD, binaryExtendedGCD)
 
 import Data.Word (Word)
 
-egcdBenchWord :: String -> (Word -> Word -> (Int, Int, Word)) -> Benchmark
+egcdBenchWord :: String -> (Word -> Word -> (Word, Int, Int)) -> Benchmark
 egcdBenchWord name f = bench name (nf (f 19234198273) 98176234001)
 
 egcdBenchInt :: String -> (Int -> Int -> (Int, Int, Int)) -> Benchmark

--- a/test-suite/Math/NumberTheory/GCDSpec.hs
+++ b/test-suite/Math/NumberTheory/GCDSpec.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module Math.NumberTheory.GCDSpec (main, spec) where
+
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Math.NumberTheory.GCD
+import Data.Word (Word)
+
+main :: IO ()
+main = hspec spec
+
+-- | Check whether (d, u, v) tuple is the extended GCD of (x, y) pair.
+-- That is check for:
+--
+-- gcd x y == d
+-- u * x + v * y == d
+isExtendedGcdOf :: (Integral a, Integral c) => (a, c, c) -> (a, a) -> Bool
+isExtendedGcdOf (d, u, v) (x, y) = (gcd x y == d) && (fromIntegral u * x + fromIntegral v * y == d)
+
+spec :: Spec
+spec = do
+  describe "extendedGCD" $ do
+    prop "is correct" $ do
+      \x y -> extendedGCD x y `isExtendedGcdOf` (x, y :: Integer)
+
+  describe "binaryExtendedGCD" $ do
+    -- check general version
+    prop "is correct for Integer" $ do
+      \x y -> (binaryExtendedGCD x y :: (Integer, Integer, Integer)) `isExtendedGcdOf` (x, y)
+    -- check specialised version
+    prop "is correct for Word" $ do
+      \x y -> (binaryExtendedGCD x y :: (Word, Int, Int)) `isExtendedGcdOf` (x, y)
+    -- check specialised version
+    prop "is correct for Int" $ do
+      \x y -> (binaryExtendedGCD x y :: (Int, Int, Int)) `isExtendedGcdOf` (x, y)

--- a/test-suite/Spec.hs
+++ b/test-suite/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
What's in:
- binary extended GCD with specialised versions for `Int` and `Word`;
- `hspec` test suite with tests for `binaryExtendedGCD` and `extendedGCD` (run `cabal test`);
- benchmarks comparing `extendedGCD` and `binaryExtendedGCD` (run `cabal bench`);
- Cabal version needed is 1.8 (because of benchmark section in `.cabal`).

I am not sure if `binaryExtendedGCD` is of any use for any of general types so, perhaps, it is `extendedGCD` that should have all those `RULES`.
`binaryExtendedGCD` can then be dismissed.
