### PR TITLE
Bilinear recurrencies and Bernoulli numbers

### DIFF
--- a/Math/NumberTheory/Recurrencies/Bilinear.hs
+++ b/Math/NumberTheory/Recurrencies/Bilinear.hs
@@ -1,0 +1,53 @@
+-- |
+-- Module:      Math.NumberTheory.Recurrencies.Bilinear
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+
+module Math.NumberTheory.Recurrencies.Bilinear
+  ( binomial
+  , stirling1
+  , stirling2
+  , eulerian1
+  , eulerian2
+  , bernoulli
+  ) where
+
+import Data.List
+import Data.Ratio
+
+factorial :: [Integer]
+factorial = 1 : zipWith (*) [1..] factorial
+
+binomial :: [[Integer]]
+binomial = [1] : map f binomial
+  where
+    f xs = 1 : zipWith (+) xs (tail xs ++ [0])
+
+stirling1 :: [[Integer]]
+stirling1 = [1] : zipWith f [0..] stirling1
+  where
+    f n xs = 0 : zipWith (\x1 x -> x1 + n * x) xs (tail xs ++ [0])
+
+stirling2 :: [[Integer]]
+stirling2 = [1] : map f stirling2
+  where
+    f xs = 0 : zipWith3 (\k x1 x -> x1 + k * x) [1..] xs (tail xs ++ [0])
+
+eulerian1 :: [[Integer]]
+eulerian1 = [] : zipWith f [1..] eulerian1
+  where
+    f n xs = 1 : zipWith3 (\k x1 x -> (n - k) * x1 + (k + 1) * x) [1..] xs (tail xs ++ [0])
+
+eulerian2 :: [[Integer]]
+eulerian2 = [] : zipWith f [1..] eulerian2
+  where
+    f n xs = 1 : zipWith3 (\k x1 x -> (2 * n - k - 1) * x1 + (k + 1) * x) [1..] xs (tail xs ++ [0])
+
+bernoulli :: [Rational]
+bernoulli = map f stirling2
+  where
+    f = sum . zipWith4 (\sgn denom fact stir -> sgn * fact * stir % denom) (cycle [1, -1]) [1..] factorial

--- a/Math/NumberTheory/Recurrencies/Bilinear.hs
+++ b/Math/NumberTheory/Recurrencies/Bilinear.hs
@@ -47,7 +47,7 @@ import Data.Ratio
 factorial :: (Num a, Enum a) => [a]
 factorial = 1 : zipWith (*) [1..] factorial
 
--- | Infinite table of binomial coefficients: @binomial !! n !! k == n! \/ k! \/ (n - k)!@.
+-- | Infinite zero-based table of binomial coefficients: @binomial !! n !! k == n! \/ k! \/ (n - k)!@.
 --
 -- > > take 5 (map (take 5) binomial)
 -- > [[1],[1,1],[1,2,1],[1,3,3,1],[1,4,6,4,1]]
@@ -58,7 +58,7 @@ binomial = [1] : map f binomial
   where
     f xs = 1 : zipWith (+) xs (tail xs ++ [0])
 
--- | Infinite table of <https://en.wikipedia.org/wiki/Stirling_numbers_of_the_first_kind Stirling numbers of the first kind>.
+-- | Infinite zero-based table of <https://en.wikipedia.org/wiki/Stirling_numbers_of_the_first_kind Stirling numbers of the first kind>.
 --
 -- > > take 5 (map (take 5) stirling1)
 -- > [[1],[0,1],[0,1,1],[0,2,3,1],[0,6,11,6,1]]
@@ -69,7 +69,7 @@ stirling1 = [1] : zipWith f [0..] stirling1
   where
     f n xs = 0 : zipWith (\x1 x -> x1 + n * x) xs (tail xs ++ [0])
 
--- | Infinite table of <https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind Stirling numbers of the second kind>.
+-- | Infinite zero-based table of <https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind Stirling numbers of the second kind>.
 --
 -- > > take 5 (map (take 5) stirling2)
 -- > [[1],[0,1],[0,1,1],[0,1,3,1],[0,1,7,6,1]]
@@ -80,7 +80,7 @@ stirling2 = [1] : map f stirling2
   where
     f xs = 0 : zipWith3 (\k x1 x -> x1 + k * x) [1..] xs (tail xs ++ [0])
 
--- | Infinite table of <https://en.wikipedia.org/wiki/Eulerian_number Eulerian numbers of the first kind>.
+-- | Infinite zero-based table of <https://en.wikipedia.org/wiki/Eulerian_number Eulerian numbers of the first kind>.
 --
 -- > > take 5 (map (take 5) eulerian1)
 -- > [[],[1],[1,1],[1,4,1],[1,11,11,1]]
@@ -90,7 +90,7 @@ eulerian1 = [] : zipWith f [1..] eulerian1
   where
     f n xs = 1 : zipWith3 (\k x1 x -> (n - k) * x1 + (k + 1) * x) [1..] xs (tail xs ++ [0])
 
--- | Infinite table of <https://en.wikipedia.org/wiki/Eulerian_number#Eulerian_numbers_of_the_second_kind Eulerian numbers of the second kind>.
+-- | Infinite zero-based table of <https://en.wikipedia.org/wiki/Eulerian_number#Eulerian_numbers_of_the_second_kind Eulerian numbers of the second kind>.
 --
 -- > > take 5 (map (take 5) eulerian2)
 -- > [[],[1],[1,2],[1,8,6],[1,22,58,24]]
@@ -100,7 +100,7 @@ eulerian2 = [] : zipWith f [1..] eulerian2
   where
     f n xs = 1 : zipWith3 (\k x1 x -> (2 * n - k - 1) * x1 + (k + 1) * x) [1..] xs (tail xs ++ [0])
 
--- | Infinite sequence of <https://en.wikipedia.org/wiki/Bernoulli_number Bernoulli numbers>,
+-- | Infinite zero-based sequence of <https://en.wikipedia.org/wiki/Bernoulli_number Bernoulli numbers>,
 -- computed via <https://en.wikipedia.org/wiki/Bernoulli_number#Connection_with_Stirling_numbers_of_the_second_kind connection>
 -- with 'stirling2'.
 --

--- a/Math/NumberTheory/Recurrencies/Bilinear.hs
+++ b/Math/NumberTheory/Recurrencies/Bilinear.hs
@@ -153,6 +153,7 @@ bernoulli :: Integral a => [Ratio a]
 bernoulli = map f stirling2
   where
     f = sum . zipWith4 (\sgn denom fact stir -> sgn * fact * stir % denom) (cycle [1, -1]) [1..] factorial
