### PR TITLE
Fix redundant import

### DIFF
--- a/Math/NumberTheory/Moduli.hs
+++ b/Math/NumberTheory/Moduli.hs
@@ -34,9 +34,9 @@ module Math.NumberTheory.Moduli
 
 #include "MachDeps.h"
 
--- #if __GLASGOW_HASKELL__ < 709
+#if __GLASGOW_HASKELL__ < 709 || WORD_SIZE_IN_BITS == 32
 import Data.Word
--- #endif
+#endif
 import Data.Bits
 import Data.Array.Unboxed
 import Data.Maybe (fromJust)

--- a/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
+++ b/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
@@ -41,9 +41,9 @@ import Data.Array.ST
 #endif
 import Control.Monad (when)
 import Data.Bits
--- #if __GLASGOW_HASKELL__ < 709
+#if __GLASGOW_HASKELL__ < 709 || WORD_SIZE_IN_BITS == 32
 import Data.Word
--- #endif
+#endif
 
 import Math.NumberTheory.Powers.Squares (integerSquareRoot)
 import Math.NumberTheory.Unsafe


### PR DESCRIPTION
#10 has introduced a redundant import on 64-bit GHC >= 7.10. This patch fixes it, adding check `WORD_SIZE_IN_BITS == 32`.