### PR TITLE
Bugfix and add quickcheck test for `sieveFactor` trial division

### DIFF
--- a/Math/NumberTheory/Primes/Sieve/Misc.hs
+++ b/Math/NumberTheory/Primes/Sieve/Misc.hs
@@ -56,7 +56,7 @@ FactorSieve:
    To relate an odd number x to its index i:
 
        i = (x `div` 2) - 1
-       x = i*2 + 3
+       x = i * 2 + 3
 
 TotientSieve, CarmichaelSieve:
 
@@ -170,7 +170,7 @@ sieveFactor (FS bnd sve) = check
                                                j | j <= bound -> intLoop (fromIntegral (j `shiftR` 1) - 1)
                                                  | otherwise -> tdLoop j (integerSquareRoot' j) (ix+1)
           where
-            p = fromIntegral $ 2*ix + 3
+            p = fromIntegral $ 2 * ix + 3
             pix = unsafeAt sve ix
     curve n = stdGenFactorisation (Just (bound*(bound+2))) (mkStdGen $ fromIntegral n `xor` 0xdecaf00d) Nothing n
 

--- a/Math/NumberTheory/Primes/Sieve/Misc.hs
+++ b/Math/NumberTheory/Primes/Sieve/Misc.hs
@@ -149,8 +149,8 @@ sieveFactor (FS bnd sve) = check
                                                j | j <= bound -> intLoop (fromIntegral (j `shiftR` 1) - 1)
                                                  | otherwise -> tdLoop j (integerSquareRoot' j) (ix+1)
           where
-            p = toPrim ix
-            pix = unsafeAt sve $ fromIntegral p
+            p = fromIntegral $ 2*ix + 3
+            pix = unsafeAt sve ix
     curve n = stdGenFactorisation (Just (bound*(bound+2))) (mkStdGen $ fromIntegral n `xor` 0xdecaf00d) Nothing n
 
 -- | @'totientSieve' n@ creates a store of the totients of the numbers not exceeding @n@.

--- a/Math/NumberTheory/Primes/Sieve/Misc.hs
+++ b/Math/NumberTheory/Primes/Sieve/Misc.hs
@@ -47,6 +47,27 @@ import Math.NumberTheory.Primes.Factorisation.Utils
 import Math.NumberTheory.Unsafe
 import Math.NumberTheory.Utils
 
+{-
+IMPORTANT NOTICE: Not all sieves use the same layout!
+
+FactorSieve:
+
+   To remain as efficient as possible, FactorSieve omits only even numbers.
+   To relate an odd number x to its index i:
+
+       i = (x `div` 2) - 1
+       x = i*2 + 3
+
+TotientSieve, CarmichaelSieve:
+
+   These sieves use a (2,3,5) wheel optimization, sacrificing performance to save
+   more memory. The only indices stored are those coprime to 2, 3, and 5.
+   To relate such an integer x to its index i:
+
+       i = toIdx x
+       x = toPrim i
+-}
+
 -- | A compact store of smallest prime factors.
 data FactorSieve = FS {-# UNPACK #-} !Word {-# UNPACK #-} !(UArray Int Word16)
 
@@ -278,6 +299,9 @@ sieveCarmichael (CS bnd sve) = check
     curve tt n = tt `lcm` carmichaelFromCanonical (stdGenFactorisation (Just (bound*(bound+2))) (mkStdGen $ fromIntegral n `xor` 0xdecaf00d) Nothing n)
 
 
+-- NOTE: This is a legacy implementation of FactorSieve which uses the
+--       same (2,3,5) wheel optimization as the other sieves.
+--       It is still used to generate the other sieves.
 spfSieve :: Word -> ST s (STUArray s Int Word)
 spfSieve bound = do
   let (octs,lidx) = idxPr bound

--- a/test-suite/Math/NumberTheory/PrimesTests.hs
+++ b/test-suite/Math/NumberTheory/PrimesTests.hs
@@ -31,10 +31,16 @@ primesSumProperty (NonNegative n) = primesSumWonk n == primesSum n
 
 
 sieveFactorSpecialCase1 :: Assertion
-sieveFactorSpecialCase1 = assertEqual "sieveFactor" [(29, 1), (73, 1)] $ sieveFactor (factorSieve 2048) (29*73)
+sieveFactorSpecialCase1 = do
+    assertEqual "sieveFactor 2048" [(29, 1), (73, 1)] $ sieveFactor (factorSieve 2048) (29*73)
+    assertEqual "sieveFactor 15"   [(3, 1),  (5, 2)]  $ sieveFactor (factorSieve 15) (75)
+
+sieveFactorProperty :: Integer -> Bool
+sieveFactorProperty n = (n==0) || factorise n == sieveFactor (factorSieve 25) n
 
 testSuite :: TestTree
 testSuite = testGroup "Primes"
   [ testSmallAndQuick "primesSum"   primesSumProperty
-  , testCase          "sieveFactor" sieveFactorSpecialCase1
+  , testCase          "sieveFactor special"  sieveFactorSpecialCase1
+  , testSmallAndQuick "sieveFactor property" sieveFactorProperty
   ]


### PR DESCRIPTION
After much effort trying to decipher the trial division loop in `sieveFactor`, the only conclusion I could come to is that it cannot possibly work.  And it does not:

```haskell
import Math.NumberTheory.Primes.Factorisation
main = print $ sieveFactor (factorSieve 15) 75 -- prints [(75,1)]
```

As far as I can surmise, `toPrim` simply does not have anything to do with `FactorSieve` (it is for something that uses a much higher-order wheel optimization).

This commit also adds a quickcheck/smallcheck style test on a fairly small sieve (size 25) in a hope to exercise the trial division and curve factorization paths beyond just singular cases.

---
This raises the question, how did #17 appear to fix #7 if it was still using the wrong indices?

I was curious about this and also wanted to make sure that my "fix" wasn't just masking the issue by e.g. causing it to begin curve factorization too early.  After [debugging it with some traceShows](https://gist.github.com/ExpHP/6d8acbbd070ee8e67c71ebe0d87c8bc5), it appears that the 2048 case was merely fixed "by chance", as the majority of small odd numbers are prime. (so there is a high chance of `pix` fortituously being zero)