### PR TITLE
Drop support of GHC 7.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.6.3 BENCH=disable
-      compiler: "GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4 BENCH=enable
       compiler: "GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}

--- a/Math/NumberTheory/ArithmeticFunctions/Standard.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/Standard.hs
@@ -36,6 +36,7 @@ module Math.NumberTheory.ArithmeticFunctions.Standard
   , expMangoldt, expMangoldtA
   ) where
 
+import Data.Coerce
 import Data.IntSet (IntSet)
 import qualified Data.IntSet as IS
 import Data.Set (Set)
@@ -51,15 +52,6 @@ import Numeric.Natural
 #else
 import Data.Foldable
 import Data.Word
-#endif
-
-#if MIN_VERSION_base(4,7,0)
-import Data.Coerce
-#else
-import Unsafe.Coerce
-
-coerce :: a -> b
-coerce = unsafeCoerce
 #endif
 
 wordToInt :: Word -> Int

--- a/Math/NumberTheory/Logarithms.hs
+++ b/Math/NumberTheory/Logarithms.hs
@@ -9,7 +9,7 @@
 -- Integer Logarithms. For efficiency, the internal representation of 'Integer's
 -- from integer-gmp is used.
 --
-{-# LANGUAGE CPP, MagicHash #-}
+{-# LANGUAGE MagicHash #-}
 module Math.NumberTheory.Logarithms
     ( -- * Integer logarithms with input checks
       integerLogBase
@@ -37,9 +37,6 @@ import GHC.Integer.Logarithms
 
 import Math.NumberTheory.Powers.Integer
 import Math.NumberTheory.Unsafe
-#if __GLASGOW_HASKELL__ < 707
-import Math.NumberTheory.Utils  (isTrue#)
-#endif
 
 -- | Calculate the integer logarithm for an arbitrary base.
 --   The base must be greater than 1, the second argument, the number

--- a/Math/NumberTheory/Powers/Cubes.hs
+++ b/Math/NumberTheory/Powers/Cubes.hs
@@ -31,9 +31,6 @@ import GHC.Integer.GMP.Internals
 import GHC.Integer.Logarithms (integerLog2#)
 
 import Math.NumberTheory.Unsafe
-#if __GLASGOW_HASKELL__ < 707
-import Math.NumberTheory.Utils (isTrue#)
-#endif
 
 -- | Calculate the integer cube root of an integer @n@,
 --   that is the largest integer @r@ such that @r^3 <= n@.

--- a/Math/NumberTheory/Powers/Fourth.hs
+++ b/Math/NumberTheory/Powers/Fourth.hs
@@ -31,9 +31,6 @@ import Data.Array.ST
 import Data.Bits
 
 import Math.NumberTheory.Unsafe
-#if __GLASGOW_HASKELL__ < 707
-import Math.NumberTheory.Utils (isTrue#)
-#endif
 
 -- | Calculate the integer fourth root of a nonnegative number,
 --   that is, the largest integer @r@ with @r^4 <= n@.

--- a/Math/NumberTheory/Powers/General.hs
+++ b/Math/NumberTheory/Powers/General.hs
@@ -34,9 +34,6 @@ import qualified Data.Set as Set
 import Math.NumberTheory.Logarithms (integerLogBase')
 import Math.NumberTheory.Utils  (shiftToOddCount
                                 , splitOff
-#if __GLASGOW_HASKELL__ < 707
-                                , isTrue#
-#endif
                                 )
 import qualified Math.NumberTheory.Powers.Squares as P2
 import qualified Math.NumberTheory.Powers.Cubes as P3

--- a/Math/NumberTheory/Powers/Integer.hs
+++ b/Math/NumberTheory/Powers/Integer.hs
@@ -9,7 +9,8 @@
 -- Potentially faster power function for 'Integer' base and 'Int'
 -- or 'Word' exponent.
 --
-{-# LANGUAGE MagicHash, BangPatterns, CPP #-}
+{-# LANGUAGE MagicHash    #-}
+{-# LANGUAGE BangPatterns #-}
 module Math.NumberTheory.Powers.Integer
     ( integerPower
     , integerWordPower
@@ -17,10 +18,6 @@ module Math.NumberTheory.Powers.Integer
 
 import GHC.Base
 import GHC.Integer.Logarithms (wordLog2#)
-
-#if __GLASGOW_HASKELL__ < 707
-import Math.NumberTheory.Utils (isTrue#)
-#endif
 
 -- | Power of an 'Integer' by the left-to-right repeated squaring algorithm.
 --   This needs two multiplications in each step while the right-to-left

--- a/Math/NumberTheory/Powers/Squares/Internal.hs
+++ b/Math/NumberTheory/Powers/Squares/Internal.hs
@@ -29,9 +29,6 @@ import GHC.Integer.GMP.Internals
 import GHC.Integer.Logarithms (integerLog2#)
 
 import Math.NumberTheory.Logarithms (integerLog2)
-#if __GLASGOW_HASKELL__ < 707
-import Math.NumberTheory.Utils (isTrue#)
-#endif
 
 -- Find approximation to square root in 'Integer', then
 -- find the integer square root by the integer variant

--- a/Math/NumberTheory/UniqueFactorisation.hs
+++ b/Math/NumberTheory/UniqueFactorisation.hs
@@ -18,6 +18,7 @@ module Math.NumberTheory.UniqueFactorisation
   ) where
 
 import Control.Arrow
+import Data.Coerce
 
 #if MIN_VERSION_base(4,8,0)
 #else
@@ -28,15 +29,6 @@ import Math.NumberTheory.Primes.Factorisation as F (factorise')
 import Math.NumberTheory.GaussianIntegers as G
 
 import Numeric.Natural
-
-#if MIN_VERSION_base(4,7,0)
-import Data.Coerce
-#else
-import Unsafe.Coerce
-
-coerce :: a -> b
-coerce = unsafeCoerce
-#endif
 
 newtype SmallPrime = SmallPrime { _unSmallPrime :: Word }
   deriving (Eq, Ord, Show)

--- a/Math/NumberTheory/Utils.hs
+++ b/Math/NumberTheory/Utils.hs
@@ -20,9 +20,6 @@ module Math.NumberTheory.Utils
     , bitCountWord#
     , uncheckedShiftR
     , splitOff
-#if __GLASGOW_HASKELL__ < 707
-    , isTrue#
-#endif
     ) where
 
 #include "MachDeps.h"
@@ -205,9 +202,3 @@ splitOff p n = go 0 n
     go !k m = case m `quotRem` p of
                 (q,r) | r == 0 -> go (k+1) q
                       | otherwise -> (k,m)
-
-#if __GLASGOW_HASKELL__ < 707
--- The times they are a-changing. The types of primops too :(
-isTrue# :: Bool -> Bool
-isTrue# = id
-#endif

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -23,7 +23,7 @@ description         : A library of basic functionality needed for
 
 category            : Math, Algorithms, Number Theory
 
-tested-with         : GHC==7.6.3, GHC==7.8.4, GHC==7.10.3, GHC==8.0.1
+tested-with         : GHC==7.8.4, GHC==7.10.3, GHC==8.0.1
 
 extra-source-files  : Changes, TODO
 
@@ -34,7 +34,7 @@ flag check-bounds
 
 library
     default-language: Haskell2010
-    build-depends       : base >= 4.6 && < 5
+    build-depends       : base >= 4.7 && < 5
                         , array >= 0.5 && < 0.6
                         , ghc-prim < 0.6
                         , integer-gmp < 1.1
@@ -130,8 +130,7 @@ test-suite spec
                       , tasty-hunit >= 0.9 && < 0.10
                       , QuickCheck >= 2.7.6 && < 2.10
                       , smallcheck >= 1.1 && < 1.2
-                      , transformers >= 0.3
-                      , transformers-compat >= 0.4
+                      , transformers >= 0.5
   if impl(ghc < 7.10)
     build-depends     : nats >= 1 && <1.2
 

--- a/test-suite/Math/NumberTheory/TestUtils.hs
+++ b/test-suite/Math/NumberTheory/TestUtils.hs
@@ -92,24 +92,14 @@ class    (f (g x)) => (f `Compose` g) x
 instance (f (g x)) => (f `Compose` g) x
 
 type family ConcatMap (w :: * -> Constraint) (cs :: [*]) :: Constraint
-#if __GLASGOW_HASKELL__ >= 708
   where
     ConcatMap w '[] = ()
     ConcatMap w (c ': cs) = (w c, ConcatMap w cs)
-#else
-type instance ConcatMap w '[] = ()
-type instance ConcatMap w (c ': cs) = (w c, ConcatMap w cs)
-#endif
 
 type family Matrix (as :: [* -> Constraint]) (w :: * -> *) (bs :: [*]) :: Constraint
-#if __GLASGOW_HASKELL__ >= 708
   where
     Matrix '[] w bs = ()
     Matrix (a ': as) w bs = (ConcatMap (a `Compose` w) bs, Matrix as w bs)
-#else
-type instance Matrix '[] w bs = ()
-type instance Matrix (a ': as) w bs = (ConcatMap (a `Compose` w) bs, Matrix as w bs)
-#endif
 
 type TestableIntegral wrapper =
   ( Matrix '[Arbitrary, Show, Serial IO] wrapper '[Int, Word, Integer]

--- a/test-suite/Math/NumberTheory/TestUtils/Compose.hs
+++ b/test-suite/Math/NumberTheory/TestUtils/Compose.hs
@@ -21,6 +21,7 @@
 
 module Math.NumberTheory.TestUtils.Compose where
 
+import Data.Functor.Classes
 import Data.Functor.Compose
 
 import Test.Tasty.QuickCheck (Arbitrary)
@@ -30,8 +31,8 @@ deriving instance Num (f (g a))     => Num (Compose f g a)
 deriving instance Enum (f (g a))    => Enum (Compose f g a)
 deriving instance Bounded (f (g a)) => Bounded (Compose f g a)
 
-deriving instance (Ord (Compose f g a), Real (f (g a)))     => Real (Compose f g a)
-deriving instance (Ord (Compose f g a), Integral (f (g a))) => Integral (Compose f g a)
+deriving instance (Ord1 f, Ord1 g, Ord a, Real (f (g a)))     => Real (Compose f g a)
+deriving instance (Ord1 f, Ord1 g, Ord a, Integral (f (g a))) => Integral (Compose f g a)
 
 deriving instance Arbitrary (f (g a)) => Arbitrary (Compose f g a)
 

--- a/test-suite/Math/NumberTheory/TestUtils/Compose.hs
+++ b/test-suite/Math/NumberTheory/TestUtils/Compose.hs
@@ -9,7 +9,6 @@
 -- Utils to test Math.NumberTheory
 --
 
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
@@ -23,10 +22,6 @@
 module Math.NumberTheory.TestUtils.Compose where
 
 import Data.Functor.Compose
-#if MIN_VERSION_transformers(0,5,0)
-#else
-import GHC.Generics
-#endif
 
 import Test.Tasty.QuickCheck (Arbitrary)
 import Test.SmallCheck.Series (Serial)
@@ -40,8 +35,4 @@ deriving instance (Ord (Compose f g a), Integral (f (g a))) => Integral (Compose
 
 deriving instance Arbitrary (f (g a)) => Arbitrary (Compose f g a)
 
-#if MIN_VERSION_transformers(0,5,0)
-#else
-deriving instance Generic (Compose f g a)
-#endif
 instance (Monad m, Serial m (f (g a))) => Serial m (Compose f g a)

--- a/test-suite/Math/NumberTheory/TestUtils/Wrappers.hs
+++ b/test-suite/Math/NumberTheory/TestUtils/Wrappers.hs
@@ -47,25 +47,13 @@ instance (Monad m, Serial m a) => Serial m (AnySign a) where
   series = AnySign <$> series
 
 instance Eq1 AnySign where
-#if MIN_VERSION_transformers(0,5,0)
   liftEq eq (AnySign a) (AnySign b) = a `eq` b
-#else
-  (AnySign a) `eq1` (AnySign b) = a == b
-#endif
 
 instance Ord1 AnySign where
-#if MIN_VERSION_transformers(0,5,0)
   liftCompare cmp (AnySign a) (AnySign b) = a `cmp` b
-#else
-  (AnySign a) `compare1` (AnySign b) = a `compare` b
-#endif
 
 instance Show1 AnySign where
-#if MIN_VERSION_transformers(0,5,0)
   liftShowsPrec shw _ p (AnySign a) = shw p a
-#else
-  showsPrec1 p (AnySign a) = showsPrec p a
-#endif
 
 -------------------------------------------------------------------------------
 -- Positive from smallcheck
@@ -81,25 +69,13 @@ instance (Num a, Bounded a) => Bounded (Positive a) where
   maxBound = Positive (maxBound :: a)
 
 instance Eq1 Positive where
-#if MIN_VERSION_transformers(0,5,0)
   liftEq eq (Positive a) (Positive b) = a `eq` b
-#else
-  (Positive a) `eq1` (Positive b) = a == b
-#endif
 
 instance Ord1 Positive where
-#if MIN_VERSION_transformers(0,5,0)
   liftCompare cmp (Positive a) (Positive b) = a `cmp` b
-#else
-  (Positive a) `compare1` (Positive b) = a `compare` b
-#endif
 
 instance Show1 Positive where
-#if MIN_VERSION_transformers(0,5,0)
   liftShowsPrec shw _ p (Positive a) = shw p a
-#else
-  showsPrec1 p (Positive a) = showsPrec p a
-#endif
 
 -------------------------------------------------------------------------------
 -- NonNegative from smallcheck
@@ -115,25 +91,13 @@ instance (Num a, Bounded a) => Bounded (NonNegative a) where
   maxBound = NonNegative (maxBound :: a)
 
 instance Eq1 NonNegative where
-#if MIN_VERSION_transformers(0,5,0)
   liftEq eq (NonNegative a) (NonNegative b) = a `eq` b
-#else
-  (NonNegative a) `eq1` (NonNegative b) = a == b
-#endif
 
 instance Ord1 NonNegative where
-#if MIN_VERSION_transformers(0,5,0)
   liftCompare cmp (NonNegative a) (NonNegative b) = a `cmp` b
-#else
-  (NonNegative a) `compare1` (NonNegative b) = a `compare` b
-#endif
 
 instance Show1 NonNegative where
-#if MIN_VERSION_transformers(0,5,0)
   liftShowsPrec shw _ p (NonNegative a) = shw p a
-#else
-  showsPrec1 p (NonNegative a) = showsPrec p a
-#endif
 
 -------------------------------------------------------------------------------
 -- Huge
@@ -148,25 +112,13 @@ instance (Num a, Arbitrary a) => Arbitrary (Huge a) where
     return $ Huge $ foldl1 (\acc n -> acc * 2^63 + n) ds
 
 instance Eq1 Huge where
-#if MIN_VERSION_transformers(0,5,0)
   liftEq eq (Huge a) (Huge b) = a `eq` b
-#else
-  (Huge a) `eq1` (Huge b) = a == b
-#endif
 
 instance Ord1 Huge where
-#if MIN_VERSION_transformers(0,5,0)
   liftCompare cmp (Huge a) (Huge b) = a `cmp` b
-#else
-  (Huge a) `compare1` (Huge b) = a `compare` b
-#endif
 
 instance Show1 Huge where
-#if MIN_VERSION_transformers(0,5,0)
   liftShowsPrec shw _ p (Huge a) = shw p a
-#else
-  showsPrec1 p (Huge a) = showsPrec p a
-#endif
 
 -------------------------------------------------------------------------------
 -- Power
@@ -182,25 +134,13 @@ instance (Num a, Ord a, Integral a, Arbitrary a) => Arbitrary (Power a) where
   shrink (Power x) = Power <$> filter (> 0) (shrink x)
 
 instance Eq1 Power where
-#if MIN_VERSION_transformers(0,5,0)
   liftEq eq (Power a) (Power b) = a `eq` b
-#else
-  (Power a) `eq1` (Power b) = a == b
-#endif
 
 instance Ord1 Power where
-#if MIN_VERSION_transformers(0,5,0)
   liftCompare cmp (Power a) (Power b) = a `cmp` b
-#else
-  (Power a) `compare1` (Power b) = a `compare` b
-#endif
 
 instance Show1 Power where
-#if MIN_VERSION_transformers(0,5,0)
   liftShowsPrec shw _ p (Power a) = shw p a
-#else
-  showsPrec1 p (Power a) = showsPrec p a
-#endif
 
 -------------------------------------------------------------------------------
 -- Odd
@@ -216,25 +156,13 @@ instance (Integral a, Arbitrary a) => Arbitrary (Odd a) where
   shrink (Odd x) = Odd <$> filter odd (shrink x)
 
 instance Eq1 Odd where
-#if MIN_VERSION_transformers(0,5,0)
   liftEq eq (Odd a) (Odd b) = a `eq` b
-#else
-  (Odd a) `eq1` (Odd b) = a == b
-#endif
 
 instance Ord1 Odd where
-#if MIN_VERSION_transformers(0,5,0)
   liftCompare cmp (Odd a) (Odd b) = a `cmp` b
-#else
-  (Odd a) `compare1` (Odd b) = a `compare` b
-#endif
 
 instance Show1 Odd where
-#if MIN_VERSION_transformers(0,5,0)
   liftShowsPrec shw _ p (Odd a) = shw p a
-#else
-  showsPrec1 p (Odd a) = showsPrec p a
-#endif
 
 -------------------------------------------------------------------------------
 -- Prime


### PR DESCRIPTION
After release of `arithmoi-0.4.3.0` with stability fixes, IMHO it is time to stop supporting GHC 7.6 and `base-4.6`. It is really outdated and the maintenance is extremely tedious: we need to insert CPP macros here and there to make GHC 7.6 happy. The changelog is a solid evidence: ~100 lines of `#if..#endif` hell were required. 

GHC 7.6 also blocks us from using some dependencies. For example, the upcoming branch with Riemann zeta function inevitably requires `exact-pi >= 0.4.1.1`, which requires GHC 7.8 at least.