### PR TITLE
Tests and bug fixes for Lucas, MoebiusInversion, Primes

### DIFF
--- a/Math/NumberTheory/Logarithms.hs
+++ b/Math/NumberTheory/Logarithms.hs
@@ -36,10 +36,10 @@ import GHC.Word (Word(..))      -- Moved to GHC.Types
 
 import Data.Bits
 import Data.Array.Unboxed
-import Data.Array.Base (unsafeAt)
 
 import Math.NumberTheory.Logarithms.Internal
 import Math.NumberTheory.Powers.Integer
+import Math.NumberTheory.Unsafe
 #if __GLASGOW_HASKELL__ < 707
 import Math.NumberTheory.Utils  (isTrue#)
 #endif

--- a/Math/NumberTheory/Moduli.hs
+++ b/Math/NumberTheory/Moduli.hs
@@ -39,7 +39,6 @@ import Data.Word
 #endif
 import Data.Bits
 import Data.Array.Unboxed
-import Data.Array.Base (unsafeAt)
 import Data.Maybe (fromJust)
 import Data.List (nub)
 import Control.Monad (foldM, liftM2)
@@ -47,6 +46,8 @@ import Control.Monad (foldM, liftM2)
 import Math.NumberTheory.Utils (shiftToOddCount, splitOff)
 import Math.NumberTheory.GCD (extendedGCD)
 import Math.NumberTheory.Primes.Heap (sieveFrom)
+import Math.NumberTheory.Unsafe
+
 -- Guesstimated startup time for the Heap algorithm is lower than
 -- the cost to sieve an entire chunk.
 

--- a/Math/NumberTheory/MoebiusInversion.hs
+++ b/Math/NumberTheory/MoebiusInversion.hs
@@ -16,6 +16,7 @@ module Math.NumberTheory.MoebiusInversion
 
 import Data.Array.ST
 import Data.Array.Base
+import Control.Monad
 import Control.Monad.ST
 
 import Math.NumberTheory.Powers.Squares
@@ -90,7 +91,8 @@ fastInvert fun n = big `unsafeAt` 0
         small <- newArray_ (0,mk0) :: ST s (STArray s Int Integer)
         unsafeWrite small 0 0
         unsafeWrite small 1 $! (fun 1)
-        unsafeWrite small 2 $! (fun 2 - fun 1)
+        when (mk0 >= 2) $
+            unsafeWrite small 2 $! (fun 2 - fun 1)
         let calcit switch change i
                 | mk0 < i   = return (switch,change)
                 | i == change = calcit (switch+1) (change + 4*switch+6) i

--- a/Math/NumberTheory/MoebiusInversion.hs
+++ b/Math/NumberTheory/MoebiusInversion.hs
@@ -69,7 +69,7 @@ totientSum = (+1) . generalInversion (triangle . fromIntegral)
 --   Since the function arguments are used as array indices, the domain of
 --   @f@ is restricted to 'Int'.
 --
---   The value @f n@ is then computed by @generalInversion g n@). Note that when
+--   The value @f n@ is then computed by @generalInversion g n@. Note that when
 --   many values of @f@ are needed, there are far more efficient methods, this
 --   method is only appropriate to compute isolated values of @f@.
 generalInversion :: (Int -> Integer) -> Int -> Integer

--- a/Math/NumberTheory/MoebiusInversion.hs
+++ b/Math/NumberTheory/MoebiusInversion.hs
@@ -15,11 +15,11 @@ module Math.NumberTheory.MoebiusInversion
     ) where
 
 import Data.Array.ST
-import Data.Array.Base
 import Control.Monad
 import Control.Monad.ST
 
 import Math.NumberTheory.Powers.Squares
+import Math.NumberTheory.Unsafe
 
 -- | @totientSum n@ is, for @n > 0@, the sum of @[totient k | k <- [1 .. n]]@,
 --   computed via generalised Moebius inversion.

--- a/Math/NumberTheory/MoebiusInversion/Int.hs
+++ b/Math/NumberTheory/MoebiusInversion/Int.hs
@@ -16,12 +16,11 @@ module Math.NumberTheory.MoebiusInversion.Int
     ) where
 
 import Data.Array.ST
-import Data.Array.Base
 import Control.Monad
 import Control.Monad.ST
 
 import Math.NumberTheory.Powers.Squares
-
+import Math.NumberTheory.Unsafe
 
 -- | @totientSum n@ is, for @n > 0@, the sum of @[totient k | k <- [1 .. n]]@,
 --   computed via generalised Moebius inversion.

--- a/Math/NumberTheory/MoebiusInversion/Int.hs
+++ b/Math/NumberTheory/MoebiusInversion/Int.hs
@@ -17,6 +17,7 @@ module Math.NumberTheory.MoebiusInversion.Int
 
 import Data.Array.ST
 import Data.Array.Base
+import Control.Monad
 import Control.Monad.ST
 
 import Math.NumberTheory.Powers.Squares
@@ -92,7 +93,8 @@ fastInvert fun n = big `unsafeAt` 0
         small <- newArray_ (0,mk0) :: ST s (STUArray s Int Int)
         unsafeWrite small 0 0
         unsafeWrite small 1 (fun 1)
-        unsafeWrite small 2 (fun 2 - fun 1)
+        when (mk0 >= 2) $
+            unsafeWrite small 2 (fun 2 - fun 1)
         let calcit switch change i
                 | mk0 < i   = return (switch,change)
                 | i == change = calcit (switch+1) (change + 4*switch+6) i

--- a/Math/NumberTheory/MoebiusInversion/Int.hs
+++ b/Math/NumberTheory/MoebiusInversion/Int.hs
@@ -71,11 +71,12 @@ totientSum = (+1) . generalInversion triangle
 --   That bears the risk of overflow, however, so be sure to use it only when it's
 --   safe.
 --
