### PR TITLE
Tests for Primes and Moduli

### DIFF
--- a/Math/NumberTheory/Moduli.hs
+++ b/Math/NumberTheory/Moduli.hs
@@ -462,6 +462,7 @@ chineseRemainder :: [(Integer,Integer)] -> Maybe Integer
 chineseRemainder remainders = foldM addRem 0 remainders
   where
     !modulus = product (map snd remainders)
+    addRem acc (_,1) = Just acc
     addRem acc (r,m) = do
         let cf = modulus `quot` m
         inv <- invertMod cf m

--- a/Math/NumberTheory/Moduli.hs
+++ b/Math/NumberTheory/Moduli.hs
@@ -51,36 +51,34 @@ import Math.NumberTheory.Unsafe
 -- Guesstimated startup time for the Heap algorithm is lower than
 -- the cost to sieve an entire chunk.
 
--- | Invert a number relative to a modulus.
+-- | Invert a number relative to a positive modulus.
 --   If @number@ and @modulus@ are coprime, the result is
 --   @Just inverse@ where
 --
--- >    (number * inverse) `mod` (abs modulus) == 1
--- >    0 <= inverse < abs modulus
+-- >    (number * inverse) `mod` modulus == 1
+-- >    0 <= inverse < modulus
 --
---   unless @modulus == 0@ and @abs number == 1@, in which case the
---   result is @Just number@.
---   If @gcd number modulus > 1@, the result is @Nothing@.
+--   If @number `mod` modulus == 0@ or @gcd number modulus > 1@, the result is @Nothing@.
 invertMod :: Integer -> Integer -> Maybe Integer
-invertMod k 0 = if k == 1 || k == (-1) then Just k else Nothing
-invertMod k m = wrap $ go False 1 0 m' k'
+invertMod k m
+  | m <= 0 = error "Math.NumberTheory.Moduli.invertMod: non-positive modulus"
+  | otherwise = wrap $ go False 1 0 m k'
   where
-    m' = abs m
-    k' | r < 0     = r+m'
+    k' | r < 0     = r+m
        | otherwise = r
          where
