### PR TITLE
QuickCheck 2.9 fixes

### DIFF
--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -131,6 +131,7 @@ test-suite spec
                         , tasty-hunit >= 0.9 && < 0.10
                         , QuickCheck >= 2.8 && < 2.9
                         , smallcheck >= 1.1 && < 1.2
+                        , transformers >= 0.4
   other-modules :   Math.NumberTheory.ArithmeticFunctionsTests
                   , Math.NumberTheory.GaussianIntegersTests
                   , Math.NumberTheory.GCDTests
@@ -150,4 +151,6 @@ test-suite spec
                   , Math.NumberTheory.Primes.HeapTests
                   , Math.NumberTheory.Primes.SieveTests
                   , Math.NumberTheory.TestUtils
+                  , Math.NumberTheory.TestUtils.Wrappers
+                  , Math.NumberTheory.TestUtils.Compose
                   , Math.NumberTheory.UniqueFactorisationTests

--- a/test-suite/Math/NumberTheory/ModuliTests.hs
+++ b/test-suite/Math/NumberTheory/ModuliTests.hs
@@ -8,8 +8,8 @@
 -- Tests for Math.NumberTheory.Moduli
 --
 
-{-# LANGUAGE CPP          #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE CPP             #-}
+{-# LANGUAGE ViewPatterns    #-}
 
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
@@ -32,42 +32,42 @@ unwrapPP :: (Prime, Power Int) -> (Integer, Int)
 unwrapPP (Prime p, Power e) = (p, e)
 
 -- | Check that 'jacobi' matches 'jacobi''.
-jacobiProperty1 :: (Integral a, Bits a) => AnySign a -> (Compose NonNegative Odd) a -> Bool
-jacobiProperty1 (AnySign a) (Compose (NonNegative (Odd n))) = n == 1 && j == 1 || n > 1 && j == j'
+jacobiProperty1 :: (Integral a, Bits a) => AnySign a -> (Compose Positive Odd) a -> Bool
+jacobiProperty1 (AnySign a) (Compose (Positive (Odd n))) = n == 1 && j == 1 || n > 1 && j == j'
   where
     j = jacobi a n
     j' = jacobi' a n
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 2
-jacobiProperty2 :: (Integral a, Bits a) => AnySign a -> (Compose NonNegative Odd) a -> Bool
-jacobiProperty2 (AnySign a) (Compose (NonNegative (Odd n)))
+jacobiProperty2 :: (Integral a, Bits a) => AnySign a -> (Compose Positive Odd) a -> Bool
+jacobiProperty2 (AnySign a) (Compose (Positive (Odd n)))
   =  a + n < a -- check overflow
   || jacobi a n == jacobi (a + n) n
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 3
-jacobiProperty3 :: (Integral a, Bits a) => AnySign a -> (Compose NonNegative Odd) a -> Bool
-jacobiProperty3 (AnySign a) (Compose (NonNegative (Odd n))) = j == 0 && g /= 1 || abs j == 1 && g == 1
+jacobiProperty3 :: (Integral a, Bits a) => AnySign a -> (Compose Positive Odd) a -> Bool
+jacobiProperty3 (AnySign a) (Compose (Positive (Odd n))) = j == 0 && g /= 1 || abs j == 1 && g == 1
   where
     j = jacobi a n
     g = gcd a n
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 4
-jacobiProperty4 :: (Integral a, Bits a) => AnySign a -> AnySign a -> (Compose NonNegative Odd) a -> Bool
-jacobiProperty4 (AnySign a) (AnySign b) (Compose (NonNegative (Odd n))) = jacobi (a * b) n == jacobi a n * jacobi b n
+jacobiProperty4 :: (Integral a, Bits a) => AnySign a -> AnySign a -> (Compose Positive Odd) a -> Bool
+jacobiProperty4 (AnySign a) (AnySign b) (Compose (Positive (Odd n))) = jacobi (a * b) n == jacobi a n * jacobi b n
 
-jacobiProperty4_Integer :: AnySign Integer -> AnySign Integer -> (Compose NonNegative Odd) Integer -> Bool
+jacobiProperty4_Integer :: AnySign Integer -> AnySign Integer -> (Compose Positive Odd) Integer -> Bool
 jacobiProperty4_Integer = jacobiProperty4
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 5
-jacobiProperty5 :: (Integral a, Bits a) => AnySign a -> (Compose NonNegative Odd) a -> (Compose NonNegative Odd) a -> Bool
-jacobiProperty5 (AnySign a) (Compose (NonNegative (Odd m))) (Compose (NonNegative (Odd n))) = jacobi a (m * n) == jacobi a m * jacobi a n
+jacobiProperty5 :: (Integral a, Bits a) => AnySign a -> (Compose Positive Odd) a -> (Compose Positive Odd) a -> Bool
+jacobiProperty5 (AnySign a) (Compose (Positive (Odd m))) (Compose (Positive (Odd n))) = jacobi a (m * n) == jacobi a m * jacobi a n
 
-jacobiProperty5_Integer :: AnySign Integer -> (Compose NonNegative Odd) Integer -> (Compose NonNegative Odd) Integer -> Bool
+jacobiProperty5_Integer :: AnySign Integer -> (Compose Positive Odd) Integer -> (Compose Positive Odd) Integer -> Bool
 jacobiProperty5_Integer = jacobiProperty5
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 6
-jacobiProperty6 :: (Integral a, Bits a) => (Compose NonNegative Odd) a -> (Compose NonNegative Odd) a -> Bool
-jacobiProperty6 (Compose (NonNegative (Odd m))) (Compose (NonNegative (Odd n))) = gcd m n /= 1 || jacobi m n * jacobi n m == (if m `mod` 4 == 1 || n `mod` 4 == 1 then 1 else -1)
+jacobiProperty6 :: (Integral a, Bits a) => (Compose Positive Odd) a -> (Compose Positive Odd) a -> Bool
+jacobiProperty6 (Compose (Positive (Odd m))) (Compose (Positive (Odd n))) = gcd m n /= 1 || jacobi m n * jacobi n m == (if m `mod` 4 == 1 || n `mod` 4 == 1 then 1 else -1)
 
 -- | Check that 'invertMod' inverts numbers modulo.
 invertModProperty :: AnySign Integer -> Positive Integer -> Bool

--- a/test-suite/Math/NumberTheory/ModuliTests.hs
+++ b/test-suite/Math/NumberTheory/ModuliTests.hs
@@ -9,9 +9,11 @@
 --
 
 {-# LANGUAGE CPP             #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns    #-}
 
-{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults       #-}
+{-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
 
 module Math.NumberTheory.ModuliTests
   ( testSuite
@@ -28,46 +30,49 @@ import Data.Functor.Compose
 import Math.NumberTheory.Moduli
 import Math.NumberTheory.TestUtils
 
+pattern PositiveOdd :: t -> Compose Positive Odd t
+pattern PositiveOdd n = Compose (Positive (Odd n))
+
 unwrapPP :: (Prime, Power Int) -> (Integer, Int)
 unwrapPP (Prime p, Power e) = (p, e)
 
 -- | Check that 'jacobi' matches 'jacobi''.
 jacobiProperty1 :: (Integral a, Bits a) => AnySign a -> (Compose Positive Odd) a -> Bool
-jacobiProperty1 (AnySign a) (Compose (Positive (Odd n))) = n == 1 && j == 1 || n > 1 && j == j'
+jacobiProperty1 (AnySign a) (PositiveOdd n) = n == 1  && j == 1 || n > 1 && j == j'
   where
     j = jacobi a n
     j' = jacobi' a n
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 2
 jacobiProperty2 :: (Integral a, Bits a) => AnySign a -> (Compose Positive Odd) a -> Bool
-jacobiProperty2 (AnySign a) (Compose (Positive (Odd n)))
+jacobiProperty2 (AnySign a) (PositiveOdd n)
   =  a + n < a -- check overflow
   || jacobi a n == jacobi (a + n) n
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 3
 jacobiProperty3 :: (Integral a, Bits a) => AnySign a -> (Compose Positive Odd) a -> Bool
-jacobiProperty3 (AnySign a) (Compose (Positive (Odd n))) = j == 0 && g /= 1 || abs j == 1 && g == 1
+jacobiProperty3 (AnySign a) (PositiveOdd n) = j == 0 && g /= 1 || abs j == 1 && g == 1
   where
     j = jacobi a n
     g = gcd a n
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 4
 jacobiProperty4 :: (Integral a, Bits a) => AnySign a -> AnySign a -> (Compose Positive Odd) a -> Bool
-jacobiProperty4 (AnySign a) (AnySign b) (Compose (Positive (Odd n))) = jacobi (a * b) n == jacobi a n * jacobi b n
+jacobiProperty4 (AnySign a) (AnySign b) (PositiveOdd n) = jacobi (a * b) n == jacobi a n * jacobi b n
 
 jacobiProperty4_Integer :: AnySign Integer -> AnySign Integer -> (Compose Positive Odd) Integer -> Bool
 jacobiProperty4_Integer = jacobiProperty4
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 5
 jacobiProperty5 :: (Integral a, Bits a) => AnySign a -> (Compose Positive Odd) a -> (Compose Positive Odd) a -> Bool
-jacobiProperty5 (AnySign a) (Compose (Positive (Odd m))) (Compose (Positive (Odd n))) = jacobi a (m * n) == jacobi a m * jacobi a n
+jacobiProperty5 (AnySign a) (PositiveOdd m) (PositiveOdd n) = jacobi a (m * n) == jacobi a m * jacobi a n
 
 jacobiProperty5_Integer :: AnySign Integer -> (Compose Positive Odd) Integer -> (Compose Positive Odd) Integer -> Bool
 jacobiProperty5_Integer = jacobiProperty5
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 6
 jacobiProperty6 :: (Integral a, Bits a) => (Compose Positive Odd) a -> (Compose Positive Odd) a -> Bool
-jacobiProperty6 (Compose (Positive (Odd m))) (Compose (Positive (Odd n))) = gcd m n /= 1 || jacobi m n * jacobi n m == (if m `mod` 4 == 1 || n `mod` 4 == 1 then 1 else -1)
+jacobiProperty6 (PositiveOdd m) (PositiveOdd n) = gcd m n /= 1 || jacobi m n * jacobi n m == (if m `mod` 4 == 1 || n `mod` 4 == 1 then 1 else -1)
 
 -- | Check that 'invertMod' inverts numbers modulo.
 invertModProperty :: AnySign Integer -> Positive Integer -> Bool

--- a/test-suite/Math/NumberTheory/ModuliTests.hs
+++ b/test-suite/Math/NumberTheory/ModuliTests.hs
@@ -9,11 +9,9 @@
 --
 
 {-# LANGUAGE CPP             #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns    #-}
 
-{-# OPTIONS_GHC -fno-warn-type-defaults       #-}
-{-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 module Math.NumberTheory.ModuliTests
   ( testSuite
@@ -30,49 +28,46 @@ import Data.Functor.Compose
 import Math.NumberTheory.Moduli
 import Math.NumberTheory.TestUtils
 
-pattern PositiveOdd :: t -> Compose Positive Odd t
-pattern PositiveOdd n = Compose (Positive (Odd n))
-
 unwrapPP :: (Prime, Power Int) -> (Integer, Int)
 unwrapPP (Prime p, Power e) = (p, e)
 
 -- | Check that 'jacobi' matches 'jacobi''.
 jacobiProperty1 :: (Integral a, Bits a) => AnySign a -> (Compose Positive Odd) a -> Bool
-jacobiProperty1 (AnySign a) (PositiveOdd n) = n == 1  && j == 1 || n > 1 && j == j'
+jacobiProperty1 (AnySign a) (Compose (Positive (Odd n))) = n == 1 && j == 1 || n > 1 && j == j'
   where
     j = jacobi a n
     j' = jacobi' a n
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 2
 jacobiProperty2 :: (Integral a, Bits a) => AnySign a -> (Compose Positive Odd) a -> Bool
-jacobiProperty2 (AnySign a) (PositiveOdd n)
+jacobiProperty2 (AnySign a) (Compose (Positive (Odd n)))
   =  a + n < a -- check overflow
   || jacobi a n == jacobi (a + n) n
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 3
 jacobiProperty3 :: (Integral a, Bits a) => AnySign a -> (Compose Positive Odd) a -> Bool
-jacobiProperty3 (AnySign a) (PositiveOdd n) = j == 0 && g /= 1 || abs j == 1 && g == 1
+jacobiProperty3 (AnySign a) (Compose (Positive (Odd n))) = j == 0 && g /= 1 || abs j == 1 && g == 1
   where
     j = jacobi a n
     g = gcd a n
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 4
 jacobiProperty4 :: (Integral a, Bits a) => AnySign a -> AnySign a -> (Compose Positive Odd) a -> Bool
-jacobiProperty4 (AnySign a) (AnySign b) (PositiveOdd n) = jacobi (a * b) n == jacobi a n * jacobi b n
+jacobiProperty4 (AnySign a) (AnySign b) (Compose (Positive (Odd n))) = jacobi (a * b) n == jacobi a n * jacobi b n
 
 jacobiProperty4_Integer :: AnySign Integer -> AnySign Integer -> (Compose Positive Odd) Integer -> Bool
 jacobiProperty4_Integer = jacobiProperty4
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 5
 jacobiProperty5 :: (Integral a, Bits a) => AnySign a -> (Compose Positive Odd) a -> (Compose Positive Odd) a -> Bool
-jacobiProperty5 (AnySign a) (PositiveOdd m) (PositiveOdd n) = jacobi a (m * n) == jacobi a m * jacobi a n
+jacobiProperty5 (AnySign a) (Compose (Positive (Odd m))) (Compose (Positive (Odd n))) = jacobi a (m * n) == jacobi a m * jacobi a n
 
 jacobiProperty5_Integer :: AnySign Integer -> (Compose Positive Odd) Integer -> (Compose Positive Odd) Integer -> Bool
 jacobiProperty5_Integer = jacobiProperty5
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 6
 jacobiProperty6 :: (Integral a, Bits a) => (Compose Positive Odd) a -> (Compose Positive Odd) a -> Bool
-jacobiProperty6 (PositiveOdd m) (PositiveOdd n) = gcd m n /= 1 || jacobi m n * jacobi n m == (if m `mod` 4 == 1 || n `mod` 4 == 1 then 1 else -1)
+jacobiProperty6 (Compose (Positive (Odd m))) (Compose (Positive (Odd n))) = gcd m n /= 1 || jacobi m n * jacobi n m == (if m `mod` 4 == 1 || n `mod` 4 == 1 then 1 else -1)
 
 -- | Check that 'invertMod' inverts numbers modulo.
 invertModProperty :: AnySign Integer -> Positive Integer -> Bool

--- a/test-suite/Math/NumberTheory/ModuliTests.hs
+++ b/test-suite/Math/NumberTheory/ModuliTests.hs
@@ -23,51 +23,51 @@ import Control.Arrow
 import Data.Bits
 import Data.List (tails, nub)
 import Data.Maybe
+import Data.Functor.Compose
 
 import Math.NumberTheory.Moduli
 import Math.NumberTheory.TestUtils
-
-toOdd :: Num a => a -> a
-toOdd n = n * 2 + 1
 
 unwrapPP :: (Prime, Power Int) -> (Integer, Int)
 unwrapPP (Prime p, Power e) = (p, e)
 
 -- | Check that 'jacobi' matches 'jacobi''.
-jacobiProperty1 :: (Integral a, Bits a) => AnySign a -> NonNegative a -> Bool
-jacobiProperty1 (AnySign a) (NonNegative (toOdd -> n)) = n == 1 && j == 1 || n > 1 && j == j'
+jacobiProperty1 :: (Integral a, Bits a) => AnySign a -> (Compose NonNegative Odd) a -> Bool
+jacobiProperty1 (AnySign a) (Compose (NonNegative (Odd n))) = n == 1 && j == 1 || n > 1 && j == j'
   where
     j = jacobi a n
     j' = jacobi' a n
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 2
-jacobiProperty2 :: (Integral a, Bits a) => AnySign a -> NonNegative a -> Bool
-jacobiProperty2 (AnySign a) (NonNegative (toOdd -> n)) = jacobi a n == jacobi (a + n) n
+jacobiProperty2 :: (Integral a, Bits a) => AnySign a -> (Compose NonNegative Odd) a -> Bool
+jacobiProperty2 (AnySign a) (Compose (NonNegative (Odd n)))
+  =  a + n < a -- check overflow
+  || jacobi a n == jacobi (a + n) n
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 3
-jacobiProperty3 :: (Integral a, Bits a) => AnySign a -> NonNegative a -> Bool
-jacobiProperty3 (AnySign a) (NonNegative (toOdd -> n)) = j == 0 && g /= 1 || abs j == 1 && g == 1
+jacobiProperty3 :: (Integral a, Bits a) => AnySign a -> (Compose NonNegative Odd) a -> Bool
+jacobiProperty3 (AnySign a) (Compose (NonNegative (Odd n))) = j == 0 && g /= 1 || abs j == 1 && g == 1
   where
     j = jacobi a n
     g = gcd a n
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 4
-jacobiProperty4 :: (Integral a, Bits a) => AnySign a -> AnySign a -> NonNegative a -> Bool
-jacobiProperty4 (AnySign a) (AnySign b) (NonNegative (toOdd -> n)) = jacobi (a * b) n == jacobi a n * jacobi b n
+jacobiProperty4 :: (Integral a, Bits a) => AnySign a -> AnySign a -> (Compose NonNegative Odd) a -> Bool
+jacobiProperty4 (AnySign a) (AnySign b) (Compose (NonNegative (Odd n))) = jacobi (a * b) n == jacobi a n * jacobi b n
 
-jacobiProperty4_Integer :: AnySign Integer -> AnySign Integer -> NonNegative Integer -> Bool
+jacobiProperty4_Integer :: AnySign Integer -> AnySign Integer -> (Compose NonNegative Odd) Integer -> Bool
 jacobiProperty4_Integer = jacobiProperty4
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 5
-jacobiProperty5 :: (Integral a, Bits a) => AnySign a -> NonNegative a -> NonNegative a -> Bool
-jacobiProperty5 (AnySign a) (NonNegative (toOdd -> m)) (NonNegative (toOdd -> n)) = jacobi a (m * n) == jacobi a m * jacobi a n
+jacobiProperty5 :: (Integral a, Bits a) => AnySign a -> (Compose NonNegative Odd) a -> (Compose NonNegative Odd) a -> Bool
+jacobiProperty5 (AnySign a) (Compose (NonNegative (Odd m))) (Compose (NonNegative (Odd n))) = jacobi a (m * n) == jacobi a m * jacobi a n
 
-jacobiProperty5_Integer :: AnySign Integer -> NonNegative Integer -> NonNegative Integer -> Bool
+jacobiProperty5_Integer :: AnySign Integer -> (Compose NonNegative Odd) Integer -> (Compose NonNegative Odd) Integer -> Bool
 jacobiProperty5_Integer = jacobiProperty5
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 6
-jacobiProperty6 :: (Integral a, Bits a) => NonNegative a -> NonNegative a -> Bool
-jacobiProperty6 (NonNegative (toOdd -> m)) (NonNegative (toOdd -> n)) = gcd m n /= 1 || jacobi m n * jacobi n m == (if m `mod` 4 == 1 || n `mod` 4 == 1 then 1 else -1)
+jacobiProperty6 :: (Integral a, Bits a) => (Compose NonNegative Odd) a -> (Compose NonNegative Odd) a -> Bool
+jacobiProperty6 (Compose (NonNegative (Odd m))) (Compose (NonNegative (Odd n))) = gcd m n /= 1 || jacobi m n * jacobi n m == (if m `mod` 4 == 1 || n `mod` 4 == 1 then 1 else -1)
 
 -- | Check that 'invertMod' inverts numbers modulo.
 invertModProperty :: AnySign Integer -> Positive Integer -> Bool
@@ -98,6 +98,10 @@ powerModProperty2 (AnySign e) (AnySign b1) (AnySign b2) (Positive m)
 powerModProperty3 :: (Integral a, Bits a) => AnySign a -> AnySign a -> AnySign Integer -> Positive Integer -> Bool
 powerModProperty3 (AnySign e1) (AnySign e2) (AnySign b) (Positive m)
   =  (e1 < 0 || e2 < 0) && isNothing (invertMod b m)
+  || e2 >= 0 && e1 + e2 < e1 -- check overflow
+  || e1 >= 0 && e1 + e2 < e2 -- check overflow
+  || e2 <= 0 && e1 + e2 > e1 -- check overflow
+  || e1 <= 0 && e1 + e2 > e2 -- check overflow
   || pm1 * pm2 `mod` m == pm12
   where
     pm1  = powerMod b e1 m

--- a/test-suite/Math/NumberTheory/TestUtils/Compose.hs
+++ b/test-suite/Math/NumberTheory/TestUtils/Compose.hs
@@ -10,54 +10,38 @@
 --
 
 {-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans               #-}
-#if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
-#endif
+{-# OPTIONS_GHC -fno-warn-orphans       #-}
 
 module Math.NumberTheory.TestUtils.Compose where
 
-#if MIN_VERSION_base(4,8,0)
-#else
-import Control.Applicative
-#endif
-import Control.Arrow
-import Data.Functor.Classes
 import Data.Functor.Compose
+#if MIN_VERSION_transformers(0,5,0)
+#else
+import GHC.Generics
+#endif
 
-import Test.Tasty.QuickCheck (Arbitrary(..))
-import Test.SmallCheck.Series (Serial(..))
+import Test.Tasty.QuickCheck (Arbitrary)
+import Test.SmallCheck.Series (Serial)
 
-instance Num (f (g a)) => Num (Compose f g a) where
-  (Compose a) + (Compose b) = Compose (a + b)
-  (Compose a) * (Compose b) = Compose (a * b)
-  abs = Compose . abs . getCompose
-  signum = Compose . signum . getCompose
-  negate = Compose . negate . getCompose
-  fromInteger = Compose . fromInteger
+deriving instance Num (f (g a))     => Num (Compose f g a)
+deriving instance Enum (f (g a))    => Enum (Compose f g a)
+deriving instance Bounded (f (g a)) => Bounded (Compose f g a)
 
-instance Enum (f (g a)) => Enum (Compose f g a) where
-  toEnum = Compose . toEnum
-  fromEnum = fromEnum . getCompose
+deriving instance (Ord (Compose f g a), Real (f (g a)))     => Real (Compose f g a)
+deriving instance (Ord (Compose f g a), Integral (f (g a))) => Integral (Compose f g a)
 
-instance Bounded (f (g a)) => Bounded (Compose f g a) where
-  minBound = Compose minBound
-  maxBound = Compose maxBound
+deriving instance Arbitrary (f (g a)) => Arbitrary (Compose f g a)
 
-instance (Functor f, Ord1 f, Ord1 g, Ord a, Real (f (g a))) => Real (Compose f g a) where
-  toRational = toRational . getCompose
-
-instance (Functor f, Ord1 f, Ord1 g, Ord a, Integral (f (g a))) => Integral (Compose f g a) where
-  quotRem (Compose a) (Compose b) = (Compose *** Compose) (quotRem a b)
-  toInteger = toInteger . getCompose
-
-instance (Monad m, Serial m (f (g a))) => Serial m (Compose f g a) where
-  series = Compose <$> series
-
-instance Arbitrary (f (g a)) => Arbitrary (Compose f g a) where
-  arbitrary = Compose <$> arbitrary
-  shrink = fmap Compose . shrink . getCompose
+#if MIN_VERSION_transformers(0,5,0)
+#else
+deriving instance Generic (Compose f g a)
+#endif
+instance (Monad m, Serial m (f (g a))) => Serial m (Compose f g a)

--- a/test-suite/Math/NumberTheory/TestUtils/Compose.hs
+++ b/test-suite/Math/NumberTheory/TestUtils/Compose.hs
@@ -1,0 +1,63 @@
+-- |
+-- Module:      Math.NumberTheory.TestUtils.Compose
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- Utils to test Math.NumberTheory
+--
+
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans               #-}
+#if __GLASGOW_HASKELL__ >= 800
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+#endif
+
+module Math.NumberTheory.TestUtils.Compose where
+
+#if MIN_VERSION_base(4,8,0)
+#else
+import Control.Applicative
+#endif
+import Control.Arrow
+import Data.Functor.Classes
+import Data.Functor.Compose
+
+import Test.Tasty.QuickCheck (Arbitrary(..))
+import Test.SmallCheck.Series (Serial(..))
+
+instance Num (f (g a)) => Num (Compose f g a) where
+  (Compose a) + (Compose b) = Compose (a + b)
+  (Compose a) * (Compose b) = Compose (a * b)
+  abs = Compose . abs . getCompose
+  signum = Compose . signum . getCompose
+  negate = Compose . negate . getCompose
+  fromInteger = Compose . fromInteger
+
+instance Enum (f (g a)) => Enum (Compose f g a) where
+  toEnum = Compose . toEnum
+  fromEnum = fromEnum . getCompose
+
+instance Bounded (f (g a)) => Bounded (Compose f g a) where
+  minBound = Compose minBound
+  maxBound = Compose maxBound
+
+instance (Functor f, Ord1 f, Ord1 g, Ord a, Real (f (g a))) => Real (Compose f g a) where
+  toRational = toRational . getCompose
+
+instance (Functor f, Ord1 f, Ord1 g, Ord a, Integral (f (g a))) => Integral (Compose f g a) where
+  quotRem (Compose a) (Compose b) = (Compose *** Compose) (quotRem a b)
+  toInteger = toInteger . getCompose
+
+instance (Monad m, Serial m (f (g a))) => Serial m (Compose f g a) where
+  series = Compose <$> series
+
+instance Arbitrary (f (g a)) => Arbitrary (Compose f g a) where
+  arbitrary = Compose <$> arbitrary
+  shrink = fmap Compose . shrink . getCompose

--- a/test-suite/Math/NumberTheory/TestUtils/Wrappers.hs
+++ b/test-suite/Math/NumberTheory/TestUtils/Wrappers.hs
@@ -1,0 +1,255 @@
+-- |
+-- Module:      Math.NumberTheory.TestUtils.Wrappers
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- Utils to test Math.NumberTheory
+--
+
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DeriveFoldable             #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE DeriveTraversable          #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans       #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.TestUtils.Wrappers where
+
+import Control.Applicative
+import Data.Functor.Classes
+#if MIN_VERSION_base(4,8,0)
+#else
+import Data.Foldable (Foldable)
+import Data.Traversable (Traversable)
+#endif
+
+import Test.Tasty.QuickCheck as QC hiding (Positive, NonNegative, generate, getNonNegative, getPositive)
+import Test.SmallCheck.Series (Positive(..), NonNegative(..), Serial(..), Series)
+
+import Math.NumberTheory.Primes (isPrime)
+
+-------------------------------------------------------------------------------
+-- AnySign
+
+newtype AnySign a = AnySign { getAnySign :: a }
+  deriving (Eq, Ord, Read, Show, Num, Enum, Bounded, Integral, Real, Functor, Foldable, Traversable, Arbitrary)
+
+instance (Monad m, Serial m a) => Serial m (AnySign a) where
+  series = AnySign <$> series
+
+instance Eq1 AnySign where
+#if MIN_VERSION_transformers(0,5,0)
+  liftEq eq (AnySign a) (AnySign b) = a `eq` b
+#else
+  (AnySign a) `eq1` (AnySign b) = a == b
+#endif
+
+instance Ord1 AnySign where
+#if MIN_VERSION_transformers(0,5,0)
+  liftCompare cmp (AnySign a) (AnySign b) = a `cmp` b
+#else
+  (AnySign a) `compare1` (AnySign b) = a `compare` b
+#endif
+
+instance Show1 AnySign where
+#if MIN_VERSION_transformers(0,5,0)
+  liftShowsPrec shw _ p (AnySign a) = shw p a
+#else
+  showsPrec1 p (AnySign a) = showsPrec p a
+#endif
+
+-------------------------------------------------------------------------------
+-- Positive from smallcheck
+
+deriving instance Functor Positive
+
+instance (Num a, Ord a, Arbitrary a) => Arbitrary (Positive a) where
+  arbitrary = Positive <$> (arbitrary `suchThat` (> 0))
+  shrink (Positive x) = Positive <$> filter (> 0) (shrink x)
+
+instance (Num a, Bounded a) => Bounded (Positive a) where
+  minBound = Positive 1
+  maxBound = Positive (maxBound :: a)
+
+instance Eq1 Positive where
+#if MIN_VERSION_transformers(0,5,0)
+  liftEq eq (Positive a) (Positive b) = a `eq` b
+#else
+  (Positive a) `eq1` (Positive b) = a == b
+#endif
+
+instance Ord1 Positive where
+#if MIN_VERSION_transformers(0,5,0)
+  liftCompare cmp (Positive a) (Positive b) = a `cmp` b
+#else
+  (Positive a) `compare1` (Positive b) = a `compare` b
+#endif
+
+instance Show1 Positive where
+#if MIN_VERSION_transformers(0,5,0)
+  liftShowsPrec shw _ p (Positive a) = shw p a
+#else
+  showsPrec1 p (Positive a) = showsPrec p a
+#endif
+
+-------------------------------------------------------------------------------
+-- NonNegative from smallcheck
+
+deriving instance Functor NonNegative
+
+instance (Num a, Ord a, Arbitrary a) => Arbitrary (NonNegative a) where
+  arbitrary = NonNegative <$> (arbitrary `suchThat` (>= 0))
+  shrink (NonNegative x) = NonNegative <$> filter (>= 0) (shrink x)
+
+instance (Num a, Bounded a) => Bounded (NonNegative a) where
+  minBound = NonNegative 0
+  maxBound = NonNegative (maxBound :: a)
+
+instance Eq1 NonNegative where
+#if MIN_VERSION_transformers(0,5,0)
+  liftEq eq (NonNegative a) (NonNegative b) = a `eq` b
+#else
+  (NonNegative a) `eq1` (NonNegative b) = a == b
+#endif
+
+instance Ord1 NonNegative where
+#if MIN_VERSION_transformers(0,5,0)
+  liftCompare cmp (NonNegative a) (NonNegative b) = a `cmp` b
+#else
+  (NonNegative a) `compare1` (NonNegative b) = a `compare` b
+#endif
+
+instance Show1 NonNegative where
+#if MIN_VERSION_transformers(0,5,0)
+  liftShowsPrec shw _ p (NonNegative a) = shw p a
+#else
+  showsPrec1 p (NonNegative a) = showsPrec p a
+#endif
+
+-------------------------------------------------------------------------------
+-- Huge
+
+newtype Huge a = Huge { getHuge :: a }
+  deriving (Eq, Ord, Read, Show, Num, Enum, Bounded, Integral, Real, Functor, Foldable, Traversable)
+
+instance (Num a, Arbitrary a) => Arbitrary (Huge a) where
+  arbitrary = do
+    Positive l <- arbitrary
+    ds <- vector l
+    return $ Huge $ foldl1 (\acc n -> acc * 2^63 + n) ds
+
+instance Eq1 Huge where
+#if MIN_VERSION_transformers(0,5,0)
+  liftEq eq (Huge a) (Huge b) = a `eq` b
+#else
+  (Huge a) `eq1` (Huge b) = a == b
+#endif
+
+instance Ord1 Huge where
+#if MIN_VERSION_transformers(0,5,0)
+  liftCompare cmp (Huge a) (Huge b) = a `cmp` b
+#else
+  (Huge a) `compare1` (Huge b) = a `compare` b
+#endif
+
+instance Show1 Huge where
+#if MIN_VERSION_transformers(0,5,0)
+  liftShowsPrec shw _ p (Huge a) = shw p a
+#else
+  showsPrec1 p (Huge a) = showsPrec p a
+#endif
+
+-------------------------------------------------------------------------------
+-- Power
+
+newtype Power a = Power { getPower :: a }
+  deriving (Eq, Ord, Read, Show, Num, Enum, Bounded, Integral, Real, Functor, Foldable, Traversable)
+
+instance (Monad m, Num a, Ord a, Serial m a) => Serial m (Power a) where
+  series = Power <$> series `suchThatSerial` (> 0)
+
+instance (Num a, Ord a, Integral a, Arbitrary a) => Arbitrary (Power a) where
+  arbitrary = Power <$> (getSmall <$> arbitrary) `suchThat` (> 0)
+  shrink (Power x) = Power <$> filter (> 0) (shrink x)
+
+instance Eq1 Power where
+#if MIN_VERSION_transformers(0,5,0)
+  liftEq eq (Power a) (Power b) = a `eq` b
+#else
+  (Power a) `eq1` (Power b) = a == b
+#endif
+
+instance Ord1 Power where
+#if MIN_VERSION_transformers(0,5,0)
+  liftCompare cmp (Power a) (Power b) = a `cmp` b
+#else
+  (Power a) `compare1` (Power b) = a `compare` b
+#endif
+
+instance Show1 Power where
+#if MIN_VERSION_transformers(0,5,0)
+  liftShowsPrec shw _ p (Power a) = shw p a
+#else
+  showsPrec1 p (Power a) = showsPrec p a
+#endif
+
+-------------------------------------------------------------------------------
+-- Odd
+
+newtype Odd a = Odd { getOdd :: a }
+  deriving (Eq, Ord, Read, Show, Num, Enum, Bounded, Integral, Real, Functor, Foldable, Traversable)
+
+instance (Monad m, Serial m a, Integral a) => Serial m (Odd a) where
+  series = Odd <$> series `suchThatSerial` odd
+
+instance (Integral a, Arbitrary a) => Arbitrary (Odd a) where
+  arbitrary = Odd <$> (arbitrary `suchThat` odd)
+  shrink (Odd x) = Odd <$> filter odd (shrink x)
+
+instance Eq1 Odd where
+#if MIN_VERSION_transformers(0,5,0)
+  liftEq eq (Odd a) (Odd b) = a `eq` b
+#else
+  (Odd a) `eq1` (Odd b) = a == b
+#endif
+
+instance Ord1 Odd where
+#if MIN_VERSION_transformers(0,5,0)
+  liftCompare cmp (Odd a) (Odd b) = a `cmp` b
+#else
+  (Odd a) `compare1` (Odd b) = a `compare` b
+#endif
+
+instance Show1 Odd where
+#if MIN_VERSION_transformers(0,5,0)
+  liftShowsPrec shw _ p (Odd a) = shw p a
+#else
+  showsPrec1 p (Odd a) = showsPrec p a
+#endif
+
+-------------------------------------------------------------------------------
+-- Prime
+
+newtype Prime = Prime { getPrime :: Integer }
+  deriving (Eq, Ord, Show)
+
+instance Arbitrary Prime where
+  arbitrary = Prime <$> arbitrary `suchThat` (\p -> p > 0 && isPrime p)
+
+instance Monad m => Serial m Prime where
+  series = Prime <$> series `suchThatSerial` (\p -> p > 0 && isPrime p)
+
+-------------------------------------------------------------------------------
+-- Utils
+
+suchThatSerial :: Series m a -> (a -> Bool) -> Series m a
+suchThatSerial s p = s >>= \x -> if p x then pure x else empty


### PR DESCRIPTION
QuickCheck 2.9 fixed bug in `arbitrarySizedBoundedIntegral`, which generates really huge numbers now. This fix caused several test failures in `arithmoi` due to integer overflow. See discussion in #33.

The PR fixes our test-suite to be compatible with new version of QuickCheck. 

Since there is no changes in library code, I am keen to merge it ASAP, if no-one minds.