### PR TITLE
Arithmoi fails to build on GHC 7.10.2 due to Word64 not being imported.

### DIFF
--- a/Math/NumberTheory/Moduli.hs
+++ b/Math/NumberTheory/Moduli.hs
@@ -34,9 +34,9 @@ module Math.NumberTheory.Moduli
 
 #include "MachDeps.h"
 
-#if __GLASGOW_HASKELL__ < 709
+-- #if __GLASGOW_HASKELL__ < 709
 import Data.Word
-#endif
+-- #endif
 import Data.Bits
 import Data.Array.Unboxed
 import Data.Array.Base (unsafeAt)

--- a/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
+++ b/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
@@ -42,9 +42,9 @@ import Data.Array.ST
 #endif
 import Control.Monad (when)
 import Data.Bits
-#if __GLASGOW_HASKELL__ < 709
+-- #if __GLASGOW_HASKELL__ < 709
 import Data.Word
-#endif
+-- #endif
 
 import Math.NumberTheory.Powers.Squares (integerSquareRoot)
 import Math.NumberTheory.Utils


### PR DESCRIPTION
Attempt to fix the following error when compiling on GHC 7.10.2:

```
    Not in scope: type constructor or class ‘Word64’
    Perhaps you meant ‘Word’ (imported from Prelude)
```