-           r = k `rem` m'
-    wrap x = case (x*k') `rem` m' of
+           r = k `rem` m
+    wrap x = case (x*k') `rem` m of
                1 -> Just x
                _ -> Nothing
-    -- Calculate modular inverse of k' modulo m' by continued fraction expansion
-    -- of m'/k', say [a_0,a_1,...,a_s]. Let the convergents be p_j/q_j.
+    -- Calculate modular inverse of k' modulo m by continued fraction expansion
+    -- of m/k', say [a_0,a_1,...,a_s]. Let the convergents be p_j/q_j.
     -- Starting from j = -2, the arguments of go are
-    -- (p_j/q_j) > m'/k', p_{j+1}, p_j, and n, d with n/d = [a_{j+2},...,a_s].
-    -- Since m'/k' = p_s/q_s, and p_j*q_{j+1} - p_{j+1}*q_j = (-1)^(j+1), we have
-    -- p_{s-1}*k' - q_{s-1}*m' = (-1)^s * gcd m' k', so if the inverse exists,
+    -- (p_j/q_j) > m/k', p_{j+1}, p_j, and n, d with n/d = [a_{j+2},...,a_s].
+    -- Since m/k' = p_s/q_s, and p_j*q_{j+1} - p_{j+1}*q_j = (-1)^(j+1), we have
+    -- p_{s-1}*k' - q_{s-1}*m = (-1)^s * gcd m k', so if the inverse exists,
     -- it is either p_{s-1} or -p_{s-1}, depending on whether s is even or odd.
-    go !b _ po _ 0 = if b then po else (m'-po)
+    go !b _ po _ 0 = if b then po else (m-po)
     go b !pn po n d = case n `quotRem` d of
                         (q,r) -> go (not b) (q*pn+po) pn d r
 
@@ -162,7 +160,7 @@ jacOL !j a b
 --
 -- > powerMod base exponent modulus
 --
---   calculates @(base ^ exponent) \`mod\` modulus@ by repeated squaring and reduction.
+--   calculates @(base ^ exponent) \`mod\` modulus@ by repeated squaring and reduction. Modulus must be positive.
 --   If @exponent < 0@ and @base@ is invertible modulo @modulus@, @(inverse ^ |exponent|) \`mod\` modulus@
 --   is calculated. This function does some input checking and sanitation before calling the unsafe worker.
 {-# RULES
@@ -177,18 +175,17 @@ powerMod = powerModImpl
   #-}
 powerModImpl :: (Integral a, Bits a) => Integer -> a -> Integer -> Integer
 powerModImpl base expo md
-  | md == 0     = base ^ expo
-  | md' == 1    = 0
+  | md <= 0     = error "Math.NumberTheory.Moduli.powerMod: non-positive modulus"
+  | md == 1     = 0
   | expo == 0   = 1
   | bse' == 1   = 1
-  | expo < 0    = case invertMod bse' md' of
-                    Just i  -> powerMod'Impl i (negate expo) md'
+  | expo < 0    = case invertMod bse' md of
+                    Just i  -> powerMod'Impl i (negate expo) md
                     Nothing -> error "Math.NumberTheory.Moduli.powerMod: Base isn't invertible with respect to modulus"
   | bse' == 0   = 0
-  | otherwise   = powerMod'Impl bse' expo md'
+  | otherwise   = powerMod'Impl bse' expo md
     where
-      md' = abs md
-      bse' = if base < 0 || md' <= base then base `mod` md' else base
+      bse' = if base < 0 || md <= base then base `mod` md else base
 
 -- | Modular power worker without input checking.
 --   Assumes all arguments strictly positive and modulus greater than 1.
@@ -214,21 +211,20 @@ powerMod'Impl base expo md = go expo 1 base
 -- | Specialised version of 'powerMod' for 'Integer' exponents.
 --   Reduces the number of shifts of the exponent since shifting
 --   large 'Integer's is expensive. Call this function directly
---   if you don't want or can't rely on rewrite rules.
+--   if you don't want or can't rely on rewrite rules. Modulus must be positive.
 powerModInteger :: Integer -> Integer -> Integer -> Integer
 powerModInteger base ex mdl
-  | mdl == 0    = base ^ ex
-  | mdl' == 1   = 0
+  | mdl <= 0     = error "Math.NumberTheory.Moduli.powerModInteger: non-positive modulus"
+  | mdl == 1    = 0
   | ex == 0     = 1
-  | ex < 0      = case invertMod bse' mdl' of
-                    Just i  -> powerModInteger' i (negate ex) mdl'
+  | ex < 0      = case invertMod bse' mdl of
+                    Just i  -> powerModInteger' i (negate ex) mdl
                     Nothing -> error "Math.NumberTheory.Moduli.powerMod: Base isn't invertible with respect to modulus"
   | bse' == 0   = 0
   | bse' == 1   = 1
-  | otherwise   = powerModInteger' bse' ex mdl'
+  | otherwise   = powerModInteger' bse' ex mdl
     where
-      mdl' = abs mdl
-      bse' = if base < 0 || mdl' <= base then base `mod` mdl' else base
+      bse' = if base < 0 || mdl <= base then base `mod` mdl else base
 
 -- | Specialised worker without input checks. Makes the same assumptions
 --   as the general version 'powerMod''.
@@ -323,7 +319,7 @@ sqrtModPList n prime
                         _      -> []
 
 -- | @sqrtModP' square prime@ finds a square root of @square@ modulo
---   prime. @prime@ /must/ be a (positive) prime, and @sqaure@ /must/ be a
+--   prime. @prime@ /must/ be a (positive) prime, and @square@ /must/ be a positive
 --   quadratic residue modulo @prime@, i.e. @'jacobi square prime == 1@.
 --   The precondition is /not/ checked.
 sqrtModP' :: Integer -> Integer -> Integer
@@ -334,7 +330,7 @@ sqrtModP' square prime
 
 -- | @tonelliShanks square prime@ calculates a square root of @square@
 --   modulo @prime@, where @prime@ is a prime of the form @4*k + 1@ and
---   @square@ is a quadratic residue modulo @prime@, using the
+--   @square@ is a positive quadratic residue modulo @prime@, using the
 --   Tonelli-Shanks algorithm.
 --   No checks on the input are performed.
 tonelliShanks :: Integer -> Integer -> Integer
@@ -459,8 +455,8 @@ sqrtModPPList n pe@(prime,expo)
 -- > r ≡ r_k (mod m_k)
 -- >
 --
---   if all moduli are pairwise coprime. If not all moduli are
---   pairwise coprime, the result is @Nothing@ regardless of whether
+--   if all moduli are positive and pairwise coprime. Otherwise
+--   the result is @Nothing@ regardless of whether
 --   a solution exists.
 chineseRemainder :: [(Integer,Integer)] -> Maybe Integer
 chineseRemainder remainders = foldM addRem 0 remainders

--- a/Math/NumberTheory/Moduli.hs
+++ b/Math/NumberTheory/Moduli.hs
@@ -414,14 +414,17 @@ sqM2P n e
 
 -- | @sqrtModF n primePowers@ calculates a square root of @n@ modulo
 --   @product [p^k | (p,k) <- primePowers]@ if one exists and all primes
---   are distinct.
+--   are distinct. The list must be non-empty.
 sqrtModF :: Integer -> [(Integer,Int)] -> Maybe Integer
+sqrtModF _ []  = Nothing
 sqrtModF n pps = do roots <- mapM (sqrtModPP n) pps
                     chineseRemainder $ zip roots (map (uncurry (^)) pps)
 
 -- | @sqrtModFList n primePowers@ calculates all square roots of @n@ modulo
 --   @product [p^k | (p,k) <- primePowers]@ if all primes are distinct.
+--   The list must be non-empty.
 sqrtModFList :: Integer -> [(Integer,Int)] -> [Integer]
+sqrtModFList _ []  = []
 sqrtModFList n pps = map fst $ foldl1 (liftM2 comb) cs
   where
     ms :: [Integer]

--- a/Math/NumberTheory/Moduli.hs
+++ b/Math/NumberTheory/Moduli.hs
@@ -436,6 +436,7 @@ sqrtModFList n pps = map fst $ foldl1 (liftM2 comb) cs
 --   square roots of @n@ modulo @prime^expo@. The same restriction
 --   as in 'sqrtModPP' applies to the arguments.
 sqrtModPPList :: Integer -> (Integer,Int) -> [Integer]
+sqrtModPPList n (2,1) = [n `mod` 2]
 sqrtModPPList n (2,expo)
     = case sqM2P n expo of
         Just r -> let m = 1 `shiftL` (expo-1)

--- a/Math/NumberTheory/Primes/Counting.hs
+++ b/Math/NumberTheory/Primes/Counting.hs
@@ -11,7 +11,9 @@
 module Math.NumberTheory.Primes.Counting
     ( -- * Exact functions
       primeCount
+    , primeCountMaxArg
     , nthPrime
+    , nthPrimeMaxArg
       -- * Approximations
     , approxPrimeCount
     , nthPrimeApprox

--- a/Math/NumberTheory/Primes/Counting.hs
+++ b/Math/NumberTheory/Primes/Counting.hs
@@ -16,7 +16,9 @@ module Math.NumberTheory.Primes.Counting
     , nthPrimeMaxArg
       -- * Approximations
     , approxPrimeCount
+    , approxPrimeCountOverestimateLimit
     , nthPrimeApprox
+    , nthPrimeApproxUnderestimateLimit
     ) where
 
 import Math.NumberTheory.Primes.Counting.Impl

--- a/Math/NumberTheory/Primes/Counting/Approximate.hs
+++ b/Math/NumberTheory/Primes/Counting/Approximate.hs
@@ -39,10 +39,10 @@ approxPrimeCount = truncate . max 0 . appi . fromIntegral
 nthPrimeApproxUnderestimateLimit :: Integer
 nthPrimeApproxUnderestimateLimit = 1000000000000
 
--- | @'nthPrimeApprox' n@ gives (for @n > 0@) an
+-- | @'nthPrimeApprox' n@ gives an
 --   approximation to the n-th prime. The approximation
 --   is fairly good for @n@ large enough.
-nthPrimeApprox :: Integral a => a -> a
+nthPrimeApprox :: Integer -> Integer
 nthPrimeApprox = max 1 . truncate . nthApp . fromIntegral . max 3
 
 -- Basically the approximation of the prime count by Li(x),

--- a/Math/NumberTheory/Primes/Counting/Approximate.hs
+++ b/Math/NumberTheory/Primes/Counting/Approximate.hs
@@ -27,11 +27,11 @@ module Math.NumberTheory.Primes.Counting.Approximate
 approxPrimeCountOverestimateLimit :: Integral a => a
 approxPrimeCountOverestimateLimit = 3742914359
 
--- | @'approxPrimeCount' n@ gives (for @n > 0@) an
+-- | @'approxPrimeCount' n@ gives an
 --   approximation of the number of primes not exceeding
 --   @n@. The approximation is fairly good for @n@ large enough.
 approxPrimeCount :: Integral a => a -> a
-approxPrimeCount = truncate . appi . fromIntegral
+approxPrimeCount = truncate . max 0 . appi . fromIntegral
 
 -- | Following property holds:
 --

--- a/Math/NumberTheory/Primes/Counting/Approximate.hs
+++ b/Math/NumberTheory/Primes/Counting/Approximate.hs
@@ -12,23 +12,36 @@
 {-# OPTIONS_HADDOCK hide #-}
 module Math.NumberTheory.Primes.Counting.Approximate
     ( approxPrimeCount
+    , approxPrimeCountOverestimateLimit
     , nthPrimeApprox
+    , nthPrimeApproxUnderestimateLimit
     ) where
+
+-- For prime p = 3742914359 we have
+--   approxPrimeCount p = 178317879
+--         primeCount p = 178317880
+
+-- | Following property holds:
+--
+-- > approxPrimeCount n >= primeCount n || n >= approxPrimeCountOverestimateLimit
+approxPrimeCountOverestimateLimit :: Integral a => a
+approxPrimeCountOverestimateLimit = 3742914359
 
 -- | @'approxPrimeCount' n@ gives (for @n > 0@) an
 --   approximation of the number of primes not exceeding
 --   @n@. The approximation is fairly good for @n@ large enough.
---   The number of primes should be slightly overestimated
---   (so it is suitable for allocation of storage) and is
---   never underestimated for @n <= 10^12@.
 approxPrimeCount :: Integral a => a -> a
 approxPrimeCount = truncate . appi . fromIntegral
 
+-- | Following property holds:
+--
+-- > nthPrimeApprox n <= nthPrime n || n >= nthPrimeApproxUnderestimateLimit
+nthPrimeApproxUnderestimateLimit :: Integer
+nthPrimeApproxUnderestimateLimit = 1000000000000
+
 -- | @'nthPrimeApprox' n@ gives (for @n > 0@) an
 --   approximation to the n-th prime. The approximation
---   is fairly good for @n@ large enough. Dual to
---   @'approxPrimeCount'@, this estimate should err
---   on the low side (and does for @n < 10^12@).
+--   is fairly good for @n@ large enough.
 nthPrimeApprox :: Integral a => a -> a
 nthPrimeApprox = max 1 . truncate . nthApp . fromIntegral . max 3
 

--- a/Math/NumberTheory/Primes/Counting/Impl.hs
+++ b/Math/NumberTheory/Primes/Counting/Impl.hs
@@ -13,7 +13,12 @@
 {-# OPTIONS_GHC -fspec-constr-count=24 #-}
 #endif
 {-# OPTIONS_HADDOCK hide #-}
-module Math.NumberTheory.Primes.Counting.Impl (primeCount, nthPrime) where
+module Math.NumberTheory.Primes.Counting.Impl
+    ( primeCount
+    , primeCountMaxArg
+    , nthPrime
+    , nthPrimeMaxArg
+    ) where
 
 #include "MachDeps.h"
 
@@ -39,10 +44,14 @@ import Data.Int
 #define COUNT_T Int
 #endif
 
+-- | Maximal allowed argument of 'primeCount'. Currently 8e18.
+primeCountMaxArg :: Integer
+primeCountMaxArg = 8000000000000000000
+
 -- | @'primeCount' n == &#960;(n)@ is the number of (positive) primes not exceeding @n@.
 --
 --   For efficiency, the calculations are done on 64-bit signed integers, therefore @n@ must
---   not exceed @8 * 10^18@.
+--   not exceed 'primeCountMaxArg'.
 --
 --   Requires @/O/(n^0.5)@ space, the time complexity is roughly @/O/(n^0.7)@.
 --   For small bounds, @'primeCount' n@ simply counts the primes not exceeding @n@,
@@ -51,7 +60,7 @@ import Data.Int
 --   <http://en.wikipedia.org/wiki/Prime_counting_function#Algorithms_for_evaluating_.CF.80.28x.29>.
 primeCount :: Integer -> Integer
 primeCount n
-    | n > 8000000000000000000   = error $ "primeCount: can't handle bound " ++ show n
+    | n > primeCountMaxArg = error $ "primeCount: can't handle bound " ++ show n
     | n < 2     = 0
     | n < 1000  = fromIntegral . length . takeWhile (<= n) . primeList . primeSieve $ max 242 n
     | n < 30000 = runST $ do
@@ -69,15 +78,19 @@ primeCount n
             !pdf = sieveCount ub cs sr
         in phn1 - pdf
 
+-- | Maximal allowed argument of 'nthPrime'. Currently 1.5e17.
+nthPrimeMaxArg :: Integer
+nthPrimeMaxArg = 150000000000000000
+
 -- | @'nthPrime' n@ calculates the @n@-th prime. Numbering of primes is
 --   @1@-based, so @'nthPrime' 1 == 2@.
 --
 --   Requires @/O/((n*log n)^0.5)@ space, the time complexity is roughly @/O/((n*log n)^0.7@.
---   The argument must be strictly positive, and must not exceed @1.5 * 10^17@.
+--   The argument must be strictly positive, and must not exceed 'nthPrimeMaxArg'.
 nthPrime :: Integer -> Integer
 nthPrime n
     | n < 1         = error "Prime indexing starts at 1"
-    | n > 150000000000000000    = error $ "nthPrime: can't handle index " ++ show n
+    | n > nthPrimeMaxArg = error $ "nthPrime: can't handle index " ++ show n
     | n < 200000    = nthPrimeCt n
     | ct0 < n       = tooLow n p0 (n-ct0) approxGap
     | otherwise     = tooHigh n p0 (ct0-n) approxGap

--- a/Math/NumberTheory/Primes/Heap.hs
+++ b/Math/NumberTheory/Primes/Heap.hs
@@ -332,12 +332,14 @@ findIx r
     | r < m     = down (a-1)
     | otherwise = up a
       where
-        a = min 5758 ((192*r) `quot` 1001 - 1)
+        a = max 0 (min 5758 ((192*r) `quot` 1001 - 1))
         m = remainders `unsafeAt` a
         down k
+            | k < 0                         = 0
             | r < (remainders `unsafeAt` k) = down (k-1)
             | otherwise                     = k
         up k
+            | k+1 > 5759                        = 5759
             | r < (remainders `unsafeAt` (k+1)) = k
             | otherwise                         = up (k+1)
 

--- a/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
+++ b/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
@@ -97,7 +97,7 @@ type CacheWord = Word64
 -- | Compact store of primality flags.
 data PrimeSieve = PS !Integer {-# UNPACK #-} !(UArray Int Bool)
 
--- | Sieve primes up to (and including) a bound.
+-- | Sieve primes up to (and including) a bound (or 7, if bound is smaller).
 --   For small enough bounds, this is more efficient than
 --   using the segmented sieve.
 --

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -129,6 +129,7 @@ test-suite spec
                   , Math.NumberTheory.GCD.LowLevelTests
                   , Math.NumberTheory.LogarithmsTests
                   , Math.NumberTheory.LucasTests
+                  , Math.NumberTheory.ModuliTests
                   , Math.NumberTheory.Powers.CubesTests
                   , Math.NumberTheory.MoebiusInversionTests
                   , Math.NumberTheory.MoebiusInversion.IntTests

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -137,5 +137,5 @@ test-suite spec
                   , Math.NumberTheory.Powers.IntegerTests
                   , Math.NumberTheory.Powers.SquaresTests
                   , Math.NumberTheory.PrimesTests
+                  , Math.NumberTheory.Primes.CountingTests
                   , Math.NumberTheory.TestUtils
-

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -139,4 +139,5 @@ test-suite spec
                   , Math.NumberTheory.PrimesTests
                   , Math.NumberTheory.Primes.CountingTests
                   , Math.NumberTheory.Primes.HeapTests
+                  , Math.NumberTheory.Primes.SieveTests
                   , Math.NumberTheory.TestUtils

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -138,4 +138,5 @@ test-suite spec
                   , Math.NumberTheory.Powers.SquaresTests
                   , Math.NumberTheory.PrimesTests
                   , Math.NumberTheory.Primes.CountingTests
+                  , Math.NumberTheory.Primes.HeapTests
                   , Math.NumberTheory.TestUtils

--- a/test-suite/Math/NumberTheory/ModuliTests.hs
+++ b/test-suite/Math/NumberTheory/ModuliTests.hs
@@ -1,0 +1,222 @@
+-- |
+-- Module:      Math.NumberTheory.ModuliTests
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.Moduli
+--
+
+{-# LANGUAGE CPP          #-}
+{-# LANGUAGE ViewPatterns #-}
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.ModuliTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+
+import Control.Arrow
+import Data.Bits
+import Data.List (tails, nub)
+import Data.Maybe
+
+import Math.NumberTheory.Moduli
+import Math.NumberTheory.TestUtils
+
+toOdd :: Num a => a -> a
+toOdd n = n * 2 + 1
+
+unwrapPP :: (Prime, Power Int) -> (Integer, Int)
+unwrapPP (Prime p, Power e) = (p, e)
+
+-- | Check that 'jacobi' matches 'jacobi''.
+jacobiProperty1 :: (Integral a, Bits a) => AnySign a -> NonNegative a -> Bool
+jacobiProperty1 (AnySign a) (NonNegative (toOdd -> n)) = n == 1 && j == 1 || n > 1 && j == j'
+  where
+    j = jacobi a n
+    j' = jacobi' a n
+
+-- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 2
+jacobiProperty2 :: (Integral a, Bits a) => AnySign a -> NonNegative a -> Bool
+jacobiProperty2 (AnySign a) (NonNegative (toOdd -> n)) = jacobi a n == jacobi (a + n) n
+
+-- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 3
+jacobiProperty3 :: (Integral a, Bits a) => AnySign a -> NonNegative a -> Bool
+jacobiProperty3 (AnySign a) (NonNegative (toOdd -> n)) = j == 0 && g /= 1 || abs j == 1 && g == 1
+  where
+    j = jacobi a n
+    g = gcd a n
+
+-- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 4
+jacobiProperty4 :: (Integral a, Bits a) => AnySign a -> AnySign a -> NonNegative a -> Bool
+jacobiProperty4 (AnySign a) (AnySign b) (NonNegative (toOdd -> n)) = jacobi (a * b) n == jacobi a n * jacobi b n
+
+jacobiProperty4_Integer :: AnySign Integer -> AnySign Integer -> NonNegative Integer -> Bool
+jacobiProperty4_Integer = jacobiProperty4
+
+-- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 5
+jacobiProperty5 :: (Integral a, Bits a) => AnySign a -> NonNegative a -> NonNegative a -> Bool
+jacobiProperty5 (AnySign a) (NonNegative (toOdd -> m)) (NonNegative (toOdd -> n)) = jacobi a (m * n) == jacobi a m * jacobi a n
+
+jacobiProperty5_Integer :: AnySign Integer -> NonNegative Integer -> NonNegative Integer -> Bool
+jacobiProperty5_Integer = jacobiProperty5
+
+-- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 6
+jacobiProperty6 :: (Integral a, Bits a) => NonNegative a -> NonNegative a -> Bool
+jacobiProperty6 (NonNegative (toOdd -> m)) (NonNegative (toOdd -> n)) = gcd m n /= 1 || jacobi m n * jacobi n m == (if m `mod` 4 == 1 || n `mod` 4 == 1 then 1 else -1)
+
+-- | Check that 'invertMod' inverts numbers modulo.
+invertModProperty :: AnySign Integer -> Positive Integer -> Bool
+invertModProperty (AnySign k) (Positive m) = case invertMod k m of
+  Nothing  -> k `mod` m == 0 || gcd k m > 1
+  Just inv -> gcd k m == 1
+      && k * inv `mod` m == 1 && 0 <= inv && inv < m
+
+-- | Check that the result of 'powerMod' is between 0 and modulo (non-inclusive).
+powerModProperty1 :: (Integral a, Bits a) => AnySign a -> AnySign Integer -> Positive Integer -> Bool
+powerModProperty1 (AnySign e) (AnySign b) (Positive m)
+  =  e < 0 && isNothing (invertMod b m)
+  || (0 <= pm && pm < m)
+  where
+    pm = powerMod b e m
+
+-- | Check that 'powerMod' is multiplicative by first argument.
+powerModProperty2 :: (Integral a, Bits a) => AnySign a -> AnySign Integer -> AnySign Integer -> Positive Integer -> Bool
+powerModProperty2 (AnySign e) (AnySign b1) (AnySign b2) (Positive m)
+  =  e < 0 && (isNothing (invertMod b1 m) || isNothing (invertMod b2 m))
+  || pm1 * pm2 `mod` m == pm12
+  where
+    pm1  = powerMod b1  e m
+    pm2  = powerMod b2  e m
+    pm12 = powerMod (b1 * b2) e m
+
+-- | Check that 'powerMod' is additive by second argument.
+powerModProperty3 :: (Integral a, Bits a) => AnySign a -> AnySign a -> AnySign Integer -> Positive Integer -> Bool
+powerModProperty3 (AnySign e1) (AnySign e2) (AnySign b) (Positive m)
+  =  (e1 < 0 || e2 < 0) && isNothing (invertMod b m)
+  || pm1 * pm2 `mod` m == pm12
+  where
+    pm1  = powerMod b e1 m
+    pm2  = powerMod b e2 m
+    pm12 = powerMod b (e1 + e2) m
+
+-- | Specialized to trigger 'powerModInteger'.
+powerModProperty1_Integer :: AnySign Integer -> AnySign Integer -> Positive Integer -> Bool
+powerModProperty1_Integer = powerModProperty1
+
+-- | Specialized to trigger 'powerModInteger'.
+powerModProperty2_Integer :: AnySign Integer -> AnySign Integer -> AnySign Integer -> Positive Integer -> Bool
+powerModProperty2_Integer = powerModProperty2
+
+-- | Specialized to trigger 'powerModInteger'.
+powerModProperty3_Integer :: AnySign Integer -> AnySign Integer -> AnySign Integer -> Positive Integer -> Bool
+powerModProperty3_Integer = powerModProperty3
+
+-- | Check that 'powerMod' matches 'powerMod''.
+powerMod'Property :: (Integral a, Bits a) => Positive a -> Positive Integer -> Positive Integer -> Bool
+powerMod'Property (Positive e) (Positive b) (Positive m) = m == 1 || powerMod' b e m == powerMod b e m
+
+-- | Specialized to trigger 'powerModInteger''.
+powerMod'Property_Integer :: Positive Integer -> Positive Integer -> Positive Integer -> Bool
+powerMod'Property_Integer = powerMod'Property
+
+-- | Check that 'chineseRemainder' is defined iff modulos are coprime.
+--   Also check that the result is a solution of input modular equations.
+chineseRemainderProperty :: [(Integer, Positive Integer)] -> Bool
+chineseRemainderProperty rms' = case chineseRemainder rms of
+  Nothing -> not areCoprime
+  Just n  -> areCoprime && map (n `mod`) ms == zipWith mod rs ms
+  where
+    rms = map (second getPositive) rms'
+    (rs, ms) = unzip rms
+    areCoprime = all (== 1) [ gcd m1 m2 | (m1 : m2s) <- tails ms, m2 <- m2s ]
+
+-- | Check that 'chineseRemainder' matches 'chineseRemainder2'.
+chineseRemainder2Property :: Integer -> Positive Integer -> Integer -> Positive Integer -> Bool
+chineseRemainder2Property r1 (Positive m1) r2 (Positive m2) = gcd m1 m2 /= 1
+  || Just (chineseRemainder2 (r1, m1) (r2, m2)) == chineseRemainder [(r1, m1), (r2, m2)]
+
+-- | Check that 'sqrtMod' is defined iff a quadratic residue exists.
+--   Also check that the result is a solution of input modular equation.
+sqrtModPProperty :: AnySign Integer -> Prime -> Bool
+sqrtModPProperty (AnySign n) (Prime p) = case sqrtModP n p of
+  Nothing -> jacobi n p == -1
+  Just rt -> (p == 2 || jacobi n p /= -1) && rt ^ 2 `mod` p == n `mod` p
+
+sqrtModPListProperty :: AnySign Integer -> Prime -> Bool
+sqrtModPListProperty (AnySign n) (Prime p) = all (\rt -> rt ^ 2 `mod` p == n `mod` p) (sqrtModPList n p)
+
+sqrtModP'Property :: Positive Integer -> Prime -> Bool
+sqrtModP'Property (Positive n) (Prime p) = (p /= 2 && jacobi n p /= 1) || rt ^ 2 `mod` p == n `mod` p
+  where
+    rt = sqrtModP' n p
+
+tonelliShanksProperty :: Positive Integer -> Prime -> Bool
+tonelliShanksProperty (Positive n) (Prime p) = p `mod` 4 /= 1 || jacobi n p /= 1 || rt ^ 2 `mod` p == n `mod` p
+  where
+    rt = tonelliShanks n p
+
+sqrtModPPProperty :: AnySign Integer -> (Prime, Power Int) -> Bool
+sqrtModPPProperty (AnySign n) (Prime p, Power e) = gcd n p > 1 || case sqrtModPP n (p, e) of
+  Nothing -> True
+  Just rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)
+
+sqrtModPPListProperty :: AnySign Integer -> (Prime, Power Int) -> Bool
+sqrtModPPListProperty (AnySign n) (Prime p, Power e) = gcd n p > 1
+  || all (\rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) (sqrtModPPList n (p, e))
+
+sqrtModFProperty :: AnySign Integer -> [(Prime, Power Int)] -> Bool
+sqrtModFProperty (AnySign n) (map unwrapPP -> pes) = case sqrtModF n pes of
+  Nothing -> True
+  Just rt -> all (\(p, e) -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) pes
+
+sqrtModFListProperty :: AnySign Integer -> [(Prime, Power Int)] -> Bool
+sqrtModFListProperty (AnySign n) (map unwrapPP -> pes)
+  = nub ps /= ps || all
+    (\rt -> all (\(p, e) -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) pes)
+    (sqrtModFList n pes)
+  where
+    ps = map fst pes
+
+testSuite :: TestTree
+testSuite = testGroup "Moduli"
+  [ testGroup "jacobi"
+    [ testSameIntegralProperty "matches jacobi'"              jacobiProperty1
+    , testSameIntegralProperty "same modulo n"                jacobiProperty2
+    , testSameIntegralProperty "consistent with gcd"          jacobiProperty3
+    , testSmallAndQuick        "multiplicative 1"             jacobiProperty4_Integer
+    , testSmallAndQuick        "multiplicative 2"             jacobiProperty5_Integer
+    , testSameIntegralProperty "law of quadratic reciprocity" jacobiProperty6
+    ]
+  , testSmallAndQuick "invertMod" invertModProperty
+  , testGroup "powerMod"
+    [ testGroup "generic"
+      [ testIntegralProperty "bounded between 0 and m"  powerModProperty1
+      , testIntegralProperty "multiplicative by base"   powerModProperty2
+      , testSameIntegralProperty "additive by exponent" powerModProperty3
+      , testIntegralProperty "matches powerMod'"        powerMod'Property
+      ]
+    , testGroup "Integer"
+      [ testSmallAndQuick "bounded between 0 and m" powerModProperty1_Integer
+      , testSmallAndQuick "multiplicative by base"  powerModProperty2_Integer
+      , testSmallAndQuick "additive by exponent"    powerModProperty3_Integer
+      , testSmallAndQuick "matches powerMod'"       powerMod'Property_Integer
+      ]
+    ]
+    , testSmallAndQuick "chineseRemainder"  chineseRemainderProperty
+    , testSmallAndQuick "chineseRemainder2" chineseRemainder2Property
+    , testGroup "sqrtMod"
+      [ testSmallAndQuick "sqrtModP"      sqrtModPProperty
+      , testSmallAndQuick "sqrtModPList"  sqrtModPListProperty
+      , testSmallAndQuick "sqrtModP'"     sqrtModP'Property
+      , testSmallAndQuick "tonelliShanks" tonelliShanksProperty
+      , testSmallAndQuick "sqrtModPP"     sqrtModPPProperty
+      , testSmallAndQuick "sqrtModPPList" sqrtModPPListProperty
+      , testSmallAndQuick "sqrtModF"      sqrtModFProperty
+      , testSmallAndQuick "sqrtModFList"  sqrtModFListProperty
+      ]
+  ]

--- a/test-suite/Math/NumberTheory/Primes/CountingTests.hs
+++ b/test-suite/Math/NumberTheory/Primes/CountingTests.hs
@@ -1,0 +1,148 @@
+-- |
+-- Module:      Math.NumberTheory.Primes.CountingTests
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.Primes.Counting
+--
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.Primes.CountingTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Math.NumberTheory.Primes.Counting
+import Math.NumberTheory.Primes.Testing
+import Math.NumberTheory.TestUtils
+
+-- | https://en.wikipedia.org/wiki/Prime-counting_function#Table_of_.CF.80.28x.29.2C_x_.2F_ln_x.2C_and_li.28x.29
+table :: [(Integer, Integer)]
+table =
+  [ (10^1,   4)
+  , (10^2,   25)
+  , (10^3,   168)
+  , (10^4,   1229)
+  , (10^5,   9592)
+  , (10^6,   78498)
+  , (10^7,   664579)
+  , (10^8,   5761455)
+  , (10^9,   50847534)
+  , (10^10,  455052511)
+  , (10^11,  4118054813)
+  , (10^12,  37607912018)
+  , (10^13,  346065536839)
+  -- , (10^14,  3204941750802)
+  -- , (10^15,  29844570422669)
+  -- , (10^16,  279238341033925)
+  -- , (10^17,  2623557157654233)
+  -- , (10^18,  24739954287740860)
+  -- , (10^19,  234057667276344607)
+  -- , (10^20,  2220819602560918840)
+  ]
+
+-- | Check that values of 'primeCount' are non-negative.
+primeCountProperty1 :: Integer -> Bool
+primeCountProperty1 n = n > primeCountMaxArg
+  || n >  0 && primeCount n >= 0
+  || n <= 0 && primeCount n == 0
+
+-- | Check that 'primeCount' is monotonically increasing function.
+primeCountProperty2 :: Positive Integer -> Positive Integer -> Bool
+primeCountProperty2 (Positive n1) (Positive n2)
+  =  n1 > primeCountMaxArg
+  || n2 > primeCountMaxArg
+  || n1 <= n2 && p1 <= p2
+  || n1 >  n2 && p1 >= p2
+  where
+    p1 = primeCount n1
+    p2 = primeCount n2
+
+-- | Check that 'primeCount' is strictly increasing iff an argument is prime.
+primeCountProperty3 :: Positive Integer -> Bool
+primeCountProperty3 (Positive n)
+  =  isPrime n && primeCount (n - 1) + 1 == primeCount n
+  || not (isPrime n) && primeCount (n - 1) == primeCount n
+
+-- | Check tabulated values.
+primeCountSpecialCases :: [Assertion]
+primeCountSpecialCases = map a table
+  where
+  a (n, m) = assertEqual "primeCount" m (primeCount n)
+
+
+-- | Check that values of 'nthPrime' are positive.
+nthPrimeProperty1 :: Positive Integer -> Bool
+nthPrimeProperty1 (Positive n) = n > nthPrimeMaxArg
+  || nthPrime n > 0
+
+-- | Check that 'nthPrime' is monotonically increasing function.
+nthPrimeProperty2 :: Positive Integer -> Positive Integer -> Bool
+nthPrimeProperty2 (Positive n1) (Positive n2)
+  =  n1 > nthPrimeMaxArg
+  || n2 > nthPrimeMaxArg
+  || n1 <= n2 && p1 <= p2
+  || n1 >  n2 && p1 >= p2
+  where
+    p1 = nthPrime n1
+    p2 = nthPrime n2
+
+-- | Check that values of 'nthPrime' are prime.
+nthPrimeProperty3 :: Positive Integer -> Bool
+nthPrimeProperty3 (Positive n) = isPrime $ nthPrime n
+
+-- | Check tabulated values.
+nthPrimeSpecialCases :: [Assertion]
+nthPrimeSpecialCases = map a table
+  where
+  a (n, m) = assertBool "nthPrime" $ n > nthPrime m
+
+
+-- | Check that values of 'approxPrimeCount' are non-negative.
+approxPrimeCountProperty1 :: Integral a => AnySign a -> Bool
+approxPrimeCountProperty1 (AnySign a) = approxPrimeCount a >= 0
+
+-- | Check that 'approxPrimeCount' is consistent with 'approxPrimeCountOverestimateLimit'.
+approxPrimeCountProperty2 :: Integral a => Positive a -> Bool
+approxPrimeCountProperty2 (Positive a) = a >= approxPrimeCountOverestimateLimit
+  || toInteger (approxPrimeCount a) >= primeCount (toInteger a)
+
+
+-- | Check that values of 'nthPrimeApprox' are positive.
+nthPrimeApproxProperty1 :: AnySign Integer -> Bool
+nthPrimeApproxProperty1 (AnySign a) = nthPrimeApprox a > 0
+
+-- | Check that 'nthPrimeApprox' is consistent with 'nthPrimeApproxUnderestimateLimit'.
+nthPrimeApproxProperty2 :: Positive Integer -> Bool
+nthPrimeApproxProperty2 (Positive a) = a >= nthPrimeApproxUnderestimateLimit
+  || toInteger (nthPrimeApprox a) <= nthPrime (toInteger a)
+
+
+testSuite :: TestTree
+testSuite = testGroup "Counting"
+  [ testGroup "primeCount"
+    ( testSmallAndQuick "non-negative"        primeCountProperty1
+    : testSmallAndQuick "monotonic"           primeCountProperty2
+    : testSmallAndQuick "increases on primes" primeCountProperty3
+    : zipWith (\i a -> testCase ("special case " ++ show i) a) [1..] primeCountSpecialCases
+    )
+  , testGroup "nthPrime"
+    ( testSmallAndQuick "positive"  nthPrimeProperty1
+    : testSmallAndQuick "monotonic" nthPrimeProperty2
+    : testSmallAndQuick "is prime"  nthPrimeProperty3
+    : zipWith (\i a -> testCase ("special case " ++ show i) a) [1..] nthPrimeSpecialCases
+    )
+  , testGroup "approxPrimeCount"
+    [ testIntegralProperty "non-negative"             approxPrimeCountProperty1
+    , testIntegralProperty "overestimates primeCount" approxPrimeCountProperty2
+    ]
+  , testGroup "nthPrimeApprox"
+    [ testSmallAndQuick "positive"                nthPrimeApproxProperty1
+    , testSmallAndQuick "underestimates nthPrime" nthPrimeApproxProperty2
+    ]
+  ]

--- a/test-suite/Math/NumberTheory/Primes/HeapTests.hs
+++ b/test-suite/Math/NumberTheory/Primes/HeapTests.hs
@@ -1,0 +1,67 @@
+-- |
+-- Module:      Math.NumberTheory.Primes.HeapTests
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.Primes.Heap
+--
+
+{-# LANGUAGE CPP #-}
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.Primes.HeapTests
+  ( testSuite
+  ) where
+
+import Prelude hiding (words)
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+#if MIN_VERSION_base(4,8,0)
+#else
+import Data.Word
+#endif
+
+import Math.NumberTheory.Primes.Heap
+import Math.NumberTheory.Primes.Testing
+import Math.NumberTheory.TestUtils
+
+-- | Check that 'primes' over different integral types matches with 'isPrime'.
+primesProperty1 :: Assertion
+primesProperty1 = do
+  assertEqual "ints  == integers" (trim ints)  (trim integers)
+  assertEqual "words == integers" (trim words) (trim integers)
+  assertEqual "naive == integers" (trim naive) (trim integers)
+  where
+    trim :: Integral a => [a] -> [Integer]
+    trim = map toInteger . take 100000
+
+    ints     = primes :: [Int]
+    words    = primes :: [Word]
+    integers = primes :: [Integer]
+    naive    = filter isPrime [1..] :: [Integer]
+
+-- | Check that 'sieveFrom' over different integral types matches with 'isPrime'.
+sieveFromProperty1 :: NonNegative Integer -> Bool
+sieveFromProperty1 (NonNegative lowBound)
+  =  trim ints  == trim integers
+  && trim words == trim integers
+  && trim naive == trim integers
+  where
+    trim :: Integral a => [a] -> [Integer]
+    trim = map toInteger . take 1000
+
+    ints     = sieveFrom (fromInteger lowBound) :: [Int]
+    words    = sieveFrom (fromInteger lowBound) :: [Word]
+    integers = sieveFrom lowBound               :: [Integer]
+    naive    = filter isPrime [lowBound..]      :: [Integer]
+
+testSuite :: TestTree
+testSuite = testGroup "Heap"
+  [ testCase          "primes"    primesProperty1
+  , testSmallAndQuick "sieveFrom" sieveFromProperty1
+  ]

--- a/test-suite/Math/NumberTheory/Primes/SieveTests.hs
+++ b/test-suite/Math/NumberTheory/Primes/SieveTests.hs
@@ -1,0 +1,69 @@
+-- |
+-- Module:      Math.NumberTheory.Primes.SieveTests
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.Primes.Sieve
+--
+
+{-# LANGUAGE CPP #-}
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.Primes.SieveTests
+  ( testSuite
+  ) where
+
+import Prelude hiding (words)
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Math.NumberTheory.Primes.Sieve
+import qualified Math.NumberTheory.Primes.Heap as H
+import Math.NumberTheory.TestUtils
+
+-- | Check that both 'primes' produce the same.
+primesProperty1 :: Assertion
+primesProperty1 = do
+  assertEqual "Sieve == Heap" (trim primes) (trim H.primes)
+  where
+    trim = take 100000
+
+-- | Check that both 'sieveFrom' produce the same.
+sieveFromProperty1 :: AnySign Integer -> Bool
+sieveFromProperty1 (AnySign lowBound)
+  = trim (sieveFrom lowBound) == trim (H.sieveFrom lowBound)
+  where
+    trim = take 1000
+
+-- | Check that 'primeList' from 'primeSieve' matches truncated 'primes'.
+primeSieveProperty1 :: AnySign Integer -> Bool
+primeSieveProperty1 (AnySign highBound)
+  = primeList (primeSieve highBound) == takeWhile (<= (highBound `max` 7)) primes
+
+-- | Check that 'primeList' from 'psieveList' matches 'primes'.
+psieveListProperty1 :: Assertion
+psieveListProperty1 = do
+  assertEqual "primes == primeList . psieveList" (trim primes) (trim $ concatMap primeList psieveList)
+  where
+    trim = take 100000
+
+-- | Check that 'primeList' from 'psieveFrom' matches 'sieveFrom'.
+psieveFromProperty1 :: AnySign Integer -> Bool
+psieveFromProperty1 (AnySign lowBound)
+  = trim (sieveFrom lowBound) == trim (filter (>= lowBound) (concatMap primeList $ psieveFrom lowBound))
+  where
+    trim = take 1000
+
+
+testSuite :: TestTree
+testSuite = testGroup "Sieve"
+  [ testCase          "primes"     primesProperty1
+  , testSmallAndQuick "sieveFrom"  sieveFromProperty1
+  , testSmallAndQuick "primeSieve" primeSieveProperty1
+  , testCase          "psieveList" psieveListProperty1
+  , testSmallAndQuick "psieveFrom" psieveFromProperty1
+  ]

--- a/test-suite/Math/NumberTheory/TestUtils.hs
+++ b/test-suite/Math/NumberTheory/TestUtils.hs
@@ -55,8 +55,9 @@ import Data.Foldable (Foldable)
 import Data.Traversable (Traversable)
 import Data.Word
 #endif
-
 import GHC.Exts
+
+import Math.NumberTheory.Primes
 
 newtype AnySign a = AnySign { getAnySign :: a }
   deriving (Eq, Ord, Read, Show, Num, Enum, Bounded, Integral, Real, Functor, Foldable, Traversable, Arbitrary)
@@ -95,8 +96,18 @@ newtype Power a = Power { getPower :: a }
 instance (Monad m, Num a, Ord a, Serial m a) => Serial m (Power a) where
   series = Power <$> series `suchThatSerial` (> 0)
 
-instance (Num a, Ord a, Arbitrary (Small a)) => Arbitrary (Power a) where
+instance (Num a, Ord a, Integral a, Arbitrary a) => Arbitrary (Power a) where
   arbitrary = Power <$> (getSmall <$> arbitrary) `suchThat` (> 0)
+  shrink (Power x) = Power <$> filter (> 0) (shrink x)
+
+newtype Prime = Prime { getPrime :: Integer }
+  deriving (Eq, Ord, Show)
+
+instance Arbitrary Prime where
+  arbitrary = Prime <$> arbitrary `suchThat` (\p -> p > 0 && isPrime p)
+
+instance Monad m => Serial m Prime where
+  series = Prime <$> series `suchThatSerial` (\p -> p > 0 && isPrime p)
 
 instance Monad m => Serial m Word where
   series =

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -17,6 +17,7 @@ import qualified Math.NumberTheory.Powers.IntegerTests as Integer
 import qualified Math.NumberTheory.Powers.SquaresTests as Squares
 
 import qualified Math.NumberTheory.PrimesTests as Primes
+import qualified Math.NumberTheory.Primes.CountingTests as Counting
 
 import qualified Math.NumberTheory.GaussianIntegersTests as Gaussian
 
@@ -48,6 +49,7 @@ tests = testGroup "All"
     ]
   , testGroup "Primes"
     [ Primes.testSuite
+    , Counting.testSuite
     ]
   , testGroup "Gaussian"
     [ Gaussian.testSuite

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -18,6 +18,7 @@ import qualified Math.NumberTheory.Powers.SquaresTests as Squares
 
 import qualified Math.NumberTheory.PrimesTests as Primes
 import qualified Math.NumberTheory.Primes.CountingTests as Counting
+import qualified Math.NumberTheory.Primes.HeapTests as Heap
 
 import qualified Math.NumberTheory.GaussianIntegersTests as Gaussian
 
@@ -50,6 +51,7 @@ tests = testGroup "All"
   , testGroup "Primes"
     [ Primes.testSuite
     , Counting.testSuite
+    , Heap.testSuite
     ]
   , testGroup "Gaussian"
     [ Gaussian.testSuite

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -7,6 +7,8 @@ import qualified Math.NumberTheory.LogarithmsTests as Logarithms
 
 import qualified Math.NumberTheory.LucasTests as Lucas
 
+import qualified Math.NumberTheory.ModuliTests as Moduli
+
 import qualified Math.NumberTheory.MoebiusInversionTests as MoebiusInversion
 import qualified Math.NumberTheory.MoebiusInversion.IntTests as MoebiusInversionInt
 
@@ -44,6 +46,9 @@ tests = testGroup "All"
     ]
   , testGroup "Lucas"
     [ Lucas.testSuite
+    ]
+  , testGroup "Moduli"
+    [ Moduli.testSuite
     ]
   , testGroup "MoebiusInversion"
     [ MoebiusInversion.testSuite

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -19,6 +19,7 @@ import qualified Math.NumberTheory.Powers.SquaresTests as Squares
 import qualified Math.NumberTheory.PrimesTests as Primes
 import qualified Math.NumberTheory.Primes.CountingTests as Counting
 import qualified Math.NumberTheory.Primes.HeapTests as Heap
+import qualified Math.NumberTheory.Primes.SieveTests as Sieve
 
 import qualified Math.NumberTheory.GaussianIntegersTests as Gaussian
 
@@ -52,6 +53,7 @@ tests = testGroup "All"
     [ Primes.testSuite
     , Counting.testSuite
     , Heap.testSuite
+    , Sieve.testSuite
     ]
   , testGroup "Gaussian"
     [ Gaussian.testSuite


### PR DESCRIPTION
One more pack of tests.

1. I have written tests for `Math.NumberTheory.Moduli`. They catched several edge cases with `chineseRemainder` and `sqrtMod***` functions. Tests also showed numerous issues with computations by non-positive modulo. I have not found any convenient and consistent way to fix them and, taking into account that non-positive moduli are mathematical nonsense, I decided to prohibit them. In future, when we drop support of older GHCs, moduli should be represented by `Natural`, not by `Integer`.

2. Tests for `Math.NumberTheory.Primes.Heap`. Fixed out-of-bounds error.

2. Tests for `Math.NumberTheory.Primes.Sieve`. Everything OK :)

3. Tests for `Math.NumberTheory.Primes.Counting`.
    * Since `nthPrimeApprox n > n`, there were overflows for bounded types (any `Integral` was accepted). I decided to change signature of `nthPrimeApprox` to accept and return `Integer`.
    * Fixed `approxPrimeCount 1` (was NaN).
    * Documentation refers to several magic numbers such as maximal allowed arguments of exact counters and overestimate/underestimate limits for approximate counters. I decided to expose them to user, otherwise one have copy-paste them from documentation to write reliable code. BTW `approxPrimeCountOverestimateLimit` in documentation was totally wrong.

4. Last not least: I have rewritten the definition of `TestableIntegral` class, using type families. Now it is more structured and easier to extend.
