### PR TITLE
Tests and bug fixes for GCD, Logarithms and Powers

### DIFF
--- a/Math/NumberTheory/GCD.hs
+++ b/Math/NumberTheory/GCD.hs
@@ -83,10 +83,13 @@ binaryGCDImpl :: (Integral a, Bits a) => a -> a -> a
 binaryGCDImpl a 0 = abs a
 binaryGCDImpl 0 b = abs b
 binaryGCDImpl a b =
-    case shiftToOddCount a of
+    case shiftToOddCount a' of
       (!za, !oa) ->
-        case shiftToOddCount b of
+        case shiftToOddCount b' of
           (!zb, !ob) -> gcdOdd (abs oa) (abs ob) `shiftL` min za zb
+    where
+      a' = abs a
+      b' = abs b
 
 {-# SPECIALISE extendedGCD :: Int -> Int -> (Int, Int, Int),
                               Word -> Word -> (Word, Word, Word),

--- a/Math/NumberTheory/GCD.hs
+++ b/Math/NumberTheory/GCD.hs
@@ -98,16 +98,21 @@ binaryGCDImpl a b =
 -- | Calculate the greatest common divisor of two numbers and coefficients
 --   for the linear combination.
 --
---   Satisfies:
+--   For signed types satisfies:
 --
 -- > case extendedGCD a b of
 -- >   (d, u, v) -> u*a + v*b == d
--- >
--- > d == gcd a b
+-- >                && d == gcd a b
 --
---   and, for signed types,
+--   For unsigned and bounded types the property above holds, but since @u@ and @v@ must also be unsigned,
+--   the result may look weird. E. g., on 64-bit architecture
 --
--- >
+-- > extendedGCD (2 :: Word) (3 :: Word) == (1, 2^64-1, 1)
+--
+--   For unsigned and unbounded types (like 'Numeric.Natural.Natural') the result is undefined.
+--
+--   For signed types we also have
+--
 -- > abs u < abs b || abs b <= 1
 -- >
 -- > abs v < abs a || abs a <= 1

--- a/Math/NumberTheory/Powers/Fourth.hs
+++ b/Math/NumberTheory/Powers/Fourth.hs
@@ -41,6 +41,10 @@ import Math.NumberTheory.Utils (isTrue#)
 -- | Calculate the integer fourth root of a nonnegative number,
 --   that is, the largest integer @r@ with @r^4 <= n@.
 --   Throws an error on negaitve input.
+{-# SPECIALISE integerFourthRoot :: Int -> Int,
+                                    Integer -> Integer,
+                                    Word -> Word
+  #-}
 integerFourthRoot :: Integral a => a -> a
 integerFourthRoot n
     | n < 0     = error "integerFourthRoot: negative argument"

--- a/Math/NumberTheory/Powers/General.hs
+++ b/Math/NumberTheory/Powers/General.hs
@@ -162,14 +162,17 @@ isPerfectPower n
 --   of the prime exponents if some have been found, otherwise by trying
 --   prime exponents recursively.
 highestPower :: Integral a => a -> (a, Int)
-highestPower n
-  | abs n <= 1  = (n,3)
-  | n < 0       = case integerHighPower (toInteger $ negate n) of
+highestPower n'
+  | abs n <= 1  = (n', 3)
+  | n < 0       = case integerHighPower (negate n) of
                     (r,e) -> case shiftToOddCount e of
                                (k, o) -> (negate $ fromInteger (sqr k r), o)
-  | otherwise   = case integerHighPower (toInteger n) of
+  | otherwise   = case integerHighPower n of
                     (r,e) -> (fromInteger r, e)
     where
+      n :: Integer
+      n = toInteger n'
+
       sqr :: Int -> Integer -> Integer
       sqr 0 m = m
       sqr k m = sqr (k-1) (m*m)

--- a/Math/NumberTheory/Powers/General.hs
+++ b/Math/NumberTheory/Powers/General.hs
@@ -348,5 +348,6 @@ divisorsTo mx n = case shiftToOddCount n of
       | otherwise =
         case unP p m of
           (0,_) -> go st m ps
-          (k,r) -> go (Set.unions (st:take k (iterate (mset p) st))) r ps
+          -- iterate f x = [x, f x, f (f x)...]
+          (k,r) -> go (Set.unions (take (k + 1) (iterate (mset p) st))) r ps
     go st m [] = go st m [m+1]

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -117,6 +117,7 @@ test-suite spec
                         , smallcheck >= 1.1 && < 1.2
   other-modules :   Math.NumberTheory.GCDTests
                   , Math.NumberTheory.GCD.LowLevelTests
+                  , Math.NumberTheory.LogarithmsTests
                   , Math.NumberTheory.Powers.CubesTests
                   , Math.NumberTheory.Powers.FourthTests
                   , Math.NumberTheory.Powers.GeneralTests

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -115,7 +115,8 @@ test-suite spec
                         , tasty-hunit >= 0.9 && < 0.10
                         , QuickCheck >= 2.8 && < 2.9
                         , smallcheck >= 1.1 && < 1.2
-  other-modules :   Math.NumberTheory.Powers.CubesTests
+  other-modules :   Math.NumberTheory.GCDTests
+                  , Math.NumberTheory.Powers.CubesTests
                   , Math.NumberTheory.Powers.FourthTests
                   , Math.NumberTheory.Powers.GeneralTests
                   , Math.NumberTheory.Powers.IntegerTests

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -116,6 +116,7 @@ test-suite spec
                         , QuickCheck >= 2.8 && < 2.9
                         , smallcheck >= 1.1 && < 1.2
   other-modules :   Math.NumberTheory.GCDTests
+                  , Math.NumberTheory.GCD.LowLevelTests
                   , Math.NumberTheory.Powers.CubesTests
                   , Math.NumberTheory.Powers.FourthTests
                   , Math.NumberTheory.Powers.GeneralTests

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -120,5 +120,5 @@ test-suite spec
                   , Math.NumberTheory.Powers.GeneralTests
                   , Math.NumberTheory.Powers.IntegerTests
                   , Math.NumberTheory.Powers.SquaresTests
-                  , Math.NumberTheory.Powers.Utils
+                  , Math.NumberTheory.TestUtils
 

--- a/test-suite/Math/NumberTheory/GCD/LowLevelTests.hs
+++ b/test-suite/Math/NumberTheory/GCD/LowLevelTests.hs
@@ -1,0 +1,74 @@
+-- |
+-- Module:      Math.NumberTheory.GCD.LowLevelTests
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.GCD.LowLevel
+--
+
+{-# LANGUAGE CPP       #-}
+{-# LANGUAGE MagicHash #-}
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.GCD.LowLevelTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+
+#if MIN_VERSION_base(4,8,0)
+#else
+import Data.Word
+#endif
+
+import GHC.Base
+
+import Math.NumberTheory.GCD.LowLevel
+import Math.NumberTheory.TestUtils
+
+-- | Check that 'gcdInt' matches 'gcd'.
+gcdIntProperty :: Int -> Int -> Bool
+gcdIntProperty a b = gcdInt a b == gcd a b
+
+-- | Check that 'gcdWord' matches 'gcd'.
+gcdWordProperty :: Word -> Word -> Bool
+gcdWordProperty a b = gcdWord a b == gcd a b
+
+-- | Check that 'gcdInt#' matches 'gcd'.
+gcdIntProperty# :: Int -> Int -> Bool
+gcdIntProperty# a@(I# a') b@(I# b') = I# (gcdInt# a' b') == gcd a b
+
+-- | Check that 'gcdWord#' matches 'gcd'.
+gcdWordProperty# :: Word -> Word -> Bool
+gcdWordProperty# a@(W# a') b@(W# b') = W# (gcdWord# a' b') == gcd a b
+
+-- | Check that numbers are coprime iff their gcd equals to 1.
+coprimeIntProperty :: Int -> Int -> Bool
+coprimeIntProperty a b = coprimeInt a b == (gcd a b == 1)
+
+-- | Check that numbers are coprime iff their gcd equals to 1.
+coprimeWordProperty :: Word -> Word -> Bool
+coprimeWordProperty a b = coprimeWord a b == (gcd a b == 1)
+
+-- | Check that numbers are coprime iff their gcd equals to 1.
+coprimeIntProperty# :: Int -> Int -> Bool
+coprimeIntProperty# a@(I# a') b@(I# b') = coprimeInt# a' b' == (gcd a b == 1)
+
+-- | Check that numbers are coprime iff their gcd equals to 1.
+coprimeWordProperty# :: Word -> Word -> Bool
+coprimeWordProperty# a@(W# a') b@(W# b') = coprimeWord# a' b' == (gcd a b == 1)
+
+testSuite :: TestTree
+testSuite = testGroup "LowLevel"
+  [ testSmallAndQuick "gcdInt"       gcdIntProperty
+  , testSmallAndQuick "gcdWord"      gcdWordProperty
+  , testSmallAndQuick "gcdInt#"      gcdIntProperty#
+  , testSmallAndQuick "gcdWord#"     gcdWordProperty#
+  , testSmallAndQuick "coprimeInt"   coprimeIntProperty
+  , testSmallAndQuick "coprimeWord"  coprimeWordProperty
+  , testSmallAndQuick "coprimeInt#"  coprimeIntProperty#
+  , testSmallAndQuick "coprimeWord#" coprimeWordProperty#
+  ]

--- a/test-suite/Math/NumberTheory/GCD/LowLevelTests.hs
+++ b/test-suite/Math/NumberTheory/GCD/LowLevelTests.hs
@@ -24,7 +24,7 @@ import Test.Tasty
 import Data.Word
 #endif
 
-import GHC.Base
+import GHC.Exts
 
 import Math.NumberTheory.GCD.LowLevel
 import Math.NumberTheory.TestUtils

--- a/test-suite/Math/NumberTheory/GCDTests.hs
+++ b/test-suite/Math/NumberTheory/GCDTests.hs
@@ -1,0 +1,50 @@
+-- |
+-- Module:      Math.NumberTheory.GCDTests
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.GCD
+--
+
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.GCDTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+
+import Data.Bits
+
+import Math.NumberTheory.GCD
+import Math.NumberTheory.TestUtils
+
+-- | Check that 'binaryGCD' matches 'gcd'.
+binaryGCDProperty :: (Integral a, Bits a) => AnySign a -> AnySign a -> Bool
+binaryGCDProperty (AnySign a) (AnySign b) = binaryGCD a b == gcd a b
+
+-- | Check that 'extendedGCD' is consistent with documentation.
+extendedGCDProperty :: forall a. Integral a => AnySign a -> AnySign a -> Bool
+extendedGCDProperty (AnySign a) (AnySign b) =
+  u * a + v * b == d
+  && d == gcd a b
+  -- (-1) >= 0 is true for unsigned types
+  && (abs u < abs b || abs b <= 1 || (-1 :: a) >= 0)
+  && (abs v < abs a || abs a <= 1 || (-1 :: a) >= 0)
+  where
+    (d, u, v) = extendedGCD a b
+
+-- | Check that numbers are coprime iff their gcd equals to 1.
+coprimeProperty :: (Integral a, Bits a) => AnySign a -> AnySign a -> Bool
+coprimeProperty (AnySign a) (AnySign b) = coprime a b == (gcd a b == 1)
+
+testSuite :: TestTree
+testSuite = testGroup "GCD"
+  [ testSameIntegralProperty "binaryGCD"   binaryGCDProperty
+  , testSameIntegralProperty "extendedGCD" extendedGCDProperty
+  , testSameIntegralProperty "coprime"     coprimeProperty
+  ]

--- a/test-suite/Math/NumberTheory/LogarithmsTests.hs
+++ b/test-suite/Math/NumberTheory/LogarithmsTests.hs
@@ -1,0 +1,102 @@
+-- |
+-- Module:      Math.NumberTheory.LogarithmsTests
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.Logarithms
+--
+
+{-# LANGUAGE CPP       #-}
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.LogarithmsTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+
+#if MIN_VERSION_base(4,8,0)
+#else
+import Data.Word
+#endif
+
+import Math.NumberTheory.Logarithms
+import Math.NumberTheory.TestUtils
+
+-- | Check that 'integerLogBase' returns the largest integer @l@ such that @b@ ^ @l@ <= @n@ and @b@ ^ (@l@+1) > @n@.
+integerLogBaseProperty :: Positive Integer -> Positive Integer -> Bool
+integerLogBaseProperty (Positive b) (Positive n) = b == 1 || b ^ l <= n && b ^ (l + 1) > n
+  where
+    l = toInteger $ integerLogBase b n
+
+-- | Check that 'integerLog2' returns the largest integer @l@ such that 2 ^ @l@ <= @n@ and 2 ^ (@l@+1) > @n@.
+integerLog2Property :: Positive Integer -> Bool
+integerLog2Property (Positive n) = 2 ^ l <= n && 2 ^ (l + 1) > n
+  where
+    l = toInteger $ integerLog2 n
+
+-- | Check that 'integerLog10' returns the largest integer @l@ such that 10 ^ @l@ <= @n@ and 10 ^ (@l@+1) > @n@.
+integerLog10Property :: Positive Integer -> Bool
+integerLog10Property (Positive n) = 10 ^ l <= n && 10 ^ (l + 1) > n
+  where
+    l = toInteger $ integerLog10 n
+
+-- | Check that 'intLog2' returns the largest integer @l@ such that 2 ^ @l@ <= @n@ and 2 ^ (@l@+1) > @n@.
+intLog2Property :: Positive Int -> Bool
+intLog2Property (Positive n) = 2 ^ l <= n && (2 ^ (l + 1) > n || n > maxBound `div` 2)
+  where
+    l = intLog2 n
+
+-- | Check that 'wordLog2' returns the largest integer @l@ such that 2 ^ @l@ <= @n@ and 2 ^ (@l@+1) > @n@.
+wordLog2Property :: Positive Word -> Bool
+wordLog2Property (Positive n) = 2 ^ l <= n && (2 ^ (l + 1) > n || n > maxBound `div` 2)
+  where
+    l = wordLog2 n
+
+-- | Check that 'integerLogBase'' returns the largest integer @l@ such that @b@ ^ @l@ <= @n@ and @b@ ^ (@l@+1) > @n@.
+integerLogBase'Property :: Positive Integer -> Positive Integer -> Bool
+integerLogBase'Property (Positive b) (Positive n) = b == 1 || b ^ l <= n && b ^ (l + 1) > n
+  where
+    l = toInteger $ integerLogBase' b n
+
+-- | Check that 'integerLog2'' returns the largest integer @l@ such that 2 ^ @l@ <= @n@ and 2 ^ (@l@+1) > @n@.
+integerLog2'Property :: Positive Integer -> Bool
+integerLog2'Property (Positive n) = 2 ^ l <= n && 2 ^ (l + 1) > n
+  where
+    l = toInteger $ integerLog2' n
+
+-- | Check that 'integerLog10'' returns the largest integer @l@ such that 10 ^ @l@ <= @n@ and 10 ^ (@l@+1) > @n@.
+integerLog10'Property :: Positive Integer -> Bool
+integerLog10'Property (Positive n) = 10 ^ l <= n && 10 ^ (l + 1) > n
+  where
+    l = toInteger $ integerLog10' n
+
+-- | Check that 'intLog2'' returns the largest integer @l@ such that 2 ^ @l@ <= @n@ and 2 ^ (@l@+1) > @n@.
+intLog2'Property :: Positive Int -> Bool
+intLog2'Property (Positive n) = 2 ^ l <= n && (2 ^ (l + 1) > n || n > maxBound `div` 2)
+  where
+    l = intLog2' n
+
+-- | Check that 'wordLog2'' returns the largest integer @l@ such that 2 ^ @l@ <= @n@ and 2 ^ (@l@+1) > @n@.
+wordLog2'Property :: Positive Word -> Bool
+wordLog2'Property (Positive n) = 2 ^ l <= n && (2 ^ (l + 1) > n || n > maxBound `div` 2)
+  where
+    l = wordLog2' n
+
+testSuite :: TestTree
+testSuite = testGroup "Logarithms"
+  [ testSmallAndQuick "integerLogBase"  integerLogBaseProperty
+  , testSmallAndQuick "integerLog2"     integerLog2Property
+  , testSmallAndQuick "integerLog10"    integerLog10Property
+  , testSmallAndQuick "intLog2"         intLog2Property
+  , testSmallAndQuick "wordLog2"        wordLog2Property
+
+  , testSmallAndQuick "integerLogBase'" integerLogBase'Property
+  , testSmallAndQuick "integerLog2'"    integerLog2'Property
+  , testSmallAndQuick "integerLog10'"   integerLog10'Property
+  , testSmallAndQuick "intLog2'"        intLog2'Property
+  , testSmallAndQuick "wordLog2'"       wordLog2'Property
+  ]

--- a/test-suite/Math/NumberTheory/LogarithmsTests.hs
+++ b/test-suite/Math/NumberTheory/LogarithmsTests.hs
@@ -62,6 +62,14 @@ integerLogBase'Property (Positive b) (Positive n) = b == 1 || b ^ l <= n && b ^ 
   where
     l = toInteger $ integerLogBase' b n
 
+-- | Check that 'integerLogBase'' returns the largest integer @l@ such that @b@ ^ @l@ <= @n@ and @b@ ^ (@l@+1) > @n@ for @b@ > 32 and @n@ >= @b@ ^ 2.
+integerLogBase'Property2 :: Positive Integer -> Positive Integer -> Bool
+integerLogBase'Property2 (Positive b') (Positive n') = b ^ l <= n && b ^ (l + 1) > n
+  where
+    b = b' + 32
+    n = n' + b ^ 2 - 1
+    l = toInteger $ integerLogBase' b n
+
 -- | Check that 'integerLog2'' returns the largest integer @l@ such that 2 ^ @l@ <= @n@ and 2 ^ (@l@+1) > @n@.
 integerLog2'Property :: Positive Integer -> Bool
 integerLog2'Property (Positive n) = 2 ^ l <= n && 2 ^ (l + 1) > n
@@ -95,6 +103,8 @@ testSuite = testGroup "Logarithms"
   , testSmallAndQuick "wordLog2"        wordLog2Property
 
   , testSmallAndQuick "integerLogBase'" integerLogBase'Property
+  , testSmallAndQuick "integerLogBase' with base > 32 and n >= base ^ 2"
+      integerLogBase'Property2
   , testSmallAndQuick "integerLog2'"    integerLog2'Property
   , testSmallAndQuick "integerLog10'"   integerLog10'Property
   , testSmallAndQuick "intLog2'"        intLog2'Property

--- a/test-suite/Math/NumberTheory/Powers/CubesTests.hs
+++ b/test-suite/Math/NumberTheory/Powers/CubesTests.hs
@@ -8,6 +8,8 @@
 -- Tests for Math.NumberTheory.Powers.Cubes
 --
 
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 module Math.NumberTheory.Powers.CubesTests
@@ -15,11 +17,19 @@ module Math.NumberTheory.Powers.CubesTests
   ) where
 
 import Test.Tasty
+import Test.Tasty.HUnit
 
 import Data.Maybe
+#if MIN_VERSION_base(4,8,0)
+#else
+import Data.Word
+#endif
+
 
 import Math.NumberTheory.Powers.Cubes
 import Math.NumberTheory.TestUtils
+
+#include "MachDeps.h"
 
 -- | Check that 'integerCubeRoot' returns the largest integer @m@ with @m^3 <= n@.
 --
@@ -35,6 +45,56 @@ integerCubeRootProperty (AnySign n) = m ^ 3 <= n && (m + 1) ^ 3 /= n && cond
       | m == -1   = n == -1
       | m < 0     = (m + 1) ^ 2 <= n `div` (m + 1)
       | otherwise = (m + 1) ^ 2 >= n `div` (m + 1)
+
+-- | Specialized to trigger 'cubeRootInt''.
+integerCubeRootProperty_Int :: AnySign Int -> Bool
+integerCubeRootProperty_Int = integerCubeRootProperty
+
+-- | Specialized to trigger 'cubeRootWord'.
+integerCubeRootProperty_Word :: AnySign Word -> Bool
+integerCubeRootProperty_Word = integerCubeRootProperty
+
+-- | Specialized to trigger 'cubeRootIgr'.
+integerCubeRootProperty_Integer :: AnySign Integer -> Bool
+integerCubeRootProperty_Integer = integerCubeRootProperty
+
+-- | Check that 'integerCubeRoot' returns the largest integer @m@ with @m^3 <= n@, , where @n@ has form @k@^3-1.
+integerCubeRootProperty2 :: Integral a => AnySign a -> Bool
+integerCubeRootProperty2 (AnySign k) = m ^ 3 <= n && (m + 1) ^ 3 /= n && cond
+  where
+    n = k ^ 3 - 1
+    m = integerCubeRoot n
+    cond
+      | m == -1   = n == -1
+      | m < 0     = (m + 1) ^ 2 <= n `div` (m + 1)
+      | otherwise = (m + 1) ^ 2 >= n `div` (m + 1)
+
+-- | Specialized to trigger 'cubeRootInt''.
+integerCubeRootProperty2_Int :: AnySign Int -> Bool
+integerCubeRootProperty2_Int = integerCubeRootProperty2
+
+-- | Specialized to trigger 'cubeRootWord'.
+integerCubeRootProperty2_Word :: AnySign Word -> Bool
+integerCubeRootProperty2_Word = integerCubeRootProperty2
+
+#if WORD_SIZE_IN_BITS == 64
+
+-- | Check that 'integerCubeRoot' of 2^63-1 is 2^21-1, not 2^21.
+integerCubeRootSpecialCase1_Int :: Assertion
+integerCubeRootSpecialCase1_Int =
+  assertEqual "integerCubeRoot" (integerCubeRoot (maxBound :: Int)) (2 ^ 21 - 1)
+
+-- | Check that 'integerCubeRoot' of 2^63-1 is 2^21-1, not 2^21.
+integerCubeRootSpecialCase1_Word :: Assertion
+integerCubeRootSpecialCase1_Word =
+  assertEqual "integerCubeRoot" (integerCubeRoot (maxBound `div` 2 :: Word)) (2 ^ 21 - 1)
+
+-- | Check that 'integerCubeRoot' of 2^64-1 is 2642245.
+integerCubeRootSpecialCase2 :: Assertion
+integerCubeRootSpecialCase2 =
+  assertEqual "integerCubeRoot" (integerCubeRoot (maxBound :: Word)) 2642245
+
+#endif
 
 -- | Check that 'integerCubeRoot'' returns the largest integer @m@ with @m^3 <= n@.
 integerCubeRoot'Property :: Integral a => NonNegative a -> Bool
@@ -72,7 +132,20 @@ isPossibleCubeProperty (NonNegative n) = t || not t && isNothing m
 
 testSuite :: TestTree
 testSuite = testGroup "Cubes"
-  [ testIntegralProperty "integerCubeRoot"  integerCubeRootProperty
+  [ testGroup "integerCubeRoot"
+    [ testIntegralProperty "generic"         integerCubeRootProperty
+    , testSmallAndQuick    "generic Int"     integerCubeRootProperty_Int
+    , testSmallAndQuick    "generic Word"    integerCubeRootProperty_Word
+    , testSmallAndQuick    "generic Integer" integerCubeRootProperty_Integer
+
+    , testIntegralProperty "almost cube"      integerCubeRootProperty2
+    , testSmallAndQuick    "almost cube Int"  integerCubeRootProperty2_Int
+    , testSmallAndQuick    "almost cube Word" integerCubeRootProperty2_Word
+
+    , testCase             "maxBound :: Int"      integerCubeRootSpecialCase1_Int
+    , testCase             "maxBound / 2 :: Word" integerCubeRootSpecialCase1_Word
+    , testCase             "maxBound :: Word"     integerCubeRootSpecialCase2
+    ]
   , testIntegralProperty "integerCubeRoot'" integerCubeRoot'Property
   , testIntegralProperty "isCube"           isCubeProperty
   , testIntegralProperty "isCube'"          isCube'Property

--- a/test-suite/Math/NumberTheory/Powers/CubesTests.hs
+++ b/test-suite/Math/NumberTheory/Powers/CubesTests.hs
@@ -15,12 +15,11 @@ module Math.NumberTheory.Powers.CubesTests
   ) where
 
 import Test.Tasty
-import Test.SmallCheck.Series
 
 import Data.Maybe
 
 import Math.NumberTheory.Powers.Cubes
-import Math.NumberTheory.Powers.Utils
+import Math.NumberTheory.TestUtils
 
 -- | Check that 'integerCubeRoot' returns the largest integer @m@ with @m^3 <= n@.
 --

--- a/test-suite/Math/NumberTheory/Powers/FourthTests.hs
+++ b/test-suite/Math/NumberTheory/Powers/FourthTests.hs
@@ -8,6 +8,8 @@
 -- Tests for Math.NumberTheory.Powers.Fourth
 --
 
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 module Math.NumberTheory.Powers.FourthTests
@@ -15,11 +17,18 @@ module Math.NumberTheory.Powers.FourthTests
   ) where
 
 import Test.Tasty
+import Test.Tasty.HUnit
 
 import Data.Maybe
+#if MIN_VERSION_base(4,8,0)
+#else
+import Data.Word
+#endif
 
 import Math.NumberTheory.Powers.Fourth
 import Math.NumberTheory.TestUtils
+
+#include "MachDeps.h"
 
 -- | Check that 'integerFourthRoot' returns the largest integer @m@ with @m^4 <= n@.
 --
@@ -31,6 +40,52 @@ integerFourthRootProperty :: Integral a => NonNegative a -> Bool
 integerFourthRootProperty (NonNegative n) = m >= 0 && m ^ 4 <= n && (m + 1) ^ 4 /= n && (m + 1) ^ 3 >= n `div` (m + 1)
   where
     m = integerFourthRoot n
+
+-- | Specialized to trigger 'biSqrtInt'.
+integerFourthRootProperty_Int :: NonNegative Int -> Bool
+integerFourthRootProperty_Int = integerFourthRootProperty
+
+-- | Specialized to trigger 'biSqrtWord'.
+integerFourthRootProperty_Word :: NonNegative Word -> Bool
+integerFourthRootProperty_Word = integerFourthRootProperty
+
+-- | Specialized to trigger 'biSqrtIgr'.
+integerFourthRootProperty_Integer :: NonNegative Integer -> Bool
+integerFourthRootProperty_Integer = integerFourthRootProperty
+
+-- | Check that 'integerFourthRoot' returns the largest integer @m@ with @m^4 <= n@, , where @n@ has form @k@^4-1.
+integerFourthRootProperty2 :: Integral a => NonNegative a -> Bool
+integerFourthRootProperty2 (NonNegative k) = n < 0 || m >= 0 && m ^ 4 <= n && (m + 1) ^ 4 /= n && (m + 1) ^ 3 >= n `div` (m + 1)
+  where
+    n = k ^ 4 - 1
+    m = integerFourthRoot n
+
+-- | Specialized to trigger 'biSqrtInt.
+integerFourthRootProperty2_Int :: NonNegative Int -> Bool
+integerFourthRootProperty2_Int = integerFourthRootProperty2
+
+-- | Specialized to trigger 'biSqrtWord'.
+integerFourthRootProperty2_Word :: NonNegative Word -> Bool
+integerFourthRootProperty2_Word = integerFourthRootProperty2
+
+#if WORD_SIZE_IN_BITS == 64
+
+-- | Check that 'integerFourthRoot' of 2^60-1 is 2^15-1, not 2^15.
+integerFourthRootSpecialCase1_Int :: Assertion
+integerFourthRootSpecialCase1_Int =
+  assertEqual "integerFourthRoot" (integerFourthRoot (maxBound `div` 8 :: Int)) (2 ^ 15 - 1)
+
+-- | Check that 'integerFourthRoot' of 2^60-1 is 2^15-1, not 2^15.
+integerFourthRootSpecialCase1_Word :: Assertion
+integerFourthRootSpecialCase1_Word =
+  assertEqual "integerFourthRoot" (integerFourthRoot (maxBound `div` 16 :: Word)) (2 ^ 15 - 1)
+
+-- | Check that 'integerFourthRoot' of 2^64-1 is 2^16-1, not 2^16.
+integerFourthRootSpecialCase2 :: Assertion
+integerFourthRootSpecialCase2 =
+  assertEqual "integerFourthRoot" (integerFourthRoot (maxBound :: Word)) (2 ^ 16 - 1)
+
+#endif
 
 -- | Check that 'integerFourthRoot'' returns the largest integer @m@ with @m^4 <= n@.
 integerFourthRoot'Property :: Integral a => NonNegative a -> Bool
@@ -68,7 +123,20 @@ isPossibleFourthPowerProperty (NonNegative n) = t || not t && isNothing m
 
 testSuite :: TestTree
 testSuite = testGroup "Fourth"
-  [ testIntegralProperty "integerFourthRoot"     integerFourthRootProperty
+  [ testGroup "integerFourthRoot"
+    [ testIntegralProperty "generic"         integerFourthRootProperty
+    , testSmallAndQuick    "generic Int"     integerFourthRootProperty_Int
+    , testSmallAndQuick    "generic Word"    integerFourthRootProperty_Word
+    , testSmallAndQuick    "generic Integer" integerFourthRootProperty_Integer
+
+    , testIntegralProperty "almost Fourth"      integerFourthRootProperty2
+    , testSmallAndQuick    "almost Fourth Int"  integerFourthRootProperty2_Int
+    , testSmallAndQuick    "almost Fourth Word" integerFourthRootProperty2_Word
+
+    , testCase             "maxBound / 8 :: Int"   integerFourthRootSpecialCase1_Int
+    , testCase             "maxBound / 16 :: Word" integerFourthRootSpecialCase1_Word
+    , testCase             "maxBound :: Word"      integerFourthRootSpecialCase2
+    ]
   , testIntegralProperty "integerFourthRoot'"    integerFourthRoot'Property
   , testIntegralProperty "isFourthPower"         isFourthPowerProperty
   , testIntegralProperty "isFourthPower'"        isFourthPower'Property

--- a/test-suite/Math/NumberTheory/Powers/FourthTests.hs
+++ b/test-suite/Math/NumberTheory/Powers/FourthTests.hs
@@ -15,12 +15,11 @@ module Math.NumberTheory.Powers.FourthTests
   ) where
 
 import Test.Tasty
-import Test.SmallCheck.Series
 
 import Data.Maybe
 
 import Math.NumberTheory.Powers.Fourth
-import Math.NumberTheory.Powers.Utils
+import Math.NumberTheory.TestUtils
 
 -- | Check that 'integerFourthRoot' returns the largest integer @m@ with @m^4 <= n@.
 --

--- a/test-suite/Math/NumberTheory/Powers/GeneralTests.hs
+++ b/test-suite/Math/NumberTheory/Powers/GeneralTests.hs
@@ -8,6 +8,8 @@
 -- Tests for Math.NumberTheory.Powers.General
 --
 
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 module Math.NumberTheory.Powers.GeneralTests
@@ -16,6 +18,10 @@ module Math.NumberTheory.Powers.GeneralTests
 
 import Test.Tasty
 import Test.Tasty.HUnit
+#if MIN_VERSION_base(4,8,0)
+#else
+import Data.Word
+#endif
 
 import Math.NumberTheory.Powers.General
 import Math.NumberTheory.TestUtils
@@ -62,25 +68,65 @@ largePFPowerProperty (Positive bd) n = bd == 1 || b == 0 || d' /= 0 || n <= b * 
     (b, k) = largePFPower bd n
     (d, d') = bd `quotRem` b
 
--- | Freezes before d44a13b.
-highestPowerSpecialCase1 :: Assertion
-highestPowerSpecialCase1 =
-  assertEqual "highestPower" (highestPower 1013582159576576) (1013582159576576, 1 :: Int)
+highestPowerSpecialCases :: [Assertion]
+highestPowerSpecialCases =
+  -- Freezes before d44a13b.
+  [ a ( 1013582159576576
+      , 1013582159576576
+      , 1)
+  -- Freezes before d44a13b.
+  , a ( 1013582159576576 ^ 7
+      , 1013582159576576
+      , 7)
 
--- | Freezes before d44a13b.
-highestPowerSpecialCase2 :: Assertion
-highestPowerSpecialCase2 =
-  assertEqual "highestPower" (highestPower $ 1013582159576576^7) (1013582159576576, 7 :: Int)
+  , a ( -2 ^ 63 :: Int
+      , -2 :: Int
+      , 63)
+
+  , a ( (2 ^ 63 - 1) ^ 21
+      , 2 ^ 63 - 1
+      , 21)
+
+  , a ( 576116746989720969230211509779286598589421531472851155101032940901763389787901933902294777750323196846498573545522289802689311975294763847414975335235584
+      , 576116746989720969230211509779286598589421531472851155101032940901763389787901933902294777750323196846498573545522289802689311975294763847414975335235584
+      , 1)
+
+  , a ( -340282366920938463500268095579187314689
+      , -340282366920938463500268095579187314689
+      , 1)
+
+  , a ( 268398749 :: Int
+      , 268398749 :: Int
+      , 1)
+
+  , a ( 118372752099 :: Int
+      , 118372752099 :: Int
+      , 1)
+
+  , a ( 1409777209 :: Int
+      , 37547 :: Int
+      , 2)
+
+  , a ( -6277101735386680764856636523970481806547819498980467802113
+      , -18446744073709551617
+      , 3)
+
+  , a ( -18446744073709551619 ^ 5
+      , -18446744073709551619
+      , 5)
+  ]
+  where
+    a (n, b, k) = assertEqual "highestPower" (b, k) (highestPower n)
 
 testSuite :: TestTree
 testSuite = testGroup "General"
-  [ testCase              "highestPower special case 1" highestPowerSpecialCase1
-  , testCase              "highestPower special case 2" highestPowerSpecialCase2
-
-  , testIntegral2Property "integerRoot"    integerRootProperty
+  [ testIntegral2Property "integerRoot"    integerRootProperty
   , testIntegral2Property "isKthPower"     isKthPowerProperty
   , testIntegral2Property "exactRoot"      exactRootProperty
   , testIntegralProperty  "isPerfectPower" isPerfectPowerProperty
-  , testIntegralProperty  "highestPower"   highestPowerProperty
+  , testGroup "highestPower"
+    ( testIntegralProperty  "highestPower"   highestPowerProperty
+    : zipWith (\i a -> testCase ("special case " ++ show i) a) [1..] highestPowerSpecialCases
+    )
   , testSmallAndQuick     "largePFPower"   largePFPowerProperty
   ]

--- a/test-suite/Math/NumberTheory/Powers/GeneralTests.hs
+++ b/test-suite/Math/NumberTheory/Powers/GeneralTests.hs
@@ -15,11 +15,10 @@ module Math.NumberTheory.Powers.GeneralTests
   ) where
 
 import Test.Tasty
-import Test.SmallCheck.Series
 import Test.Tasty.HUnit
 
 import Math.NumberTheory.Powers.General
-import Math.NumberTheory.Powers.Utils
+import Math.NumberTheory.TestUtils
 
 -- | Check that 'integerRoot' @pow@ returns the largest integer @m@ with @m^pow <= n@.
 integerRootProperty :: (Integral a, Integral b) => AnySign a -> Power b -> Bool

--- a/test-suite/Math/NumberTheory/Powers/GeneralTests.hs
+++ b/test-suite/Math/NumberTheory/Powers/GeneralTests.hs
@@ -18,10 +18,6 @@ module Math.NumberTheory.Powers.GeneralTests
 
 import Test.Tasty
 import Test.Tasty.HUnit
-#if MIN_VERSION_base(4,8,0)
-#else
-import Data.Word
-#endif
 
 import Math.NumberTheory.Powers.General
 import Math.NumberTheory.TestUtils

--- a/test-suite/Math/NumberTheory/Powers/IntegerTests.hs
+++ b/test-suite/Math/NumberTheory/Powers/IntegerTests.hs
@@ -24,7 +24,7 @@ import Data.Word
 #endif
 
 import Math.NumberTheory.Powers.Integer
-import Math.NumberTheory.Powers.Utils
+import Math.NumberTheory.TestUtils
 
 -- | Check that 'integerPower' == '^'.
 integerPowerProperty :: Integer -> Power Int -> Bool

--- a/test-suite/Math/NumberTheory/Powers/SquaresTests.hs
+++ b/test-suite/Math/NumberTheory/Powers/SquaresTests.hs
@@ -15,12 +15,11 @@ module Math.NumberTheory.Powers.SquaresTests
   ) where
 
 import Test.Tasty
-import Test.SmallCheck.Series
 
 import Data.Maybe
 
 import Math.NumberTheory.Powers.Squares
-import Math.NumberTheory.Powers.Utils
+import Math.NumberTheory.TestUtils
 
 -- | Check that 'integerSquareRoot' returns the largest integer @m@ with @m*m <= n@.
 --

--- a/test-suite/Math/NumberTheory/TestUtils.hs
+++ b/test-suite/Math/NumberTheory/TestUtils.hs
@@ -1,12 +1,12 @@
 -- |
--- Module:      Math.NumberTheory.Powers.CubesTests
+-- Module:      Math.NumberTheory.TestUtils
 -- Copyright:   (c) 2016 Andrew Lelechenko
 -- Licence:     MIT
 -- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
 -- Stability:   Provisional
 -- Portability: Non-portable (GHC extensions)
 --
--- Utils to test Math.NumberTheory.Powers
+-- Utils to test Math.NumberTheory
 --
 
 {-# LANGUAGE ConstraintKinds            #-}
@@ -25,7 +25,10 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
-module Math.NumberTheory.Powers.Utils where
+module Math.NumberTheory.TestUtils
+  ( module Math.NumberTheory.TestUtils
+  , module Test.SmallCheck.Series
+  ) where
 
 import Test.Tasty
 import Test.Tasty.SmallCheck as SC
@@ -34,6 +37,7 @@ import Test.Tasty.QuickCheck as QC hiding (Positive, NonNegative, generate, getN
 import Test.SmallCheck.Series (Positive(..), NonNegative(..), Serial(..), Series, generate)
 
 import Control.Applicative
+import Data.Bits
 #if MIN_VERSION_base(4,8,0)
 #else
 import Data.Foldable (Foldable)
@@ -98,7 +102,7 @@ type TestableIntegral wrapper =
 
 testIntegralProperty
   :: forall wrapper. TestableIntegral wrapper
-  => String -> (forall a. (Integral a) => wrapper a -> Bool) -> TestTree
+  => String -> (forall a. (Integral a, Bits a) => wrapper a -> Bool) -> TestTree
 testIntegralProperty name f = testGroup name
   [ SC.testProperty "smallcheck Int"     (f :: wrapper Int     -> Bool)
   , SC.testProperty "smallcheck Word"    (f :: wrapper Word    -> Bool)
@@ -113,7 +117,7 @@ testIntegralProperty name f = testGroup name
 
 testIntegral2Property
   :: forall wrapper1 wrapper2. (TestableIntegral wrapper1, TestableIntegral wrapper2)
-  => String -> (forall a1 a2. (Integral a1, Integral a2) => wrapper1 a1 -> wrapper2 a2 -> Bool) -> TestTree
+  => String -> (forall a1 a2. (Integral a1, Integral a2, Bits a1, Bits a2) => wrapper1 a1 -> wrapper2 a2 -> Bool) -> TestTree
 testIntegral2Property name f = testGroup name
   [ SC.testProperty "smallcheck Int Int"         (f :: wrapper1 Int     -> wrapper2 Int     -> Bool)
   , SC.testProperty "smallcheck Int Word"        (f :: wrapper1 Int     -> wrapper2 Word    -> Bool)

--- a/test-suite/Math/NumberTheory/TestUtils.hs
+++ b/test-suite/Math/NumberTheory/TestUtils.hs
@@ -28,6 +28,7 @@
 module Math.NumberTheory.TestUtils
   ( module Math.NumberTheory.TestUtils
   , module Test.SmallCheck.Series
+  , Large(..)
   ) where
 
 import Test.Tasty

--- a/test-suite/Math/NumberTheory/TestUtils.hs
+++ b/test-suite/Math/NumberTheory/TestUtils.hs
@@ -115,6 +115,21 @@ testIntegralProperty name f = testGroup name
   , QC.testProperty "quickcheck Huge  Integer" ((f :: wrapper Integer -> Bool) . getHuge)
   ]
 
+testSameIntegralProperty
+  :: forall wrapper. TestableIntegral wrapper
+  => String -> (forall a. (Integral a, Bits a) => wrapper a -> wrapper a -> Bool) -> TestTree
+testSameIntegralProperty name f = testGroup name
+  [ SC.testProperty "smallcheck Int"     (f :: wrapper Int     -> wrapper Int     -> Bool)
+  , SC.testProperty "smallcheck Word"    (f :: wrapper Word    -> wrapper Word    -> Bool)
+  , SC.testProperty "smallcheck Integer" (f :: wrapper Integer -> wrapper Integer -> Bool)
+  , QC.testProperty "quickcheck Int"     (f :: wrapper Int     -> wrapper Int     -> Bool)
+  , QC.testProperty "quickcheck Word"    (f :: wrapper Word    -> wrapper Word    -> Bool)
+  , QC.testProperty "quickcheck Integer" (f :: wrapper Integer -> wrapper Integer -> Bool)
+  , QC.testProperty "quickcheck Large Int"     (\(Large a) (Large b) -> (f :: wrapper Int     -> wrapper Int     -> Bool) a b)
+  , QC.testProperty "quickcheck Large Word"    (\(Large a) (Large b) -> (f :: wrapper Word    -> wrapper Word    -> Bool) a b)
+  , QC.testProperty "quickcheck Huge  Integer" (\(Huge  a) (Huge  b) -> (f :: wrapper Integer -> wrapper Integer -> Bool) a b)
+  ]
+
 testIntegral2Property
   :: forall wrapper1 wrapper2. (TestableIntegral wrapper1, TestableIntegral wrapper2)
   => String -> (forall a1 a2. (Integral a1, Integral a2, Bits a1, Bits a2) => wrapper1 a1 -> wrapper2 a2 -> Bool) -> TestTree

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -1,6 +1,7 @@
 import Test.Tasty
 
 import qualified Math.NumberTheory.GCDTests as GCD
+import qualified Math.NumberTheory.GCD.LowLevelTests as GCDLowLevel
 
 import qualified Math.NumberTheory.Powers.CubesTests as Cubes
 import qualified Math.NumberTheory.Powers.FourthTests as Fourth
@@ -22,5 +23,6 @@ tests = testGroup "All"
     ]
   , testGroup "GCD"
     [ GCD.testSuite
+    , GCDLowLevel.testSuite
     ]
   ]

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -3,6 +3,8 @@ import Test.Tasty
 import qualified Math.NumberTheory.GCDTests as GCD
 import qualified Math.NumberTheory.GCD.LowLevelTests as GCDLowLevel
 
+import qualified Math.NumberTheory.LogarithmsTests as Logarithms
+
 import qualified Math.NumberTheory.Powers.CubesTests as Cubes
 import qualified Math.NumberTheory.Powers.FourthTests as Fourth
 import qualified Math.NumberTheory.Powers.GeneralTests as General
@@ -24,5 +26,8 @@ tests = testGroup "All"
   , testGroup "GCD"
     [ GCD.testSuite
     , GCDLowLevel.testSuite
+    ]
+  , testGroup "Logarithms"
+    [ Logarithms.testSuite
     ]
   ]

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -1,5 +1,7 @@
 import Test.Tasty
 
+import qualified Math.NumberTheory.GCDTests as GCD
+
 import qualified Math.NumberTheory.Powers.CubesTests as Cubes
 import qualified Math.NumberTheory.Powers.FourthTests as Fourth
 import qualified Math.NumberTheory.Powers.GeneralTests as General
@@ -10,10 +12,15 @@ main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
-tests = testGroup "Powers"
-  [ Cubes.testSuite
-  , Fourth.testSuite
-  , General.testSuite
-  , Integer.testSuite
-  , Squares.testSuite
+tests = testGroup "All"
+  [ testGroup "Powers"
+    [ Cubes.testSuite
+    , Fourth.testSuite
+    , General.testSuite
+    , Integer.testSuite
+    , Squares.testSuite
+    ]
+  , testGroup "GCD"
+    [ GCD.testSuite
+    ]
   ]


### PR DESCRIPTION
I have written test suites for `Math.NumberTheory.GCD`, `Math.NumberTheory.Logarithms` and added new tests for `Math.NumberTheory.Powers`. I have also fixed several bugs, triggered by tests:

1. `binaryGCD` on negative numbers was broken. E. g., `binaryGCD (-2 :: Int) (-2 :: Int)` was equal to `-2` instead of 2 and (even more surprising) `binaryGCD (-2 :: Integer) (-2 :: Integer) == 18446744073709551614`.

2. `integerFourthRoot` lacked `SPECIALISE` pragma and so rewrite rules `biSqrtInt/biSqrtWord/biSqrtIgr` were not triggered (discovered from HPC output).

3. Issues with `highestPower` again (cf. d44a13b). 
    * Corner case: `highestPower (minBound :: Int)` returned `(minBound :: Int, 3)`, because `abs (minBound :: Int) < 0`.
    * Subroutine `divisorsTo` was incorrect, e. g., `toDivisors 100 21` returned `[7,1]` instead of [21,7,3,1]. 