+{-# SPECIALIZE bernoulli :: [Ratio Int] #-}
 {-# SPECIALIZE bernoulli :: [Rational] #-}
 
 -------------------------------------------------------------------------------

--- a/Math/NumberTheory/Recurrencies/Bilinear.hs
+++ b/Math/NumberTheory/Recurrencies/Bilinear.hs
@@ -9,6 +9,28 @@
 -- Bilinear recurrent sequences and Bernoulli numbers,
 -- roughly covering Ch. 5-6 of /Concrete Mathematics/
 -- by R. L. Graham, D. E. Knuth and O. Patashnik.
+--
+-- __Note on memory leaks and memoization.__
+-- Top-level definitions in this module are polymorphic, so the results of computations are not retained in memory.
+-- Make them monomorphic to take advantages of memoization. Compare
+--
+-- > > :set +s
+-- > > binomial !! 1000 !! 1000 :: Integer
+-- > 1
+-- > (0.10 secs, 153,437,432 bytes)
+-- > > binomial !! 1000 !! 1000 :: Integer
+-- > 1
+-- > (0.10 secs, 153,432,856 bytes)
+--
+-- against
+--
+-- > > let binomial' = binomial :: [[Integer]]
+-- > > binomial' !! 1000 !! 1000 :: Integer
+-- > 1
+-- > (0.10 secs, 152,401,808 bytes)
+-- > > binomial' !! 1000 !! 1000 :: Integer
+-- > 1
+-- > (0.01 secs, 1,551,416 bytes)
 
 module Math.NumberTheory.Recurrencies.Bilinear
   ( binomial
@@ -22,7 +44,7 @@ module Math.NumberTheory.Recurrencies.Bilinear
 import Data.List
 import Data.Ratio
 
-factorial :: [Integer]
+factorial :: (Num a, Enum a) => [a]
 factorial = 1 : zipWith (*) [1..] factorial
 
 -- | Infinite table of binomial coefficients: @binomial !! n !! k == n! \/ k! \/ (n - k)!@.
@@ -31,7 +53,7 @@ factorial = 1 : zipWith (*) [1..] factorial
 -- > [[1],[1,1],[1,2,1],[1,3,3,1],[1,4,6,4,1]]
 --
 -- One could also consider 'Math.Combinat.Numbers.binomial' to compute stand-alone values.
-binomial :: [[Integer]]
+binomial :: Num a => [[a]]
 binomial = [1] : map f binomial
   where
     f xs = 1 : zipWith (+) xs (tail xs ++ [0])
@@ -42,7 +64,7 @@ binomial = [1] : map f binomial
 -- > [[1],[0,1],[0,1,1],[0,2,3,1],[0,6,11,6,1]]
 --
 -- One could also consider 'Math.Combinat.Numbers.unsignedStirling1st' to compute stand-alone values.
-stirling1 :: [[Integer]]
+stirling1 :: (Num a, Enum a) => [[a]]
 stirling1 = [1] : zipWith f [0..] stirling1
   where
     f n xs = 0 : zipWith (\x1 x -> x1 + n * x) xs (tail xs ++ [0])
@@ -53,7 +75,7 @@ stirling1 = [1] : zipWith f [0..] stirling1
 -- > [[1],[0,1],[0,1,1],[0,1,3,1],[0,1,7,6,1]]
 --
 -- One could also consider 'Math.Combinat.Numbers.stirling2nd' to compute stand-alone values.
-stirling2 :: [[Integer]]
+stirling2 :: (Num a, Enum a) => [[a]]
 stirling2 = [1] : map f stirling2
   where
     f xs = 0 : zipWith3 (\k x1 x -> x1 + k * x) [1..] xs (tail xs ++ [0])
@@ -63,7 +85,7 @@ stirling2 = [1] : map f stirling2
 -- > > take 5 (map (take 5) eulerian1)
 -- > [[],[1],[1,1],[1,4,1],[1,11,11,1]]
 --
-eulerian1 :: [[Integer]]
+eulerian1 :: (Num a, Enum a) => [[a]]
 eulerian1 = [] : zipWith f [1..] eulerian1
   where
     f n xs = 1 : zipWith3 (\k x1 x -> (n - k) * x1 + (k + 1) * x) [1..] xs (tail xs ++ [0])
@@ -73,7 +95,7 @@ eulerian1 = [] : zipWith f [1..] eulerian1
 -- > > take 5 (map (take 5) eulerian2)
 -- > [[],[1],[1,2],[1,8,6],[1,22,58,24]]
 --
-eulerian2 :: [[Integer]]
+eulerian2 :: (Num a, Enum a) => [[a]]
 eulerian2 = [] : zipWith f [1..] eulerian2
   where
     f n xs = 1 : zipWith3 (\k x1 x -> (2 * n - k - 1) * x1 + (k + 1) * x) [1..] xs (tail xs ++ [0])
@@ -86,7 +108,7 @@ eulerian2 = [] : zipWith f [1..] eulerian2
 -- > [1 % 1,(-1) % 2,1 % 6,0 % 1,(-1) % 30]
 --
 -- One could also consider 'Math.Combinat.Numbers.bernoulli' to compute stand-alone values.
-bernoulli :: [Rational]
+bernoulli :: Integral a => [Ratio a]
 bernoulli = map f stirling2
   where
     f = sum . zipWith4 (\sgn denom fact stir -> sgn * fact * stir % denom) (cycle [1, -1]) [1..] factorial

--- a/Math/NumberTheory/Recurrencies/Bilinear.hs
+++ b/Math/NumberTheory/Recurrencies/Bilinear.hs
@@ -166,6 +166,6 @@ zipIndexedListWithTail f n as a = case as of
   (x : xs) -> go n x xs
   where
     go m y ys = case ys of
-      []       -> [f m y a]
-      (z : zs) -> f m y z : go (succ m) z zs
+      []       -> let v = f m y a in v `seq` [v]
+      (z : zs) -> let v = f m y z in v `seq` (v : go (succ m) z zs)
 {-# INLINE zipIndexedListWithTail #-}

--- a/Math/NumberTheory/Recurrencies/Bilinear.hs
+++ b/Math/NumberTheory/Recurrencies/Bilinear.hs
@@ -59,10 +59,15 @@ factorial = scanl (*) 1 [1..]
 {-# SPECIALIZE factorial :: [Integer] #-}
 {-# SPECIALIZE factorial :: [Natural] #-}
 
--- | Infinite zero-based table of binomial coefficients: @binomial !! n !! k == n! \/ k! \/ (n - k)!@.
+-- | Infinite zero-based table of binomial coefficients (also known as Pascal triangle):
+-- @binomial !! n !! k == n! \/ k! \/ (n - k)!@.
 --
 -- > > take 5 (map (take 5) binomial)
 -- > [[1],[1,1],[1,2,1],[1,3,3,1],[1,4,6,4,1]]
+--
+-- Complexity: @binomial !! n !! k@ is O(n) bits long, its computation
+-- takes O(k n) time and forces thunks @binomial !! n !! i@ for @0 <= i <= k@.
+-- Use the symmetry of Pascal triangle @binomial !! n !! k == binomial !! n !! (n - k)@ to speed up computations.
 --
 -- One could also consider 'Math.Combinat.Numbers.binomial' to compute stand-alone values.
 binomial :: Integral a => [[a]]
@@ -74,19 +79,13 @@ binomial = map f [0..]
 {-# SPECIALIZE binomial :: [[Integer]] #-}
 {-# SPECIALIZE binomial :: [[Natural]] #-}
 
--- binomial_ :: Num a => [[a]]
--- binomial_ = map f [0..]
---   where
---     f n = go
--- (n k) = n! / k! / (n - k)! = n! / (k - 1)! / (n - k + 1)! * (n - k + 1) / k = (n k-1) * (n - k + 1) / k
---
--- {-# SPECIALIZE binomial_ :: [[Integer]] #-}
--- {-# SPECIALIZE binomial_ :: [[Natural]] #-}
-
 -- | Infinite zero-based table of <https://en.wikipedia.org/wiki/Stirling_numbers_of_the_first_kind Stirling numbers of the first kind>.
 --
 -- > > take 5 (map (take 5) stirling1)
 -- > [[1],[0,1],[0,1,1],[0,2,3,1],[0,6,11,6,1]]
+--
+-- Complexity: @stirling1 !! n !! k@ is O(n ln n) bits long, its computation
+-- takes O(k n^2 ln n) time and forces thunks @stirling1 !! i !! j@ for @0 <= i <= n@ and @max(0, k - n + i) <= j <= k@.
 --
 -- One could also consider 'Math.Combinat.Numbers.unsignedStirling1st' to compute stand-alone values.
 stirling1 :: (Num a, Enum a) => [[a]]
@@ -103,6 +102,9 @@ stirling1 = scanl f [1] [0..]
 -- > > take 5 (map (take 5) stirling2)
 -- > [[1],[0,1],[0,1,1],[0,1,3,1],[0,1,7,6,1]]
 --
+-- Complexity: @stirling2 !! n !! k@ is O(n ln n) bits long, its computation
+-- takes O(k n^2 ln n) time and forces thunks @stirling2 !! i !! j@ for @0 <= i <= n@ and @max(0, k - n + i) <= j <= k@.
+--
 -- One could also consider 'Math.Combinat.Numbers.stirling2nd' to compute stand-alone values.
 stirling2 :: (Num a, Enum a) => [[a]]
 stirling2 = iterate f [1]
@@ -118,6 +120,9 @@ stirling2 = iterate f [1]
 -- > > take 5 (map (take 5) eulerian1)
 -- > [[],[1],[1,1],[1,4,1],[1,11,11,1]]
 --
+-- Complexity: @eulerian1 !! n !! k@ is O(n ln n) bits long, its computation
+-- takes O(k n^2 ln n) time and forces thunks @eulerian1 !! i !! j@ for @0 <= i <= n@ and @max(0, k - n + i) <= j <= k@.
+--
 eulerian1 :: (Num a, Enum a) => [[a]]
 eulerian1 = scanl f [] [1..]
   where
@@ -131,6 +136,9 @@ eulerian1 = scanl f [] [1..]
 --
 -- > > take 5 (map (take 5) eulerian2)
 -- > [[],[1],[1,2],[1,8,6],[1,22,58,24]]
+--
+-- Complexity: @eulerian2 !! n !! k@ is O(n ln n) bits long, its computation
+-- takes O(k n^2 ln n) time and forces thunks @eulerian2 !! i !! j@ for @0 <= i <= n@ and @max(0, k - n + i) <= j <= k@.
 --
 eulerian2 :: (Num a, Enum a) => [[a]]
 eulerian2 = scanl f [] [1..]
@@ -147,6 +155,9 @@ eulerian2 = scanl f [] [1..]
 --
 -- > > take 5 bernoulli
 -- > [1 % 1,(-1) % 2,1 % 6,0 % 1,(-1) % 30]
+--
+-- Complexity: @bernoulli !! n@ is O(n ln n) bits long, its computation
+-- takes O(n^3 ln n) time and forces thunks @stirling2 !! i !! j@ for @0 <= i <= n@ and @0 <= j <= i@.
 --
 -- One could also consider 'Math.Combinat.Numbers.bernoulli' to compute stand-alone values.
 bernoulli :: Integral a => [Ratio a]
@@ -167,6 +178,6 @@ zipIndexedListWithTail f n as a = case as of
   (x : xs) -> go n x xs
   where
     go m y ys = case ys of
-      []       -> let v = f m y a in v `seq` [v]
-      (z : zs) -> let v = f m y z in v `seq` (v : go (succ m) z zs)
+      []       -> let v = f m y a in [v]
+      (z : zs) -> let v = f m y z in (v : go (succ m) z zs)
 {-# INLINE zipIndexedListWithTail #-}

--- a/Math/NumberTheory/Recurrencies/Bilinear.hs
+++ b/Math/NumberTheory/Recurrencies/Bilinear.hs
@@ -38,6 +38,7 @@ module Math.NumberTheory.Recurrencies.Bilinear
   ( binomial
   , stirling1
   , stirling2
+  , lah
   , eulerian1
   , eulerian2
   , bernoulli
@@ -114,6 +115,24 @@ stirling2 = iterate f [1]
 {-# SPECIALIZE stirling2 :: [[Word]]    #-}
 {-# SPECIALIZE stirling2 :: [[Integer]] #-}
 {-# SPECIALIZE stirling2 :: [[Natural]] #-}
+
+-- | Infinite one-based table of <https://en.wikipedia.org/wiki/Lah_number Lah numbers>.
+-- @lah !! n !! k@ equals to lah(n + 1, k + 1).
+--
+-- > > take 5 (map (take 5) lah)
+-- > [[1],[2,1],[6,6,1],[24,36,12,1],[120,240,120,20,1]]
+--
+-- Complexity: @lah !! n !! k@ is O(n ln n) bits long, its computation
+-- takes O(k n ln n) time and forces thunks @lah !! n !! i@ for @0 <= i <= k@.
+lah :: Integral a => [[a]]
+-- Implementation was derived from code by https://github.com/grandpascorpion
+lah = zipWith f (tail factorial) [1..]
+  where
+    f nf n = scanl (\x k -> x * (n - k) `div` (k * (k + 1))) nf [1..n-1]
+{-# SPECIALIZE lah :: [[Int]]     #-}
+{-# SPECIALIZE lah :: [[Word]]    #-}
+{-# SPECIALIZE lah :: [[Integer]] #-}
+{-# SPECIALIZE lah :: [[Natural]] #-}
 
 -- | Infinite zero-based table of <https://en.wikipedia.org/wiki/Eulerian_number Eulerian numbers of the first kind>.
 --

--- a/Math/NumberTheory/Recurrencies/Bilinear.hs
+++ b/Math/NumberTheory/Recurrencies/Bilinear.hs
@@ -6,6 +6,9 @@
 -- Stability:   Provisional
 -- Portability: Non-portable (GHC extensions)
 --
+-- Bilinear recurrent sequences and Bernoulli numbers,
+-- roughly covering Ch. 5-6 of /Concrete Mathematics/
+-- by R. L. Graham, D. E. Knuth and O. Patashnik.
 
 module Math.NumberTheory.Recurrencies.Bilinear
   ( binomial
@@ -22,31 +25,67 @@ import Data.Ratio
 factorial :: [Integer]
 factorial = 1 : zipWith (*) [1..] factorial
 
+-- | Infinite table of binomial coefficients: @binomial !! n !! k == n! \/ k! \/ (n - k)!@.
+--
+-- > > take 5 (map (take 5) binomial)
+-- > [[1],[1,1],[1,2,1],[1,3,3,1],[1,4,6,4,1]]
+--
+-- One could also consider 'Math.Combinat.Numbers.binomial' to compute stand-alone values.
 binomial :: [[Integer]]
 binomial = [1] : map f binomial
   where
     f xs = 1 : zipWith (+) xs (tail xs ++ [0])
 
+-- | Infinite table of <https://en.wikipedia.org/wiki/Stirling_numbers_of_the_first_kind Stirling numbers of the first kind>.
+--
+-- > > take 5 (map (take 5) stirling1)
+-- > [[1],[0,1],[0,1,1],[0,2,3,1],[0,6,11,6,1]]
+--
+-- One could also consider 'Math.Combinat.Numbers.unsignedStirling1st' to compute stand-alone values.
 stirling1 :: [[Integer]]
 stirling1 = [1] : zipWith f [0..] stirling1
   where
     f n xs = 0 : zipWith (\x1 x -> x1 + n * x) xs (tail xs ++ [0])
 
+-- | Infinite table of <https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind Stirling numbers of the second kind>.
+--
+-- > > take 5 (map (take 5) stirling2)
+-- > [[1],[0,1],[0,1,1],[0,1,3,1],[0,1,7,6,1]]
+--
+-- One could also consider 'Math.Combinat.Numbers.stirling2nd' to compute stand-alone values.
 stirling2 :: [[Integer]]
 stirling2 = [1] : map f stirling2
   where
     f xs = 0 : zipWith3 (\k x1 x -> x1 + k * x) [1..] xs (tail xs ++ [0])
 
+-- | Infinite table of <https://en.wikipedia.org/wiki/Eulerian_number Eulerian numbers of the first kind>.
+--
+-- > > take 5 (map (take 5) eulerian1)
+-- > [[],[1],[1,1],[1,4,1],[1,11,11,1]]
+--
 eulerian1 :: [[Integer]]
 eulerian1 = [] : zipWith f [1..] eulerian1
   where
     f n xs = 1 : zipWith3 (\k x1 x -> (n - k) * x1 + (k + 1) * x) [1..] xs (tail xs ++ [0])
 
+-- | Infinite table of <https://en.wikipedia.org/wiki/Eulerian_number#Eulerian_numbers_of_the_second_kind Eulerian numbers of the second kind>.
+--
+-- > > take 5 (map (take 5) eulerian2)
+-- > [[],[1],[1,2],[1,8,6],[1,22,58,24]]
+--
 eulerian2 :: [[Integer]]
 eulerian2 = [] : zipWith f [1..] eulerian2
   where
     f n xs = 1 : zipWith3 (\k x1 x -> (2 * n - k - 1) * x1 + (k + 1) * x) [1..] xs (tail xs ++ [0])
 
+-- | Infinite sequence of <https://en.wikipedia.org/wiki/Bernoulli_number Bernoulli numbers>,
+-- computed via <https://en.wikipedia.org/wiki/Bernoulli_number#Connection_with_Stirling_numbers_of_the_second_kind connection>
+-- with 'stirling2'.
+--
+-- > > take 5 bernoulli
+-- > [1 % 1,(-1) % 2,1 % 6,0 % 1,(-1) % 30]
+--
+-- One could also consider 'Math.Combinat.Numbers.bernoulli' to compute stand-alone values.
 bernoulli :: [Rational]
 bernoulli = map f stirling2
   where

--- a/Math/NumberTheory/Recurrencies/Bilinear.hs
+++ b/Math/NumberTheory/Recurrencies/Bilinear.hs
@@ -17,20 +17,22 @@
 -- > > :set +s
 -- > > binomial !! 1000 !! 1000 :: Integer
 -- > 1
--- > (0.10 secs, 153,437,432 bytes)
+-- > (0.01 secs, 1,385,512 bytes)
 -- > > binomial !! 1000 !! 1000 :: Integer
 -- > 1
--- > (0.10 secs, 153,432,856 bytes)
+-- > (0.01 secs, 1,381,616 bytes)
 --
 -- against
 --
 -- > > let binomial' = binomial :: [[Integer]]
 -- > > binomial' !! 1000 !! 1000 :: Integer
 -- > 1
--- > (0.10 secs, 152,401,808 bytes)
+-- > (0.01 secs, 1,381,696 bytes)
 -- > > binomial' !! 1000 !! 1000 :: Integer
 -- > 1
--- > (0.01 secs, 1,551,416 bytes)
+-- > (0.01 secs, 391,152 bytes)
+
+{-# LANGUAGE CPP #-}
 
 module Math.NumberTheory.Recurrencies.Bilinear
   ( binomial
@@ -43,9 +45,19 @@ module Math.NumberTheory.Recurrencies.Bilinear
 
 import Data.List
 import Data.Ratio
+import Numeric.Natural
+
+#if MIN_VERSION_base(4,8,0)
+#else
+import Data.Word
+#endif
 
 factorial :: (Num a, Enum a) => [a]
-factorial = 1 : zipWith (*) [1..] factorial
+factorial = scanl (*) 1 [1..]
+{-# SPECIALIZE factorial :: [Int]     #-}
+{-# SPECIALIZE factorial :: [Word]    #-}
+{-# SPECIALIZE factorial :: [Integer] #-}
+{-# SPECIALIZE factorial :: [Natural] #-}
 
 -- | Infinite zero-based table of binomial coefficients: @binomial !! n !! k == n! \/ k! \/ (n - k)!@.
 --
@@ -53,10 +65,23 @@ factorial = 1 : zipWith (*) [1..] factorial
 -- > [[1],[1,1],[1,2,1],[1,3,3,1],[1,4,6,4,1]]
 --
 -- One could also consider 'Math.Combinat.Numbers.binomial' to compute stand-alone values.
-binomial :: Num a => [[a]]
-binomial = [1] : map f binomial
+binomial :: Integral a => [[a]]
+binomial = map f [0..]
   where
-    f xs = 1 : zipWith (+) xs (tail xs ++ [0])
+    f n = scanl (\x k -> x * (n - k + 1) `div` k) 1 [1..n]
+{-# SPECIALIZE binomial :: [[Int]]     #-}
+{-# SPECIALIZE binomial :: [[Word]]    #-}
+{-# SPECIALIZE binomial :: [[Integer]] #-}
+{-# SPECIALIZE binomial :: [[Natural]] #-}
+
+-- binomial_ :: Num a => [[a]]
+-- binomial_ = map f [0..]
+--   where
+--     f n = go
+-- (n k) = n! / k! / (n - k)! = n! / (k - 1)! / (n - k + 1)! * (n - k + 1) / k = (n k-1) * (n - k + 1) / k
+--
+-- {-# SPECIALIZE binomial_ :: [[Integer]] #-}
+-- {-# SPECIALIZE binomial_ :: [[Natural]] #-}
 
 -- | Infinite zero-based table of <https://en.wikipedia.org/wiki/Stirling_numbers_of_the_first_kind Stirling numbers of the first kind>.
 --
@@ -65,9 +90,13 @@ binomial = [1] : map f binomial
 --
 -- One could also consider 'Math.Combinat.Numbers.unsignedStirling1st' to compute stand-alone values.
 stirling1 :: (Num a, Enum a) => [[a]]
-stirling1 = [1] : zipWith f [0..] stirling1
+stirling1 = scanl f [1] [0..]
   where
-    f n xs = 0 : zipWith (\x1 x -> x1 + n * x) xs (tail xs ++ [0])
+    f xs n = 0 : zipIndexedListWithTail (\_ x y -> x + n * y) 1 xs 0
+{-# SPECIALIZE stirling1 :: [[Int]]     #-}
+{-# SPECIALIZE stirling1 :: [[Word]]    #-}
+{-# SPECIALIZE stirling1 :: [[Integer]] #-}
+{-# SPECIALIZE stirling1 :: [[Natural]] #-}
 
 -- | Infinite zero-based table of <https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind Stirling numbers of the second kind>.
 --
@@ -76,9 +105,13 @@ stirling1 = [1] : zipWith f [0..] stirling1
 --
 -- One could also consider 'Math.Combinat.Numbers.stirling2nd' to compute stand-alone values.
 stirling2 :: (Num a, Enum a) => [[a]]
-stirling2 = [1] : map f stirling2
+stirling2 = iterate f [1]
   where
-    f xs = 0 : zipWith3 (\k x1 x -> x1 + k * x) [1..] xs (tail xs ++ [0])
+    f xs = 0 : zipIndexedListWithTail (\k x y -> x + k * y) 1 xs 0
+{-# SPECIALIZE stirling2 :: [[Int]]     #-}
+{-# SPECIALIZE stirling2 :: [[Word]]    #-}
+{-# SPECIALIZE stirling2 :: [[Integer]] #-}
+{-# SPECIALIZE stirling2 :: [[Natural]] #-}
 
 -- | Infinite zero-based table of <https://en.wikipedia.org/wiki/Eulerian_number Eulerian numbers of the first kind>.
 --
@@ -86,9 +119,13 @@ stirling2 = [1] : map f stirling2
 -- > [[],[1],[1,1],[1,4,1],[1,11,11,1]]
 --
 eulerian1 :: (Num a, Enum a) => [[a]]
-eulerian1 = [] : zipWith f [1..] eulerian1
+eulerian1 = scanl f [] [1..]
   where
-    f n xs = 1 : zipWith3 (\k x1 x -> (n - k) * x1 + (k + 1) * x) [1..] xs (tail xs ++ [0])
+    f xs n = 1 : zipIndexedListWithTail (\k x y -> (n - k) * x + (k + 1) * y) 1 xs 0
+{-# SPECIALIZE eulerian1 :: [[Int]]     #-}
+{-# SPECIALIZE eulerian1 :: [[Word]]    #-}
+{-# SPECIALIZE eulerian1 :: [[Integer]] #-}
+{-# SPECIALIZE eulerian1 :: [[Natural]] #-}
 
 -- | Infinite zero-based table of <https://en.wikipedia.org/wiki/Eulerian_number#Eulerian_numbers_of_the_second_kind Eulerian numbers of the second kind>.
 --
@@ -96,9 +133,13 @@ eulerian1 = [] : zipWith f [1..] eulerian1
 -- > [[],[1],[1,2],[1,8,6],[1,22,58,24]]
 --
 eulerian2 :: (Num a, Enum a) => [[a]]
-eulerian2 = [] : zipWith f [1..] eulerian2
+eulerian2 = scanl f [] [1..]
   where
-    f n xs = 1 : zipWith3 (\k x1 x -> (2 * n - k - 1) * x1 + (k + 1) * x) [1..] xs (tail xs ++ [0])
+    f xs n = 1 : zipIndexedListWithTail (\k x y -> (2 * n - k - 1) * x + (k + 1) * y) 1 xs 0
+{-# SPECIALIZE eulerian2 :: [[Int]]     #-}
+{-# SPECIALIZE eulerian2 :: [[Word]]    #-}
+{-# SPECIALIZE eulerian2 :: [[Integer]] #-}
+{-# SPECIALIZE eulerian2 :: [[Natural]] #-}
 
 -- | Infinite zero-based sequence of <https://en.wikipedia.org/wiki/Bernoulli_number Bernoulli numbers>,
 -- computed via <https://en.wikipedia.org/wiki/Bernoulli_number#Connection_with_Stirling_numbers_of_the_second_kind connection>
@@ -112,3 +153,19 @@ bernoulli :: Integral a => [Ratio a]
 bernoulli = map f stirling2
   where
     f = sum . zipWith4 (\sgn denom fact stir -> sgn * fact * stir % denom) (cycle [1, -1]) [1..] factorial
+{-# SPECIALIZE bernoulli :: [Rational] #-}
+
+-------------------------------------------------------------------------------
+-- Utils
+
+-- zipIndexedListWithTail f n as a == zipWith3 f [n..] as (tail as ++ [a])
+-- but inlines much better and avoids checks for distinct sizes of lists.
+zipIndexedListWithTail :: Enum b => (b -> a -> a -> b) -> b -> [a] -> a -> [b]
+zipIndexedListWithTail f n as a = case as of
+  []       -> []
+  (x : xs) -> go n x xs
+  where
+    go m y ys = case ys of
+      []       -> [f m y a]
+      (z : zs) -> f m y z : go (succ m) z zs
+{-# INLINE zipIndexedListWithTail #-}

--- a/Math/NumberTheory/Recurrencies/Linear.hs
+++ b/Math/NumberTheory/Recurrencies/Linear.hs
@@ -6,7 +6,8 @@
 -- Stability:   Provisional
 -- Portability: Non-portable (GHC extensions)
 --
--- Efficient calculation of Lucas sequences.
+-- Efficient calculation of linear recurrent sequences, including Fibonacci and Lucas sequences.
+
 {-# LANGUAGE CPP #-}
 module Math.NumberTheory.Recurrencies.Linear
   ( fibonacci

--- a/Math/NumberTheory/Recurrencies/Linear.hs
+++ b/Math/NumberTheory/Recurrencies/Linear.hs
@@ -1,5 +1,5 @@
 -- |
--- Module:      Math.NumberTheory.Lucas
+-- Module:      Math.NumberTheory.Recurrencies.Linear
 -- Copyright:   (c) 2011 Daniel Fischer
 -- Licence:     MIT
 -- Maintainer:  Daniel Fischer <daniel.is.fischer@googlemail.com>
@@ -8,7 +8,7 @@
 --
 -- Efficient calculation of Lucas sequences.
 {-# LANGUAGE CPP #-}
-module Math.NumberTheory.Lucas
+module Math.NumberTheory.Recurrencies.Linear
   ( fibonacci
   , fibonacciPair
   , lucas

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -57,6 +57,7 @@ library
                           Math.NumberTheory.Moduli
                           Math.NumberTheory.MoebiusInversion
                           Math.NumberTheory.MoebiusInversion.Int
+                          Math.NumberTheory.Recurrencies.Bilinear
                           Math.NumberTheory.Recurrencies.Linear
                           Math.NumberTheory.GaussianIntegers
                           Math.NumberTheory.GCD

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -109,8 +109,11 @@ benchmark criterion
                     , criterion
                     , containers
                     , random
+  if impl(ghc < 7.10)
+    build-depends     : nats >= 1 && <1.2
   other-modules:    Math.NumberTheory.ArithmeticFunctionsBench
                   , Math.NumberTheory.PowersBench
+                  , Math.NumberTheory.RecurrenciesBench
   hs-source-dirs:   benchmark
   main-is:          Bench.hs
   type:             exitcode-stdio-1.0

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -57,7 +57,7 @@ library
                           Math.NumberTheory.Moduli
                           Math.NumberTheory.MoebiusInversion
                           Math.NumberTheory.MoebiusInversion.Int
-                          Math.NumberTheory.Lucas
+                          Math.NumberTheory.Recurrencies.Linear
                           Math.NumberTheory.GaussianIntegers
                           Math.NumberTheory.GCD
                           Math.NumberTheory.GCD.LowLevel
@@ -140,7 +140,7 @@ test-suite spec
                   , Math.NumberTheory.GCDTests
                   , Math.NumberTheory.GCD.LowLevelTests
                   , Math.NumberTheory.LogarithmsTests
-                  , Math.NumberTheory.LucasTests
+                  , Math.NumberTheory.Recurrencies.LinearTests
                   , Math.NumberTheory.ModuliTests
                   , Math.NumberTheory.Powers.CubesTests
                   , Math.NumberTheory.MoebiusInversionTests

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -142,6 +142,7 @@ test-suite spec
                   , Math.NumberTheory.GCD.LowLevelTests
                   , Math.NumberTheory.LogarithmsTests
                   , Math.NumberTheory.Recurrencies.LinearTests
+                  , Math.NumberTheory.Recurrencies.BilinearTests
                   , Math.NumberTheory.ModuliTests
                   , Math.NumberTheory.Powers.CubesTests
                   , Math.NumberTheory.MoebiusInversionTests

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -6,8 +6,10 @@ import Criterion.Main
 
 import Math.NumberTheory.ArithmeticFunctionsBench as ArithmeticFunctions
 import Math.NumberTheory.PowersBench as Powers
+import Math.NumberTheory.RecurrenciesBench as Recurrencies
 
 main = defaultMain
   [ ArithmeticFunctions.benchSuite
   , Powers.benchSuite
+  , Recurrencies.benchSuite
   ]

--- a/benchmark/Math/NumberTheory/RecurrenciesBench.hs
+++ b/benchmark/Math/NumberTheory/RecurrenciesBench.hs
@@ -1,0 +1,17 @@
+module Math.NumberTheory.RecurrenciesBench
+  ( benchSuite
+  ) where
+
+import Criterion.Main
+import Numeric.Natural
+import System.Random
+
+import Math.NumberTheory.Recurrencies.Bilinear
+
+benchSuite = bgroup "Bilinears"
+  [ bench "binomial"  $ nf (\n -> sum (take n $ map sum binomial) :: Integer) 100
+  , bench "stirling1" $ nf (\n -> sum (take n $ map sum stirling1) :: Integer) 100
+  , bench "stirling2" $ nf (\n -> sum (take n $ map sum stirling2) :: Integer) 100
+  , bench "eulerian1" $ nf (\n -> sum (take n $ map sum eulerian1) :: Integer) 100
+  , bench "eulerian2" $ nf (\n -> sum (take n $ map sum eulerian2) :: Integer) 100
+  ]

--- a/benchmark/Math/NumberTheory/RecurrenciesBench.hs
+++ b/benchmark/Math/NumberTheory/RecurrenciesBench.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RankNTypes #-}
+
 module Math.NumberTheory.RecurrenciesBench
   ( benchSuite
   ) where
@@ -8,10 +10,21 @@ import System.Random
 
 import Math.NumberTheory.Recurrencies.Bilinear
 
-benchSuite = bgroup "Bilinears"
-  [ bench "binomial"  $ nf (\n -> sum (take n $ map sum binomial) :: Integer) 100
-  , bench "stirling1" $ nf (\n -> sum (take n $ map sum stirling1) :: Integer) 100
-  , bench "stirling2" $ nf (\n -> sum (take n $ map sum stirling2) :: Integer) 100
-  , bench "eulerian1" $ nf (\n -> sum (take n $ map sum eulerian1) :: Integer) 100
-  , bench "eulerian2" $ nf (\n -> sum (take n $ map sum eulerian2) :: Integer) 100
+benchTriangle :: String -> (forall a. (Integral a) => [[a]]) -> Int -> Benchmark
+benchTriangle name triangle n = bgroup name
+  [ benchAt (10 * n)  (1 * n)
+  , benchAt (10 * n)  (2 * n)
+  , benchAt (10 * n)  (5 * n)
+  , benchAt (10 * n)  (9 * n)
+  ]
+  where
+    benchAt i j = bench ("!! " ++ show i ++ " !! " ++ show j)
+                $ nf (\(x, y) -> triangle !! x !! y :: Integer) (i, j)
+
+benchSuite = bgroup "Bilinear"
+  [ benchTriangle "binomial"  binomial 1000
+  , benchTriangle "stirling1" stirling1 100
+  , benchTriangle "stirling2" stirling2 100
+  , benchTriangle "eulerian1" eulerian1 100
+  , benchTriangle "eulerian2" eulerian2 100
   ]

--- a/test-suite/Math/NumberTheory/Recurrencies/BilinearTests.hs
+++ b/test-suite/Math/NumberTheory/Recurrencies/BilinearTests.hs
@@ -1,0 +1,173 @@
+-- |
+-- Module:      Math.NumberTheory.Recurrencies.BilinearTests
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.Recurrencies.Bilinear
+--
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.Recurrencies.BilinearTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.Ratio
+
+import Math.NumberTheory.Recurrencies.Bilinear
+import Math.NumberTheory.TestUtils
+
+binomialProperty1 :: NonNegative Int -> Bool
+binomialProperty1 (NonNegative i) = length (binomial !! i) == i + 1
+
+binomialProperty2 :: NonNegative Int -> Bool
+binomialProperty2 (NonNegative i) = binomial !! i !! 0 == 1
+
+binomialProperty3 :: NonNegative Int -> Bool
+binomialProperty3 (NonNegative i) = binomial !! i !! i == 1
+
+binomialProperty4 :: Positive Int -> Positive Int -> Bool
+binomialProperty4 (Positive i) (Positive j)
+  =  j >= i
+  || binomial !! i !! j
+  == binomial !! (i - 1) !! (j - 1)
+  +  binomial !! (i - 1) !! j
+
+stirling1Property1 :: NonNegative Int -> Bool
+stirling1Property1 (NonNegative i) = length (stirling1 !! i) == i + 1
+
+stirling1Property2 :: NonNegative Int -> Bool
+stirling1Property2 (NonNegative i)
+  =  stirling1 !! i !! 0
+  == if i == 0 then 1 else 0
+
+stirling1Property3 :: NonNegative Int -> Bool
+stirling1Property3 (NonNegative i) = stirling1 !! i !! i == 1
+
+stirling1Property4 :: Positive Int -> Positive Int -> Bool
+stirling1Property4 (Positive i) (Positive j)
+  =  j >= i
+  || stirling1 !! i !! j
+  == stirling1 !! (i - 1) !! (j - 1)
+  +  (toInteger i - 1) * stirling1 !! (i - 1) !! j
+
+stirling2Property1 :: NonNegative Int -> Bool
+stirling2Property1 (NonNegative i) = length (stirling2 !! i) == i + 1
+
+stirling2Property2 :: NonNegative Int -> Bool
+stirling2Property2 (NonNegative i)
+  =  stirling2 !! i !! 0
+  == if i == 0 then 1 else 0
+
+stirling2Property3 :: NonNegative Int -> Bool
+stirling2Property3 (NonNegative i) = stirling2 !! i !! i == 1
+
+stirling2Property4 :: Positive Int -> Positive Int -> Bool
+stirling2Property4 (Positive i) (Positive j)
+  =  j >= i
+  || stirling2 !! i !! j
+  == stirling2 !! (i - 1) !! (j - 1)
+  +  toInteger j * stirling2 !! (i - 1) !! j
+
+eulerian1Property1 :: NonNegative Int -> Bool
+eulerian1Property1 (NonNegative i) = length (eulerian1 !! i) == i
+
+eulerian1Property2 :: Positive Int -> Bool
+eulerian1Property2 (Positive i) = eulerian1 !! i !! 0 == 1
+
+eulerian1Property3 :: Positive Int -> Bool
+eulerian1Property3 (Positive i) = eulerian1 !! i !! (i - 1) == 1
+
+eulerian1Property4 :: Positive Int -> Positive Int -> Bool
+eulerian1Property4 (Positive i) (Positive j)
+  =  j >= i - 1
+  || eulerian1 !! i !! j
+  == (toInteger $ i - j) * eulerian1 !! (i - 1) !! (j - 1)
+  +  (toInteger   j + 1) * eulerian1 !! (i - 1) !! j
+
+eulerian2Property1 :: NonNegative Int -> Bool
+eulerian2Property1 (NonNegative i) = length (eulerian2 !! i) == i
+
+eulerian2Property2 :: Positive Int -> Bool
+eulerian2Property2 (Positive i)
+  =  eulerian2 !! i !! 0 == 1
+
+eulerian2Property3 :: Positive Int -> Bool
+eulerian2Property3 (Positive i)
+  =  eulerian2 !! i !! (i - 1)
+  == product [1 .. toInteger i]
+
+eulerian2Property4 :: Positive Int -> Positive Int -> Bool
+eulerian2Property4 (Positive i) (Positive j)
+  =  j >= i - 1
+  || eulerian2 !! i !! j
+  == (toInteger $ 2 * i - j - 1) * eulerian2 !! (i - 1) !! (j - 1)
+  +  (toInteger j + 1) * eulerian2 !! (i - 1) !! j
+
+bernoulliSpecialCase1 :: Assertion
+bernoulliSpecialCase1 = assertEqual "B_0 = 1" (bernoulli !! 0) 1
+
+bernoulliSpecialCase2 :: Assertion
+bernoulliSpecialCase2 = assertEqual "B_1 = -1/2" (bernoulli !! 1) (- 1 % 2)
+
+bernoulliProperty1 :: NonNegative Int -> Bool
+bernoulliProperty1 (NonNegative m)
+  = case signum (bernoulli !! m) of
+    1  -> m == 0 || m `mod` 4 == 2
+    0  -> m /= 1 && odd m
+    -1 -> m == 1 || (m /= 0 && m `mod` 4 == 0)
+    _  -> False
+
+bernoulliProperty2 :: NonNegative Int -> Bool
+bernoulliProperty2 (NonNegative m)
+  =  bernoulli !! m
+  == (if m == 0 then 1 else 0)
+  -  sum [ bernoulli !! k
+         * (binomial !! m !! k % (toInteger $ m - k + 1))
+         | k <- [0 .. m - 1]
+         ]
+
+testSuite :: TestTree
+testSuite = testGroup "Bilinear"
+  [ testGroup "binomial"
+    [ testSmallAndQuick "shape"      binomialProperty1
+    , testSmallAndQuick "left side"  binomialProperty2
+    , testSmallAndQuick "right side" binomialProperty3
+    , testSmallAndQuick "recurrency" binomialProperty4
+    ]
+  , testGroup "stirling1"
+    [ testSmallAndQuick "shape"      stirling1Property1
+    , testSmallAndQuick "left side"  stirling1Property2
+    , testSmallAndQuick "right side" stirling1Property3
+    , testSmallAndQuick "recurrency" stirling1Property4
+    ]
+  , testGroup "stirling2"
+    [ testSmallAndQuick "shape"      stirling2Property1
+    , testSmallAndQuick "left side"  stirling2Property2
+    , testSmallAndQuick "right side" stirling2Property3
+    , testSmallAndQuick "recurrency" stirling2Property4
+    ]
+  , testGroup "eulerian1"
+    [ testSmallAndQuick "shape"      eulerian1Property1
+    , testSmallAndQuick "left side"  eulerian1Property2
+    , testSmallAndQuick "right side" eulerian1Property3
+    , testSmallAndQuick "recurrency" eulerian1Property4
+    ]
+  , testGroup "eulerian2"
+    [ testSmallAndQuick "shape"      eulerian2Property1
+    , testSmallAndQuick "left side"  eulerian2Property2
+    , testSmallAndQuick "right side" eulerian2Property3
+    , testSmallAndQuick "recurrency" eulerian2Property4
+    ]
+  , testGroup "bernoulli"
+    [ testCase "B_0"                           bernoulliSpecialCase1
+    , testCase "B_1"                           bernoulliSpecialCase2
+    , testSmallAndQuick "sign"                 bernoulliProperty1
+    , testSmallAndQuick "recursive definition" bernoulliProperty2
+    ]
+  ]

--- a/test-suite/Math/NumberTheory/Recurrencies/BilinearTests.hs
+++ b/test-suite/Math/NumberTheory/Recurrencies/BilinearTests.hs
@@ -74,6 +74,23 @@ stirling2Property4 (Positive i) (Positive j)
   == stirling2 !! (i - 1) !! (j - 1)
   +  toInteger j * stirling2 !! (i - 1) !! j
 
+lahProperty1 :: NonNegative Int -> Bool
+lahProperty1 (NonNegative i) = length (lah !! i) == i + 1
+
+lahProperty2 :: NonNegative Int -> Bool
+lahProperty2 (NonNegative i)
+  =  lah !! i !! 0
+  == product [1 .. i+1]
+
+lahProperty3 :: NonNegative Int -> Bool
+lahProperty3 (NonNegative i) = lah !! i !! i == 1
+
+lahProperty4 :: Positive Int -> Positive Int -> Bool
+lahProperty4 (Positive i) (Positive j)
+  =  j >= i
+  || lah !! i !! j
+  == sum [ stirling1 !! (i + 1) !! k * stirling2 !! k !! (j + 1) | k <- [j + 1 .. i + 1] ]
+
 eulerian1Property1 :: NonNegative Int -> Bool
 eulerian1Property1 (NonNegative i) = length (eulerian1 !! i) == i
 
@@ -151,6 +168,12 @@ testSuite = testGroup "Bilinear"
     , testSmallAndQuick "left side"  stirling2Property2
     , testSmallAndQuick "right side" stirling2Property3
     , testSmallAndQuick "recurrency" stirling2Property4
+    ]
+  , testGroup "lah"
+    [ testSmallAndQuick "shape"         lahProperty1
+    , testSmallAndQuick "left side"     lahProperty2
+    , testSmallAndQuick "right side"    lahProperty3
+    , testSmallAndQuick "zip stirlings" lahProperty4
     ]
   , testGroup "eulerian1"
     [ testSmallAndQuick "shape"      eulerian1Property1

--- a/test-suite/Math/NumberTheory/Recurrencies/LinearTests.hs
+++ b/test-suite/Math/NumberTheory/Recurrencies/LinearTests.hs
@@ -1,25 +1,25 @@
 -- |
--- Module:      Math.NumberTheory.LucasTests
+-- Module:      Math.NumberTheory.Recurrencies.LinearTests
 -- Copyright:   (c) 2016 Andrew Lelechenko
 -- Licence:     MIT
 -- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
 -- Stability:   Provisional
 --
--- Tests for Math.NumberTheory.Lucas
+-- Tests for Math.NumberTheory.Recurrencies.Linear
 --
 
 {-# LANGUAGE CPP       #-}
 
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
-module Math.NumberTheory.LucasTests
+module Math.NumberTheory.Recurrencies.LinearTests
   ( testSuite
   ) where
 
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Math.NumberTheory.Lucas
+import Math.NumberTheory.Recurrencies.Linear
 import Math.NumberTheory.TestUtils
 
 -- | Check that 'fibonacci' matches the definition of Fibonacci sequence.

--- a/test-suite/Math/NumberTheory/Recurrencies/LinearTests.hs
+++ b/test-suite/Math/NumberTheory/Recurrencies/LinearTests.hs
@@ -81,7 +81,7 @@ generalLucasProperty3 :: AnySign Integer -> AnySign Integer -> Bool
 generalLucasProperty3 (AnySign p) (AnySign q) = generalLucas p q 0 == (0, 1, 2, p)
 
 testSuite :: TestTree
-testSuite = testGroup "Lucas"
+testSuite = testGroup "Linear"
   [ testGroup "fibonacci"
     [ testSmallAndQuick "matches definition"  fibonacciProperty1
     , testSmallAndQuick "negative indices"    fibonacciProperty2

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -5,6 +5,7 @@ import qualified Math.NumberTheory.GCD.LowLevelTests as GCDLowLevel
 
 import qualified Math.NumberTheory.LogarithmsTests as Logarithms
 
+import qualified Math.NumberTheory.Recurrencies.BilinearTests as RecurrenciesBilinear
 import qualified Math.NumberTheory.Recurrencies.LinearTests as RecurrenciesLinear
 
 import qualified Math.NumberTheory.ModuliTests as Moduli
@@ -49,6 +50,7 @@ tests = testGroup "All"
     ]
   , testGroup "Recurrencies"
     [ RecurrenciesLinear.testSuite
+    , RecurrenciesBilinear.testSuite
     ]
   , testGroup "Moduli"
     [ Moduli.testSuite

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -5,7 +5,7 @@ import qualified Math.NumberTheory.GCD.LowLevelTests as GCDLowLevel
 
 import qualified Math.NumberTheory.LogarithmsTests as Logarithms
 
-import qualified Math.NumberTheory.LucasTests as Lucas
+import qualified Math.NumberTheory.Recurrencies.LinearTests as RecurrenciesLinear
 
 import qualified Math.NumberTheory.ModuliTests as Moduli
 
@@ -47,8 +47,8 @@ tests = testGroup "All"
   , testGroup "Logarithms"
     [ Logarithms.testSuite
     ]
-  , testGroup "Lucas"
-    [ Lucas.testSuite
+  , testGroup "Recurrencies"
+    [ RecurrenciesLinear.testSuite
     ]
   , testGroup "Moduli"
     [ Moduli.testSuite


### PR DESCRIPTION
`arithmoi` supports linear recurrent sequences such as Fibonacci numbers, Lucas numbers and general sequences of form `a(n+2) = p * a(n+1) + q * a(n)`. Recurrent sequences find many applications in number theory. 

This PR implements a bunch of other classical recurrent sequences, including binomial coefficients, Stirling numbers, Eulerian numbers and Bernoulli numbers, along with tests. There is an option to import this stuff from `combinat` package, but besides several disappointing design choices,`combinat` has no public repo and no issue tracker alive and AFAIK almost no tests. My intention is to avoid such dependencies at all costs.

My personal motivation is to get auxiliaries ready for calculation of the Riemann zeta-function, which is an inevitable component of any mature number-theoretical library. This requires machinery  for binomials, Bernoulli and Stirling numbers.