---   The value @f n@ is then computed by @generalInversion g n@). Note that when
+--   The value @f n@ is then computed by @generalInversion g n@. Note that when
 --   many values of @f@ are needed, there are far more efficient methods, this
 --   method is only appropriate to compute isolated values of @f@.
 generalInversion :: (Int -> Int) -> Int -> Int
 generalInversion fun n
+    | n < 1     = error "Moebius inversion only defined on positive domain"
     | n == 1    = fun 1
     | n == 2    = fun 2 - fun 1
     | n == 3    = fun 3 - 2*fun 1

--- a/Math/NumberTheory/Powers/Cubes.hs
+++ b/Math/NumberTheory/Powers/Cubes.hs
@@ -21,7 +21,6 @@ module Math.NumberTheory.Powers.Cubes
 #include "MachDeps.h"
 
 import Data.Array.Unboxed
-import Data.Array.Base
 import Data.Array.ST
 
 import Data.Bits
@@ -34,6 +33,7 @@ import GHC.Integer
 import GHC.Integer.GMP.Internals
 
 import Math.NumberTheory.Logarithms.Internal (integerLog2#)
+import Math.NumberTheory.Unsafe
 #if __GLASGOW_HASKELL__ < 707
 import Math.NumberTheory.Utils (isTrue#)
 #endif

--- a/Math/NumberTheory/Powers/Fourth.hs
+++ b/Math/NumberTheory/Powers/Fourth.hs
@@ -26,7 +26,6 @@ import GHC.Integer.GMP.Internals
 
 import Data.Array.Unboxed
 import Data.Array.ST
-import Data.Array.Base (unsafeAt, unsafeWrite)
 
 import Data.Bits
 #if __GLASGOW_HASKELL__ < 705
@@ -34,6 +33,7 @@ import Data.Word
 #endif
 
 import Math.NumberTheory.Logarithms.Internal (integerLog2#)
+import Math.NumberTheory.Unsafe
 #if __GLASGOW_HASKELL__ < 707
 import Math.NumberTheory.Utils (isTrue#)
 #endif

--- a/Math/NumberTheory/Powers/Squares.hs
+++ b/Math/NumberTheory/Powers/Squares.hs
@@ -29,7 +29,6 @@ import GHC.Integer.GMP.Internals
 
 import Data.Array.Unboxed
 import Data.Array.ST
-import Data.Array.Base (unsafeAt, unsafeWrite)
 
 import Data.Bits
 #if __GLASGOW_HASKELL__ < 705
@@ -37,6 +36,7 @@ import Data.Word        -- Moved to GHC.Types
 #endif
 
 import Math.NumberTheory.Logarithms.Internal (integerLog2#)
+import Math.NumberTheory.Unsafe
 #if __GLASGOW_HASKELL__ < 707
 import Math.NumberTheory.Utils (isTrue#)
 #endif

--- a/Math/NumberTheory/Primes/Counting/Impl.hs
+++ b/Math/NumberTheory/Primes/Counting/Impl.hs
@@ -23,8 +23,8 @@ import Math.NumberTheory.Primes.Counting.Approximate
 import Math.NumberTheory.Powers.Squares
 import Math.NumberTheory.Powers.Cubes
 import Math.NumberTheory.Logarithms
+import Math.NumberTheory.Unsafe
 
-import Data.Array.Base
 import Data.Array.ST
 #if !MIN_VERSION_array(0,5,0)
     hiding (unsafeThaw)

--- a/Math/NumberTheory/Primes/Factorisation.hs
+++ b/Math/NumberTheory/Primes/Factorisation.hs
@@ -48,6 +48,10 @@ module Math.NumberTheory.Primes.Factorisation
     , carmichaelSieve
     , sieveCarmichael
     , carmichaelFromCanonical
+      -- * Moebius function
+    , moebius
+    , μ
+    , moebiusFromCanonical
       -- * Divisors
     , divisors
     , tau
@@ -111,6 +115,17 @@ carmichael n
 -- | Alias of 'carmichael' for people who prefer Greek letters.
 λ :: Integer -> Integer
 λ = carmichael
+
+-- | Calculates the Moebius function for a positive integer.
+moebius :: Integer -> Integer
+moebius n
+    | n < 1     = error "Carmichael function only defined for positive numbers"
+    | n == 1    = 1
+    | otherwise = moebiusFromCanonical (factorise' n)
+
+-- | Alias of 'moebius' for people who prefer Greek letters.
+μ :: Integer -> Integer
+μ = moebius
 
 -- | @'divisors' n@ is the set of all (positive) divisors of @n@.
 --   @'divisors' 0@ is an error because we can't create the set of all 'Integer's.

--- a/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
+++ b/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
@@ -46,7 +46,6 @@ import GHC.Base
 #if __GLASGOW_HASKELL__ < 705
 import GHC.Word     -- Moved to GHC.Types
 #endif
-import Data.Array.Base
 
 import System.Random
 import Control.Monad.State.Strict
@@ -63,6 +62,7 @@ import Math.NumberTheory.Powers.Squares     (integerSquareRoot')
 import Math.NumberTheory.Primes.Sieve.Eratosthenes
 import Math.NumberTheory.Primes.Sieve.Indexing
 import Math.NumberTheory.Primes.Testing.Probabilistic
+import Math.NumberTheory.Unsafe
 import Math.NumberTheory.Utils
 
 -- | @'factorise' n@ produces the prime factorisation of @n@, including

--- a/Math/NumberTheory/Primes/Factorisation/Utils.hs
+++ b/Math/NumberTheory/Primes/Factorisation/Utils.hs
@@ -13,6 +13,7 @@ module Math.NumberTheory.Primes.Factorisation.Utils
     ( ppTotient
     , totientFromCanonical
     , carmichaelFromCanonical
+    , moebiusFromCanonical
     , divisorsFromCanonical
     , tauFromCanonical
     , divisorSumFromCanonical
@@ -49,6 +50,15 @@ carmichaelFromCanonical = go2
     go !acc ((p,1):pps) = go (lcm acc (p-1)) pps
     go acc ((p,k):pps)  = go ((lcm acc (p-1))*integerPower p (k-1)) pps
     go acc []           = acc
+
+-- | Calculate the Moebius function from the canonical factorisation.
+moebiusFromCanonical :: [(a, Int)] -> Integer
+moebiusFromCanonical = go 1
+  where
+  go acc []            = acc
+  go acc ((_, 1) : xs) = go (negate acc) xs
+  go acc ((_, 0) : xs) = go acc xs          -- Should not really happen
+  go _   _             = 0                  -- Short circuit for powers > 1
 
 -- | The set of divisors, efficiently calculated from the canonical factorisation.
 divisorsFromCanonical :: [(Integer,Int)] -> Set Integer

--- a/Math/NumberTheory/Primes/Heap.hs
+++ b/Math/NumberTheory/Primes/Heap.hs
@@ -22,13 +22,14 @@
 module Math.NumberTheory.Primes.Heap (primes, sieveFrom) where
 
 import Data.Array.Unboxed
-import Data.Array.Base (unsafeAt, unsafeRead, unsafeWrite)
 import Data.Array.ST
 import Control.Monad.ST
 import Data.List (foldl')
 #if __GLASGOW_HASKELL__ < 709
 import Data.Word
 #endif
+
+import Math.NumberTheory.Unsafe
 
 #ifndef SH_SIZE
 #define SH_SIZE 31

--- a/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
+++ b/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
@@ -35,7 +35,6 @@ module Math.NumberTheory.Primes.Sieve.Eratosthenes
 #include "MachDeps.h"
 
 import Control.Monad.ST
-import Data.Array.Base
 import Data.Array.ST
 #if !MIN_VERSION_array(0,5,0)
                      hiding (unsafeFreeze, unsafeThaw, castSTUArray)
@@ -47,6 +46,7 @@ import Data.Word
 #endif
 
 import Math.NumberTheory.Powers.Squares (integerSquareRoot)
+import Math.NumberTheory.Unsafe
 import Math.NumberTheory.Utils
 import Math.NumberTheory.Primes.Counting.Approximate
 import Math.NumberTheory.Primes.Sieve.Indexing

--- a/Math/NumberTheory/Primes/Sieve/Indexing.hs
+++ b/Math/NumberTheory/Primes/Sieve/Indexing.hs
@@ -34,7 +34,9 @@ import Math.NumberTheory.Unsafe
 --   #-}
 {-# INLINE idxPr #-}
 idxPr :: Integral a => a -> (Int,Int)
-idxPr n0 = (fromIntegral bytes0, rm3)
+idxPr n0
+    | n0 < 7    = (0, 0)
+    | otherwise = (fromIntegral bytes0, rm3)
   where
     n = if (fromIntegral n0 .&. 1 == (1 :: Int))
             then n0 else (n0-1)

--- a/Math/NumberTheory/Primes/Sieve/Indexing.hs
+++ b/Math/NumberTheory/Primes/Sieve/Indexing.hs
@@ -21,8 +21,9 @@ module Math.NumberTheory.Primes.Sieve.Indexing
     ) where
 
 import Data.Array.Unboxed
-import Data.Array.Base (unsafeAt)
 import Data.Bits
+
+import Math.NumberTheory.Unsafe
 
 -- Auxiliary stuff, conversion between number and index,
 -- remainders modulo 30 and related things.

--- a/Math/NumberTheory/Primes/Sieve/Misc.hs
+++ b/Math/NumberTheory/Primes/Sieve/Misc.hs
@@ -31,7 +31,6 @@ module Math.NumberTheory.Primes.Sieve.Misc
     ) where
 
 import Control.Monad.ST
-import Data.Array.Base (unsafeRead, unsafeWrite, unsafeAt)
 import Data.Array.ST
 import Data.Array.Unboxed
 import Control.Monad (when)
@@ -44,6 +43,7 @@ import Math.NumberTheory.Powers.Squares (integerSquareRoot')
 import Math.NumberTheory.Primes.Sieve.Indexing
 import Math.NumberTheory.Primes.Factorisation.Montgomery
 import Math.NumberTheory.Primes.Factorisation.Utils
+import Math.NumberTheory.Unsafe
 import Math.NumberTheory.Utils
 
 -- | A compact store of smallest prime factors.

--- a/Math/NumberTheory/Primes/Sieve/Misc.hs
+++ b/Math/NumberTheory/Primes/Sieve/Misc.hs
@@ -149,7 +149,7 @@ sieveFactor (FS bnd sve) = check
                                                  | otherwise -> tdLoop j (integerSquareRoot' j) (ix+1)
           where
             p = toPrim ix
-            pix = unsafeAt sve ix
+            pix = unsafeAt sve $ fromIntegral p
     curve n = stdGenFactorisation (Just (bound*(bound+2))) (mkStdGen $ fromIntegral n `xor` 0xdecaf00d) Nothing n
 
 -- | @'totientSieve' n@ creates a store of the totients of the numbers not exceeding @n@.

--- a/Math/NumberTheory/Unsafe.hs
+++ b/Math/NumberTheory/Unsafe.hs
@@ -1,0 +1,70 @@
+-- |
+-- Module:      Math.NumberTheory.Unsafe
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Layer to switch between safe and unsafe arrays.
+--
+
+{-# LANGUAGE CPP #-}
+
+module Math.NumberTheory.Unsafe
+  ( UArray
+  , bounds
+  , castSTUArray
+  , unsafeAt
+  , unsafeFreeze
+  , unsafeNewArray_
+  , unsafeRead
+  , unsafeThaw
+  , unsafeWrite
+  ) where
+
+#ifdef CheckBounds
+
+import Data.Array.Base
+  ( UArray
+  , castSTUArray
+  )
+import Data.Array.IArray
+  ( IArray
+  , bounds
+  , (!)
+  )
+import Data.Array.MArray
+
+unsafeAt :: (IArray a e, Ix i) => a i e -> i -> e
+unsafeAt = (!)
+
+unsafeFreeze :: (Ix i, MArray a e m, IArray b e) => a i e -> m (b i e)
+unsafeFreeze = freeze
+
+unsafeNewArray_ :: (Ix i, MArray a e m) => (i, i) -> m (a i e)
+unsafeNewArray_ = newArray_
+
+unsafeRead :: (MArray a e m, Ix i) => a i e -> i -> m e
+unsafeRead = readArray
+
+unsafeThaw :: (Ix i, IArray a e, MArray b e m) => a i e -> m (b i e)
+unsafeThaw = thaw
+
+unsafeWrite :: (MArray a e m, Ix i) => a i e -> i -> e -> m ()
+unsafeWrite = writeArray
+
+#else
+
+import Data.Array.Base
+  ( UArray
+  , bounds
+  , castSTUArray
+  , unsafeAt
+  , unsafeFreeze
+  , unsafeNewArray_
+  , unsafeRead
+  , unsafeThaw
+  , unsafeWrite
+  )
+
+#endif

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -120,6 +120,8 @@ test-suite spec
                   , Math.NumberTheory.LogarithmsTests
                   , Math.NumberTheory.LucasTests
                   , Math.NumberTheory.Powers.CubesTests
+                  , Math.NumberTheory.MoebiusInversionTests
+                  , Math.NumberTheory.MoebiusInversion.IntTests
                   , Math.NumberTheory.Powers.FourthTests
                   , Math.NumberTheory.Powers.GeneralTests
                   , Math.NumberTheory.Powers.IntegerTests

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -36,6 +36,11 @@ flag llvm
     default             : False
     manual              : True
 
+flag check-bounds
+    description         : Replace unsafe array operations with safe ones
+    default             : False
+    manual              : True
+
 library
     default-language: Haskell2010
     build-depends       : base >= 4 && < 5
@@ -68,6 +73,7 @@ library
                           Math.NumberTheory.Primes.Testing.Certificates
                           Math.NumberTheory.Primes.Heap
     other-modules       : Math.NumberTheory.Utils
+                          Math.NumberTheory.Unsafe
                           Math.NumberTheory.Logarithms.Internal
                           Math.NumberTheory.Primes.Counting.Impl
                           Math.NumberTheory.Primes.Counting.Approximate
@@ -86,6 +92,8 @@ library
     if flag(llvm)
         ghc-options     : -fllvm
     ghc-prof-options    : -O2 -auto
+    if flag(check-bounds)
+        cpp-options     : -DCheckBounds
 
 source-repository head
   type:     git

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -134,5 +134,6 @@ test-suite spec
                   , Math.NumberTheory.Powers.GeneralTests
                   , Math.NumberTheory.Powers.IntegerTests
                   , Math.NumberTheory.Powers.SquaresTests
+                  , Math.NumberTheory.PrimesTests
                   , Math.NumberTheory.TestUtils
 

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -118,6 +118,7 @@ test-suite spec
   other-modules :   Math.NumberTheory.GCDTests
                   , Math.NumberTheory.GCD.LowLevelTests
                   , Math.NumberTheory.LogarithmsTests
+                  , Math.NumberTheory.LucasTests
                   , Math.NumberTheory.Powers.CubesTests
                   , Math.NumberTheory.Powers.FourthTests
                   , Math.NumberTheory.Powers.GeneralTests

--- a/test-suite/Math/NumberTheory/LucasTests.hs
+++ b/test-suite/Math/NumberTheory/LucasTests.hs
@@ -1,0 +1,104 @@
+-- |
+-- Module:      Math.NumberTheory.LucasTests
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.Lucas
+--
+
+{-# LANGUAGE CPP       #-}
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.LucasTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Math.NumberTheory.Lucas
+import Math.NumberTheory.TestUtils
+
+-- | Check that 'fibonacci' matches the definition of Fibonacci sequence.
+fibonacciProperty1 :: AnySign Int -> Bool
+fibonacciProperty1 (AnySign n) = fibonacci n + fibonacci (n + 1) == fibonacci (n +2)
+
+-- | Check that 'fibonacci' for negative indices is correctly defined.
+fibonacciProperty2 :: NonNegative Int -> Bool
+fibonacciProperty2 (NonNegative n) = fibonacci n == (if even n then negate else id) (fibonacci (- n))
+
+-- | Check that 'fibonacciPair' is a pair of consequent 'fibonacci'.
+fibonacciPairProperty :: AnySign Int -> Bool
+fibonacciPairProperty (AnySign n) = fibonacciPair n == (fibonacci n, fibonacci (n + 1))
+
+-- | Check that 'fibonacci 0' is 0.
+fibonacciSpecialCase0 :: Assertion
+fibonacciSpecialCase0 = assertEqual "fibonacci" (fibonacci 0) 0
+
+-- | Check that 'fibonacci 1' is 1.
+fibonacciSpecialCase1 :: Assertion
+fibonacciSpecialCase1 = assertEqual "fibonacci" (fibonacci 1) 1
+
+
+-- | Check that 'lucas' matches the definition of Lucas sequence.
+lucasProperty1 :: AnySign Int -> Bool
+lucasProperty1 (AnySign n) = lucas n + lucas (n + 1) == lucas (n +2)
+
+-- | Check that 'lucas' for negative indices is correctly defined.
+lucasProperty2 :: NonNegative Int -> Bool
+lucasProperty2 (NonNegative n) = lucas n == (if odd n then negate else id) (lucas (- n))
+
+-- | Check that 'lucasPair' is a pair of consequent 'lucas'.
+lucasPairProperty :: AnySign Int -> Bool
+lucasPairProperty (AnySign n) = lucasPair n == (lucas n, lucas (n + 1))
+
+-- | Check that 'lucas 0' is 2.
+lucasSpecialCase0 :: Assertion
+lucasSpecialCase0 = assertEqual "lucas" (lucas 0) 2
+
+-- | Check that 'lucas 1' is 1.
+lucasSpecialCase1 :: Assertion
+lucasSpecialCase1 = assertEqual "lucas" (lucas 1) 1
+
+-- | Check that 'generalLucas' matches its definition.
+generalLucasProperty1 :: AnySign Integer -> AnySign Integer -> NonNegative Int -> Bool
+generalLucasProperty1 (AnySign p) (AnySign q) (NonNegative n) = un1 == un1' && vn1 == vn1' && un2 == p * un1 - q * un && vn2 == p * vn1 - q * vn
+  where
+    (un, un1, vn, vn1) = generalLucas p q n
+    (un1', un2, vn1', vn2) = generalLucas p q (n + 1)
+
+-- | Check that 'generalLucas' 1 (-1) is 'fibonacciPair' plus 'lucasPair'.
+generalLucasProperty2 :: NonNegative Int -> Bool
+generalLucasProperty2 (NonNegative n) = (un, un1) == fibonacciPair n && (vn, vn1) == lucasPair n
+  where
+    (un, un1, vn, vn1) = generalLucas 1 (-1) n
+
+-- | Check that 'generalLucas' p _ 0 is (0, 1, 2, p).
+generalLucasProperty3 :: AnySign Integer -> AnySign Integer -> Bool
+generalLucasProperty3 (AnySign p) (AnySign q) = generalLucas p q 0 == (0, 1, 2, p)
+
+testSuite :: TestTree
+testSuite = testGroup "Lucas"
+  [ testGroup "fibonacci"
+    [ testSmallAndQuick "matches definition"  fibonacciProperty1
+    , testSmallAndQuick "negative indices"    fibonacciProperty2
+    , testSmallAndQuick "pair"                fibonacciPairProperty
+    , testCase          "fibonacci 0"         fibonacciSpecialCase0
+    , testCase          "fibonacci 1"         fibonacciSpecialCase1
+    ]
+  , testGroup "lucas"
+    [ testSmallAndQuick "matches definition"  lucasProperty1
+    , testSmallAndQuick "negative indices"    lucasProperty2
+    , testSmallAndQuick "pair"                lucasPairProperty
+    , testCase          "lucas 0"             lucasSpecialCase0
+    , testCase          "lucas 1"             lucasSpecialCase1
+    ]
+  , testGroup "generalLucas"
+    [ testSmallAndQuick "matches definition"  generalLucasProperty1
+    , testSmallAndQuick "generalLucas 1 (-1)" generalLucasProperty2
+    , testSmallAndQuick "generalLucas _ _ 0"  generalLucasProperty3
+    ]
+  ]

--- a/test-suite/Math/NumberTheory/MoebiusInversion/IntTests.hs
+++ b/test-suite/Math/NumberTheory/MoebiusInversion/IntTests.hs
@@ -1,0 +1,45 @@
+-- |
+-- Module:      Math.NumberTheory.MoebiusInversion.IntTests
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.MoebiusInversion.Int
+--
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.MoebiusInversion.IntTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck as QC hiding (Positive)
+
+import Math.NumberTheory.MoebiusInversion.Int
+import Math.NumberTheory.Primes.Factorisation
+import Math.NumberTheory.TestUtils
+
+totientSumProperty :: Positive Int -> Bool
+totientSumProperty (Positive n) = toInteger (totientSum n) == sum (map totient [1 .. toInteger n])
+
+totientSumSpecialCase1 :: Assertion
+totientSumSpecialCase1 = assertEqual "totientSum" 4496 (totientSum 121)
+
+generalInversionProperty :: (Int -> Int) -> Positive Int -> Bool
+generalInversionProperty g (Positive n)
+  =  g n == sum [f (n `quot` k) | k <- [1 .. n]]
+  && f n == sum [fromInteger (moebius (toInteger k)) * g (n `quot` k) | k <- [1 .. n]]
+  where
+    f = generalInversion g
+
+testSuite :: TestTree
+testSuite = testGroup "Int"
+  [ testGroup "totientSum"
+    [ testSmallAndQuick "matches definitions" totientSumProperty
+    , testCase          "special case 1"      totientSumSpecialCase1
+    ]
+  , QC.testProperty "generalInversion" generalInversionProperty
+  ]

--- a/test-suite/Math/NumberTheory/MoebiusInversionTests.hs
+++ b/test-suite/Math/NumberTheory/MoebiusInversionTests.hs
@@ -1,0 +1,45 @@
+-- |
+-- Module:      Math.NumberTheory.MoebiusInversionTests
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.MoebiusInversion
+--
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.MoebiusInversionTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck as QC hiding (Positive)
+
+import Math.NumberTheory.MoebiusInversion
+import Math.NumberTheory.Primes.Factorisation
+import Math.NumberTheory.TestUtils
+
+totientSumProperty :: Positive Int -> Bool
+totientSumProperty (Positive n) = totientSum n == sum (map totient [1 .. toInteger n])
+
+totientSumSpecialCase1 :: Assertion
+totientSumSpecialCase1 = assertEqual "totientSum" 4496 (totientSum 121)
+
+generalInversionProperty :: (Int -> Integer) -> Positive Int -> Bool
+generalInversionProperty g (Positive n)
+  =  g n == sum [f (n `quot` k) | k <- [1 .. n]]
+  && f n == sum [moebius (toInteger k) * g (n `quot` k) | k <- [1 .. n]]
+  where
+    f = generalInversion g
+
+testSuite :: TestTree
+testSuite = testGroup "MoebiusInversion"
+  [ testGroup "totientSum"
+    [ testSmallAndQuick "matches definitions" totientSumProperty
+    , testCase          "special case 1"      totientSumSpecialCase1
+    ]
+  , QC.testProperty "generalInversion" generalInversionProperty
+  ]

--- a/test-suite/Math/NumberTheory/PrimesTests.hs
+++ b/test-suite/Math/NumberTheory/PrimesTests.hs
@@ -1,0 +1,40 @@
+-- |
+-- Module:      Math.NumberTheory.PrimesTests
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.Primes
+--
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.PrimesTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Math.NumberTheory.Primes
+import Math.NumberTheory.TestUtils
+
+primesSumWonk :: Int -> Int
+primesSumWonk upto = sum . takeWhile (< upto) . map fromInteger . primeList $ primeSieve (toInteger upto)
+
+primesSum :: Int -> Int
+primesSum upto = sum . takeWhile (< upto) . map fromInteger $ primes
+
+primesSumProperty :: NonNegative Int -> Bool
+primesSumProperty (NonNegative n) = primesSumWonk n == primesSum n
+
+
+sieveFactorSpecialCase1 :: Assertion
+sieveFactorSpecialCase1 = assertEqual "sieveFactor" [(29, 1), (73, 1)] $ sieveFactor (factorSieve 2048) (29*73)
+
+testSuite :: TestTree
+testSuite = testGroup "Primes"
+  [ testSmallAndQuick "primesSum"   primesSumProperty
+  , testCase          "sieveFactor" sieveFactorSpecialCase1
+  ]

--- a/test-suite/Math/NumberTheory/TestUtils.hs
+++ b/test-suite/Math/NumberTheory/TestUtils.hs
@@ -102,68 +102,68 @@ type TestableIntegral wrapper =
   , Serial IO (wrapper Int), Serial IO (wrapper Word), Serial IO (wrapper Integer))
 
 testIntegralProperty
-  :: forall wrapper. TestableIntegral wrapper
-  => String -> (forall a. (Integral a, Bits a) => wrapper a -> Bool) -> TestTree
+  :: forall wrapper bool. (TestableIntegral wrapper, SC.Testable IO bool, QC.Testable bool)
+  => String -> (forall a. (Integral a, Bits a) => wrapper a -> bool) -> TestTree
 testIntegralProperty name f = testGroup name
-  [ SC.testProperty "smallcheck Int"     (f :: wrapper Int     -> Bool)
-  , SC.testProperty "smallcheck Word"    (f :: wrapper Word    -> Bool)
-  , SC.testProperty "smallcheck Integer" (f :: wrapper Integer -> Bool)
-  , QC.testProperty "quickcheck Int"     (f :: wrapper Int     -> Bool)
-  , QC.testProperty "quickcheck Word"    (f :: wrapper Word    -> Bool)
-  , QC.testProperty "quickcheck Integer" (f :: wrapper Integer -> Bool)
-  , QC.testProperty "quickcheck Large Int"     ((f :: wrapper Int     -> Bool) . getLarge)
-  , QC.testProperty "quickcheck Large Word"    ((f :: wrapper Word    -> Bool) . getLarge)
-  , QC.testProperty "quickcheck Huge  Integer" ((f :: wrapper Integer -> Bool) . getHuge)
+  [ SC.testProperty "smallcheck Int"     (f :: wrapper Int     -> bool)
+  , SC.testProperty "smallcheck Word"    (f :: wrapper Word    -> bool)
+  , SC.testProperty "smallcheck Integer" (f :: wrapper Integer -> bool)
+  , QC.testProperty "quickcheck Int"     (f :: wrapper Int     -> bool)
+  , QC.testProperty "quickcheck Word"    (f :: wrapper Word    -> bool)
+  , QC.testProperty "quickcheck Integer" (f :: wrapper Integer -> bool)
+  , QC.testProperty "quickcheck Large Int"     ((f :: wrapper Int     -> bool) . getLarge)
+  , QC.testProperty "quickcheck Large Word"    ((f :: wrapper Word    -> bool) . getLarge)
+  , QC.testProperty "quickcheck Huge  Integer" ((f :: wrapper Integer -> bool) . getHuge)
   ]
 
 testSameIntegralProperty
-  :: forall wrapper. TestableIntegral wrapper
-  => String -> (forall a. (Integral a, Bits a) => wrapper a -> wrapper a -> Bool) -> TestTree
+  :: forall wrapper1 wrapper2 bool. (TestableIntegral wrapper1, TestableIntegral wrapper2, SC.Testable IO bool, QC.Testable bool)
+  => String -> (forall a. (Integral a, Bits a) => wrapper1 a -> wrapper2 a -> bool) -> TestTree
 testSameIntegralProperty name f = testGroup name
-  [ SC.testProperty "smallcheck Int"     (f :: wrapper Int     -> wrapper Int     -> Bool)
-  , SC.testProperty "smallcheck Word"    (f :: wrapper Word    -> wrapper Word    -> Bool)
-  , SC.testProperty "smallcheck Integer" (f :: wrapper Integer -> wrapper Integer -> Bool)
-  , QC.testProperty "quickcheck Int"     (f :: wrapper Int     -> wrapper Int     -> Bool)
-  , QC.testProperty "quickcheck Word"    (f :: wrapper Word    -> wrapper Word    -> Bool)
-  , QC.testProperty "quickcheck Integer" (f :: wrapper Integer -> wrapper Integer -> Bool)
-  , QC.testProperty "quickcheck Large Int"     (\(Large a) (Large b) -> (f :: wrapper Int     -> wrapper Int     -> Bool) a b)
-  , QC.testProperty "quickcheck Large Word"    (\(Large a) (Large b) -> (f :: wrapper Word    -> wrapper Word    -> Bool) a b)
-  , QC.testProperty "quickcheck Huge  Integer" (\(Huge  a) (Huge  b) -> (f :: wrapper Integer -> wrapper Integer -> Bool) a b)
+  [ SC.testProperty "smallcheck Int"     (f :: wrapper1 Int     -> wrapper2 Int     -> bool)
+  , SC.testProperty "smallcheck Word"    (f :: wrapper1 Word    -> wrapper2 Word    -> bool)
+  , SC.testProperty "smallcheck Integer" (f :: wrapper1 Integer -> wrapper2 Integer -> bool)
+  , QC.testProperty "quickcheck Int"     (f :: wrapper1 Int     -> wrapper2 Int     -> bool)
+  , QC.testProperty "quickcheck Word"    (f :: wrapper1 Word    -> wrapper2 Word    -> bool)
+  , QC.testProperty "quickcheck Integer" (f :: wrapper1 Integer -> wrapper2 Integer -> bool)
+  , QC.testProperty "quickcheck Large Int"     (\(Large a) (Large b) -> (f :: wrapper1 Int     -> wrapper2 Int     -> bool) a b)
+  , QC.testProperty "quickcheck Large Word"    (\(Large a) (Large b) -> (f :: wrapper1 Word    -> wrapper2 Word    -> bool) a b)
+  , QC.testProperty "quickcheck Huge  Integer" (\(Huge  a) (Huge  b) -> (f :: wrapper1 Integer -> wrapper2 Integer -> bool) a b)
   ]
 
 testIntegral2Property
-  :: forall wrapper1 wrapper2. (TestableIntegral wrapper1, TestableIntegral wrapper2)
-  => String -> (forall a1 a2. (Integral a1, Integral a2, Bits a1, Bits a2) => wrapper1 a1 -> wrapper2 a2 -> Bool) -> TestTree
+  :: forall wrapper1 wrapper2 bool. (TestableIntegral wrapper1, TestableIntegral wrapper2, SC.Testable IO bool, QC.Testable bool)
+  => String -> (forall a1 a2. (Integral a1, Integral a2, Bits a1, Bits a2) => wrapper1 a1 -> wrapper2 a2 -> bool) -> TestTree
 testIntegral2Property name f = testGroup name
-  [ SC.testProperty "smallcheck Int Int"         (f :: wrapper1 Int     -> wrapper2 Int     -> Bool)
-  , SC.testProperty "smallcheck Int Word"        (f :: wrapper1 Int     -> wrapper2 Word    -> Bool)
-  , SC.testProperty "smallcheck Int Integer"     (f :: wrapper1 Int     -> wrapper2 Integer -> Bool)
-  , SC.testProperty "smallcheck Word Int"        (f :: wrapper1 Word    -> wrapper2 Int     -> Bool)
-  , SC.testProperty "smallcheck Word Word"       (f :: wrapper1 Word    -> wrapper2 Word    -> Bool)
-  , SC.testProperty "smallcheck Word Integer"    (f :: wrapper1 Word    -> wrapper2 Integer -> Bool)
-  , SC.testProperty "smallcheck Integer Int"     (f :: wrapper1 Integer -> wrapper2 Int     -> Bool)
-  , SC.testProperty "smallcheck Integer Word"    (f :: wrapper1 Integer -> wrapper2 Word    -> Bool)
-  , SC.testProperty "smallcheck Integer Integer" (f :: wrapper1 Integer -> wrapper2 Integer -> Bool)
+  [ SC.testProperty "smallcheck Int Int"         (f :: wrapper1 Int     -> wrapper2 Int     -> bool)
+  , SC.testProperty "smallcheck Int Word"        (f :: wrapper1 Int     -> wrapper2 Word    -> bool)
+  , SC.testProperty "smallcheck Int Integer"     (f :: wrapper1 Int     -> wrapper2 Integer -> bool)
+  , SC.testProperty "smallcheck Word Int"        (f :: wrapper1 Word    -> wrapper2 Int     -> bool)
+  , SC.testProperty "smallcheck Word Word"       (f :: wrapper1 Word    -> wrapper2 Word    -> bool)
+  , SC.testProperty "smallcheck Word Integer"    (f :: wrapper1 Word    -> wrapper2 Integer -> bool)
+  , SC.testProperty "smallcheck Integer Int"     (f :: wrapper1 Integer -> wrapper2 Int     -> bool)
+  , SC.testProperty "smallcheck Integer Word"    (f :: wrapper1 Integer -> wrapper2 Word    -> bool)
+  , SC.testProperty "smallcheck Integer Integer" (f :: wrapper1 Integer -> wrapper2 Integer -> bool)
 
-  , QC.testProperty "quickcheck Int Int"         (f :: wrapper1 Int     -> wrapper2 Int     -> Bool)
-  , QC.testProperty "quickcheck Int Word"        (f :: wrapper1 Int     -> wrapper2 Word    -> Bool)
-  , QC.testProperty "quickcheck Int Integer"     (f :: wrapper1 Int     -> wrapper2 Integer -> Bool)
-  , QC.testProperty "quickcheck Word Int"        (f :: wrapper1 Word    -> wrapper2 Int     -> Bool)
-  , QC.testProperty "quickcheck Word Word"       (f :: wrapper1 Word    -> wrapper2 Word    -> Bool)
-  , QC.testProperty "quickcheck Word Integer"    (f :: wrapper1 Word    -> wrapper2 Integer -> Bool)
-  , QC.testProperty "quickcheck Integer Int"     (f :: wrapper1 Integer -> wrapper2 Int     -> Bool)
-  , QC.testProperty "quickcheck Integer Word"    (f :: wrapper1 Integer -> wrapper2 Word    -> Bool)
-  , QC.testProperty "quickcheck Integer Integer" (f :: wrapper1 Integer -> wrapper2 Integer -> Bool)
+  , QC.testProperty "quickcheck Int Int"         (f :: wrapper1 Int     -> wrapper2 Int     -> bool)
+  , QC.testProperty "quickcheck Int Word"        (f :: wrapper1 Int     -> wrapper2 Word    -> bool)
+  , QC.testProperty "quickcheck Int Integer"     (f :: wrapper1 Int     -> wrapper2 Integer -> bool)
+  , QC.testProperty "quickcheck Word Int"        (f :: wrapper1 Word    -> wrapper2 Int     -> bool)
+  , QC.testProperty "quickcheck Word Word"       (f :: wrapper1 Word    -> wrapper2 Word    -> bool)
+  , QC.testProperty "quickcheck Word Integer"    (f :: wrapper1 Word    -> wrapper2 Integer -> bool)
+  , QC.testProperty "quickcheck Integer Int"     (f :: wrapper1 Integer -> wrapper2 Int     -> bool)
+  , QC.testProperty "quickcheck Integer Word"    (f :: wrapper1 Integer -> wrapper2 Word    -> bool)
+  , QC.testProperty "quickcheck Integer Integer" (f :: wrapper1 Integer -> wrapper2 Integer -> bool)
 
-  , QC.testProperty "quickcheck Large Int Int"         ((f :: wrapper1 Int     -> wrapper2 Int     -> Bool) . getLarge)
-  , QC.testProperty "quickcheck Large Int Word"        ((f :: wrapper1 Int     -> wrapper2 Word    -> Bool) . getLarge)
-  , QC.testProperty "quickcheck Large Int Integer"     ((f :: wrapper1 Int     -> wrapper2 Integer -> Bool) . getLarge)
-  , QC.testProperty "quickcheck Large Word Int"        ((f :: wrapper1 Word    -> wrapper2 Int     -> Bool) . getLarge)
-  , QC.testProperty "quickcheck Large Word Word"       ((f :: wrapper1 Word    -> wrapper2 Word    -> Bool) . getLarge)
-  , QC.testProperty "quickcheck Large Word Integer"    ((f :: wrapper1 Word    -> wrapper2 Integer -> Bool) . getLarge)
-  , QC.testProperty "quickcheck Huge  Integer Int"     ((f :: wrapper1 Integer -> wrapper2 Int     -> Bool) . getHuge)
-  , QC.testProperty "quickcheck Huge  Integer Word"    ((f :: wrapper1 Integer -> wrapper2 Word    -> Bool) . getHuge)
-  , QC.testProperty "quickcheck Huge  Integer Integer" ((f :: wrapper1 Integer -> wrapper2 Integer -> Bool) . getHuge)
+  , QC.testProperty "quickcheck Large Int Int"         ((f :: wrapper1 Int     -> wrapper2 Int     -> bool) . getLarge)
+  , QC.testProperty "quickcheck Large Int Word"        ((f :: wrapper1 Int     -> wrapper2 Word    -> bool) . getLarge)
+  , QC.testProperty "quickcheck Large Int Integer"     ((f :: wrapper1 Int     -> wrapper2 Integer -> bool) . getLarge)
+  , QC.testProperty "quickcheck Large Word Int"        ((f :: wrapper1 Word    -> wrapper2 Int     -> bool) . getLarge)
+  , QC.testProperty "quickcheck Large Word Word"       ((f :: wrapper1 Word    -> wrapper2 Word    -> bool) . getLarge)
+  , QC.testProperty "quickcheck Large Word Integer"    ((f :: wrapper1 Word    -> wrapper2 Integer -> bool) . getLarge)
+  , QC.testProperty "quickcheck Huge  Integer Int"     ((f :: wrapper1 Integer -> wrapper2 Int     -> bool) . getHuge)
+  , QC.testProperty "quickcheck Huge  Integer Word"    ((f :: wrapper1 Integer -> wrapper2 Word    -> bool) . getHuge)
+  , QC.testProperty "quickcheck Huge  Integer Integer" ((f :: wrapper1 Integer -> wrapper2 Integer -> bool) . getHuge)
   ]
 
 testSmallAndQuick

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -16,6 +16,8 @@ import qualified Math.NumberTheory.Powers.GeneralTests as General
 import qualified Math.NumberTheory.Powers.IntegerTests as Integer
 import qualified Math.NumberTheory.Powers.SquaresTests as Squares
 
+import qualified Math.NumberTheory.PrimesTests as Primes
+
 main :: IO ()
 main = defaultMain tests
 
@@ -41,5 +43,8 @@ tests = testGroup "All"
   , testGroup "MoebiusInversion"
     [ MoebiusInversion.testSuite
     , MoebiusInversionInt.testSuite
+    ]
+  , testGroup "Primes"
+    [ Primes.testSuite
     ]
   ]

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -7,6 +7,9 @@ import qualified Math.NumberTheory.LogarithmsTests as Logarithms
 
 import qualified Math.NumberTheory.LucasTests as Lucas
 
+import qualified Math.NumberTheory.MoebiusInversionTests as MoebiusInversion
+import qualified Math.NumberTheory.MoebiusInversion.IntTests as MoebiusInversionInt
+
 import qualified Math.NumberTheory.Powers.CubesTests as Cubes
 import qualified Math.NumberTheory.Powers.FourthTests as Fourth
 import qualified Math.NumberTheory.Powers.GeneralTests as General
@@ -34,5 +37,9 @@ tests = testGroup "All"
     ]
   , testGroup "Lucas"
     [ Lucas.testSuite
+    ]
+  , testGroup "MoebiusInversion"
+    [ MoebiusInversion.testSuite
+    , MoebiusInversionInt.testSuite
     ]
   ]

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -5,6 +5,8 @@ import qualified Math.NumberTheory.GCD.LowLevelTests as GCDLowLevel
 
 import qualified Math.NumberTheory.LogarithmsTests as Logarithms
 
+import qualified Math.NumberTheory.LucasTests as Lucas
+
 import qualified Math.NumberTheory.Powers.CubesTests as Cubes
 import qualified Math.NumberTheory.Powers.FourthTests as Fourth
 import qualified Math.NumberTheory.Powers.GeneralTests as General
@@ -29,5 +31,8 @@ tests = testGroup "All"
     ]
   , testGroup "Logarithms"
     [ Logarithms.testSuite
+    ]
+  , testGroup "Lucas"
+    [ Lucas.testSuite
     ]
   ]


### PR DESCRIPTION
1. Add new cabal flag `check-bounds`, which replaces all unsafe array functions with safe ones. Incredibly useful for debugging.

2. Write tests for `Math.NumberTheory.Lucas`. No bugs found!

3. Write tests for `Math.NumberTheory.MoebiusInversion`. Fix segfault, caused by index `2` out of bounds `(0, 1)`, when `n=0`. Add `moebius` function to the library (required for tests).

4. Fix #2 and #7, both caused by incorrect indexing of sieves. One segfault less!

If there is no objection, I am going to merge this pull request in two weeks.