### PR TITLE
Riemann zeta function

### DIFF
--- a/Math/NumberTheory/Recurrencies/Bilinear.hs
+++ b/Math/NumberTheory/Recurrencies/Bilinear.hs
@@ -10,7 +10,7 @@
 -- roughly covering Ch. 5-6 of /Concrete Mathematics/
 -- by R. L. Graham, D. E. Knuth and O. Patashnik.
 --
--- __Note on memory leaks and memoization.__
+-- #memory# __Note on memory leaks and memoization.__
 -- Top-level definitions in this module are polymorphic, so the results of computations are not retained in memory.
 -- Make them monomorphic to take advantages of memoization. Compare
 --

--- a/Math/NumberTheory/Recurrencies/Bilinear.hs
+++ b/Math/NumberTheory/Recurrencies/Bilinear.hs
@@ -42,6 +42,8 @@ module Math.NumberTheory.Recurrencies.Bilinear
   , eulerian1
   , eulerian2
   , bernoulli
+
+  , zetaEven
   ) where
 
 import Data.List
@@ -52,6 +54,8 @@ import Numeric.Natural
 #else
 import Data.Word
 #endif
+
+import Data.ExactPi
 
 factorial :: (Num a, Enum a) => [a]
 factorial = scanl (*) 1 [1..]
@@ -200,3 +204,19 @@ zipIndexedListWithTail f n as a = case as of
       []       -> let v = f m y a in [v]
       (z : zs) -> let v = f m y z in (v : go (succ m) z zs)
 {-# INLINE zipIndexedListWithTail #-}
+
+-------------------------------------------------------------------------------
+-- Zeta function
+
+-- zeta(2n) = - (2 pi i)^(2n) B_2n / 2 / (2n)!
+--       = - (-4)^n / 2 * B_2n / (2n)!  *  pi^2n
+-- Usage:
+-- > approximateValue  $ zetaEven !! 30 :: Fixed (PrecPlus20 Prec50)
+zetaEven :: [ExactPi]
+zetaEven = zipWith Exact [0, 2 ..] $ zipWith (*) (skipOdds bernoulli) cs
+  where
+    cs = (- 1 % 2) : zipWith (\i f -> i * (-4) / fromInteger (2 * f * (2 * f - 1))) cs [1..]
+
+skipOdds :: [a] -> [a]
+skipOdds (x:_:xs) = x : skipOdds xs
+skipOdds xs = xs

--- a/Math/NumberTheory/Recurrencies/Bilinear.hs
+++ b/Math/NumberTheory/Recurrencies/Bilinear.hs
@@ -34,8 +34,6 @@
 
 {-# LANGUAGE CPP #-}
 
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Math.NumberTheory.Recurrencies.Bilinear
   ( binomial
   , stirling1
@@ -44,10 +42,6 @@ module Math.NumberTheory.Recurrencies.Bilinear
   , eulerian1
   , eulerian2
   , bernoulli
-
-  , zetasEven
-  , approximateValue
-  , zetas
   ) where
 
 import Data.List
@@ -59,14 +53,7 @@ import Numeric.Natural
 import Data.Word
 #endif
 
-import Data.ExactPi
-
-factorial :: (Num a, Enum a) => [a]
-factorial = scanl (*) 1 [1..]
-{-# SPECIALIZE factorial :: [Int]     #-}
-{-# SPECIALIZE factorial :: [Word]    #-}
-{-# SPECIALIZE factorial :: [Integer] #-}
-{-# SPECIALIZE factorial :: [Natural] #-}
+import Math.NumberTheory.Recurrencies.Linear (factorial)
 
 -- | Infinite zero-based table of binomial coefficients (also known as Pascal triangle):
 -- @binomial !! n !! k == n! \/ k! \/ (n - k)!@.
@@ -208,98 +195,3 @@ zipIndexedListWithTail f n as a = case as of
       []       -> let v = f m y a in [v]
       (z : zs) -> let v = f m y z in (v : go (succ m) z zs)
 {-# INLINE zipIndexedListWithTail #-}
-
--------------------------------------------------------------------------------
--- Zeta function
-
--- | Infinite sequence of exact values of Riemann zeta-function at even arguments, starting with @ζ(0)@.
--- Note that due to numerical errors convertation to 'Double' may return values below 1:
---
--- > > approximateValue (zetasEven !! 25) :: Double
--- > 0.9999999999999996
---
--- Use your favorite type for long-precision arithmetic. For instance, 'Data.Number.Fixed.Fixed' works fine:
---
--- > > approximateValue (zetasEven !! 25) :: Fixed Prec50
--- > 1.00000000000000088817842111574532859293035196051773
---
-zetasEven :: [ExactPi]
-zetasEven = zipWith Exact [0, 2 ..] $ zipWith (*) (skipOdds bernoulli) cs
-  where
-    cs = (- 1 % 2) : zipWith (\i f -> i * (-4) / fromInteger (2 * f * (2 * f - 1))) cs [1..]
-
-skipOdds :: [a] -> [a]
-skipOdds (x : _ : xs) = x : skipOdds xs
-skipOdds xs = xs
-
-zetasEven' :: (Floating a, Ord a) => [a]
-zetasEven' = map approximateValue zetasEven
-
-zetasOdd :: forall a. (Floating a, Ord a) => a -> [a]
-zetasOdd eps = (1 / 0) : zets
-  where
-    zets :: [a] -- [zeta(3), zeta(5), zeta(7)...]
-    zets = zipWith (*) zs (tail (iterate (* (- pi * pi)) 1))
-
-    zs :: [a] -- [zeta(3) / (-pi^2), zeta(5) / pi^4, zeta(7) / (-pi^6)...]
-    zs = zipWith (\w f -> negate (w / (1 + f))) ws fourth
-
-    ys :: [a] -- [(1 - 1/4) * zeta(3) / (-pi^2), (1 - 1/4^2) * zeta(5) / pi^4...]
-    ys = zipWith (*) zs fourth
-    yss :: [[a]] -- [[], [ys !! 0], [ys !! 1, ys !! 0], [ys !! 2, ys !! 1, ys !! 0]...]
-    yss = [] : zipWith (:) ys yss
-
-    xs :: [a] -- first summand of RHS in (57) for m=[1..]
-    xs = map (sum . zipWith (flip (/)) factorial2) yss
-
-    ws :: [a] -- RHS in (57) for m=[1..]
-    ws = zipWith (+) xs cs
-
-    rs :: [a] -- [1, 1/2, 1/3, 1/4...]
-    rs = map (\n -> recip (fromInteger n)) [1..]
-    rss :: [[a]] -- [[1, 1/2, 1/3...], [1/2, 1/3, 1/4...], [1/3, 1/4...]]
-    rss = rs : map tail rss
-
-    factorial2 :: [a] -- [2!, 4!, 6!..]
-    factorial2 = map fromInteger $ tail $ skipOdds factorial
-
-    fourth :: [a] -- [1 - 1/4, 1 - 1/4^2, 1 - 1/4^3...]
-    fourth = tail $ map (1 -) $ iterate (/ 4) 1
-
-    as :: [a] -- [zeta(0), zeta(2)/4, zeta(2*2)/4^2, zeta(2*3)/4^3...]
-    as = zipWith (/) zetasEven' (iterate (* 4) 1)
-
-    bs :: [a] -- map (+ log 2) [b(1), b(2), b(3)...],
-              -- where b(m) = \sum_{n=0}^\infty zeta(2n) / 4^n / (n + m)
-    bs = map ((+ log 2) . suminf eps . zipWith (*) as) rss
-
-    cs :: [a] -- second summand of RHS in (57) for m = [1..]
-    cs = zipWith (\b f -> b / f) bs factorial2
-
-suminf :: (Floating a, Ord a) => a -> [a] -> a
-suminf eps = sum . takeWhile ((>= eps / 111) . abs)
-
--- | Infinite sequence of approximate (up to given precision)
--- values of Riemann zeta-function at integer arguments, starting with @ζ(0)@.
--- Computations for odd arguments are performed in accordance to
--- <https://cr.yp.to/bib/2000/borwein.pdf Computational strategies for the Riemann zeta function>
--- by J. M. Borwein, D. M. Bradley, R. E. Crandall, formula (57).
---
--- > > take 5 (zetas 1e-14) :: [Double]
--- > [-0.5,Infinity,1.6449340668482262,1.2020569031595942,1.0823232337111381]
---
--- Beware to force evaluation of @zetas !! 1@, if the type @a@ does not support infinite values
--- (for instance, 'Data.Number.Fixed.Fixed').
---
-zetas :: (Floating a, Ord a) => a -> [a]
-zetas eps = e : o : scanl1 f (intertwine es os)
-  where
-    e : es = zetasEven'
-    o : os = zetasOdd eps
-
-    intertwine (x : xs) (y : ys) = x : y : intertwine xs ys
-    intertwine      xs       ys  = xs ++ ys
-
-    -- Cap-and-floor to improve numerical stability:
-    -- 0 < zeta(n + 1) - 1 < (zeta(n) - 1) / 2
-    f x y = 1 `max` (y `min` (1 + (x - 1) / 2))

--- a/Math/NumberTheory/Recurrencies/Linear.hs
+++ b/Math/NumberTheory/Recurrencies/Linear.hs
@@ -28,7 +28,13 @@ import Numeric.Natural
 import Data.Word
 #endif
 
--- | Infinite sequence of factorials, starting with 0!
+-- | Infinite zero-based table of factorials.
+--
+-- > > take 5 factorial
+-- > [1,1,2,6,24]
+--
+-- The time-and-space behaviour of 'factorial' is similar to described in
+-- "Math.NumberTheory.Recurrencies.Bilinear#memory".
 factorial :: (Num a, Enum a) => [a]
 factorial = scanl (*) 1 [1..]
 {-# SPECIALIZE factorial :: [Int]     #-}

--- a/Math/NumberTheory/Recurrencies/Linear.hs
+++ b/Math/NumberTheory/Recurrencies/Linear.hs
@@ -10,7 +10,8 @@
 
 {-# LANGUAGE CPP #-}
 module Math.NumberTheory.Recurrencies.Linear
-  ( fibonacci
+  ( factorial
+  , fibonacci
   , fibonacciPair
   , lucas
   , lucasPair
@@ -20,6 +21,15 @@ module Math.NumberTheory.Recurrencies.Linear
 #include "MachDeps.h"
 
 import Data.Bits
+import Numeric.Natural
+
+-- | Infinite sequence of factorials, starting with 0!
+factorial :: (Num a, Enum a) => [a]
+factorial = scanl (*) 1 [1..]
+{-# SPECIALIZE factorial :: [Int]     #-}
+{-# SPECIALIZE factorial :: [Word]    #-}
+{-# SPECIALIZE factorial :: [Integer] #-}
+{-# SPECIALIZE factorial :: [Natural] #-}
 
 -- | @'fibonacci' k@ calculates the @k@-th Fibonacci number in
 --   /O/(@log (abs k)@) steps. The index may be negative. This

--- a/Math/NumberTheory/Recurrencies/Linear.hs
+++ b/Math/NumberTheory/Recurrencies/Linear.hs
@@ -23,6 +23,11 @@ module Math.NumberTheory.Recurrencies.Linear
 import Data.Bits
 import Numeric.Natural
 
+#if MIN_VERSION_base(4,8,0)
+#else
+import Data.Word
+#endif
+
 -- | Infinite sequence of factorials, starting with 0!
 factorial :: (Num a, Enum a) => [a]
 factorial = scanl (*) 1 [1..]

--- a/Math/NumberTheory/Zeta.hs
+++ b/Math/NumberTheory/Zeta.hs
@@ -1,0 +1,115 @@
+-- |
+-- Module:      Math.NumberTheory.Zeta
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- Riemann zeta-function.
+
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Math.NumberTheory.Zeta
+  ( zetas
+  , zetasEven
+  , approximateValue
+  ) where
+
+import Data.ExactPi
+import Data.Ratio
+
+import Math.NumberTheory.Recurrencies.Bilinear (bernoulli)
+import Math.NumberTheory.Recurrencies.Linear (factorial)
+
+-- | Infinite sequence of exact values of Riemann zeta-function at even arguments, starting with @ζ(0)@.
+-- Note that due to numerical errors convertation to 'Double' may return values below 1:
+--
+-- > > approximateValue (zetasEven !! 25) :: Double
+-- > 0.9999999999999996
+--
+-- Use your favorite type for long-precision arithmetic. For instance, 'Data.Number.Fixed.Fixed' works fine:
+--
+-- > > approximateValue (zetasEven !! 25) :: Fixed Prec50
+-- > 1.00000000000000088817842111574532859293035196051773
+--
+zetasEven :: [ExactPi]
+zetasEven = zipWith Exact [0, 2 ..] $ zipWith (*) (skipOdds bernoulli) cs
+  where
+    cs = (- 1 % 2) : zipWith (\i f -> i * (-4) / fromInteger (2 * f * (2 * f - 1))) cs [1..]
+
+skipOdds :: [a] -> [a]
+skipOdds (x : _ : xs) = x : skipOdds xs
+skipOdds xs = xs
+
+zetasEven' :: Floating a => [a]
+zetasEven' = map approximateValue zetasEven
+
+zetasOdd :: forall a. (Floating a, Ord a) => a -> [a]
+zetasOdd eps = (1 / 0) : zets
+  where
+    zets :: [a] -- [zeta(3), zeta(5), zeta(7)...]
+    zets = zipWith (*) zs (tail (iterate (* (- pi * pi)) 1))
+
+    zs :: [a] -- [zeta(3) / (-pi^2), zeta(5) / pi^4, zeta(7) / (-pi^6)...]
+    zs = zipWith (\w f -> negate (w / (1 + f))) ws fourth
+
+    ys :: [a] -- [(1 - 1/4) * zeta(3) / (-pi^2), (1 - 1/4^2) * zeta(5) / pi^4...]
+    ys = zipWith (*) zs fourth
+    yss :: [[a]] -- [[], [ys !! 0], [ys !! 1, ys !! 0], [ys !! 2, ys !! 1, ys !! 0]...]
+    yss = [] : zipWith (:) ys yss
+
+    xs :: [a] -- first summand of RHS in (57) for m=[1..]
+    xs = map (sum . zipWith (flip (/)) factorial2) yss
+
+    ws :: [a] -- RHS in (57) for m=[1..]
+    ws = zipWith (+) xs cs
+
+    rs :: [a] -- [1, 1/2, 1/3, 1/4...]
+    rs = map (\n -> recip (fromInteger n)) [1..]
+    rss :: [[a]] -- [[1, 1/2, 1/3...], [1/2, 1/3, 1/4...], [1/3, 1/4...]]
+    rss = rs : map tail rss
+
+    factorial2 :: [a] -- [2!, 4!, 6!..]
+    factorial2 = map fromInteger $ tail $ skipOdds factorial
+
+    fourth :: [a] -- [1 - 1/4, 1 - 1/4^2, 1 - 1/4^3...]
+    fourth = tail $ map (1 -) $ iterate (/ 4) 1
+
+    as :: [a] -- [zeta(0), zeta(2)/4, zeta(2*2)/4^2, zeta(2*3)/4^3...]
+    as = zipWith (/) zetasEven' (iterate (* 4) 1)
+
+    bs :: [a] -- map (+ log 2) [b(1), b(2), b(3)...],
+              -- where b(m) = \sum_{n=0}^\infty zeta(2n) / 4^n / (n + m)
+    bs = map ((+ log 2) . suminf eps . zipWith (*) as) rss
+
+    cs :: [a] -- second summand of RHS in (57) for m = [1..]
+    cs = zipWith (\b f -> b / f) bs factorial2
+
+suminf :: (Floating a, Ord a) => a -> [a] -> a
+suminf eps = sum . takeWhile ((>= eps / 111) . abs)
+
+-- | Infinite sequence of approximate (up to given precision)
+-- values of Riemann zeta-function at integer arguments, starting with @ζ(0)@.
+-- Computations for odd arguments are performed in accordance to
+-- <https://cr.yp.to/bib/2000/borwein.pdf Computational strategies for the Riemann zeta function>
+-- by J. M. Borwein, D. M. Bradley, R. E. Crandall, formula (57).
+--
+-- > > take 5 (zetas 1e-14) :: [Double]
+-- > [-0.5,Infinity,1.6449340668482262,1.2020569031595942,1.0823232337111381]
+--
+-- Beware to force evaluation of @zetas !! 1@, if the type @a@ does not support infinite values
+-- (for instance, 'Data.Number.Fixed.Fixed').
+--
+zetas :: (Floating a, Ord a) => a -> [a]
+zetas eps = e : o : scanl1 f (intertwine es os)
+  where
+    e : es = zetasEven'
+    o : os = zetasOdd eps
+
+    intertwine (x : xs) (y : ys) = x : y : intertwine xs ys
+    intertwine      xs       ys  = xs ++ ys
+
+    -- Cap-and-floor to improve numerical stability:
+    -- 0 < zeta(n + 1) - 1 < (zeta(n) - 1) / 2
+    f x y = 1 `max` (y `min` (1 + (x - 1) / 2))

--- a/Math/NumberTheory/Zeta.hs
+++ b/Math/NumberTheory/Zeta.hs
@@ -57,7 +57,7 @@ zetasOdd eps = (1 / 0) : zets
     ys :: [a] -- [(1 - 1/4) * zeta(3) / (-pi^2), (1 - 1/4^2) * zeta(5) / pi^4...]
     ys = zipWith (*) zs fourth
     yss :: [[a]] -- [[], [ys !! 0], [ys !! 1, ys !! 0], [ys !! 2, ys !! 1, ys !! 0]...]
-    yss = [] : zipWith (:) ys yss
+    yss = scanl (flip (:)) [] ys
 
     xs :: [a] -- first summand of RHS in (57) for m=[1..]
     xs = map (sum . zipWith (flip (/)) factorial2) yss
@@ -68,7 +68,7 @@ zetasOdd eps = (1 / 0) : zets
     rs :: [a] -- [1, 1/2, 1/3, 1/4...]
     rs = map (\n -> recip (fromInteger n)) [1..]
     rss :: [[a]] -- [[1, 1/2, 1/3...], [1/2, 1/3, 1/4...], [1/3, 1/4...]]
-    rss = rs : map tail rss
+    rss = iterate tail rs
 
     factorial2 :: [a] -- [2!, 4!, 6!..]
     factorial2 = map fromInteger $ tail $ skipOdds factorial

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -75,6 +75,7 @@ library
                           Math.NumberTheory.Primes.Testing.Certificates
                           Math.NumberTheory.Primes.Heap
                           Math.NumberTheory.UniqueFactorisation
+                          Math.NumberTheory.Zeta
     other-modules       : Math.NumberTheory.Utils
                           Math.NumberTheory.Unsafe
                           Math.NumberTheory.Primes.Counting.Impl
@@ -158,3 +159,4 @@ test-suite spec
                   , Math.NumberTheory.TestUtils.Wrappers
                   , Math.NumberTheory.TestUtils.Compose
                   , Math.NumberTheory.UniqueFactorisationTests
+                  , Math.NumberTheory.ZetaTests

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -41,6 +41,7 @@ library
                         , containers >= 0.5 && < 0.6
                         , random >= 1.0 && < 1.2
                         , mtl >= 2.0 && < 2.3
+                        , exact-pi >= 0.4.1.1
     if impl(ghc < 7.10)
       build-depends     : nats >= 1 && <1.2
     if impl(ghc < 8.0)

--- a/test-suite/Math/NumberTheory/Recurrencies/BilinearTests.hs
+++ b/test-suite/Math/NumberTheory/Recurrencies/BilinearTests.hs
@@ -206,7 +206,7 @@ zetaOddSpecialCase3
 zetaOddProperty1 :: Positive Int -> Bool
 zetaOddProperty1 (Positive m)
   =  zetaM < 1
-  || zetaM > zetaM1
+  || zetaM >= zetaM1
   where
     zetaM  = zetaOdd' !! m
     zetaM1 = zetaOdd' !! (m + 1)

--- a/test-suite/Math/NumberTheory/Recurrencies/BilinearTests.hs
+++ b/test-suite/Math/NumberTheory/Recurrencies/BilinearTests.hs
@@ -154,78 +154,77 @@ assertEqualUpToEps msg eps expected actual
   = assertBool msg (abs (expected - actual) < eps)
 
 epsilon :: Double
-epsilon = 1e-15
+epsilon = 1e-14
 
-zetaEvenSpecialCase1 :: Assertion
-zetaEvenSpecialCase1
+zetasEvenSpecialCase1 :: Assertion
+zetasEvenSpecialCase1
   = assertEqual "zeta(0) = -1/2"
-    (approximateValue $ zetaEven !! 0)
+    (approximateValue $ zetasEven !! 0)
     (-1 / 2)
 
-zetaEvenSpecialCase2 :: Assertion
-zetaEvenSpecialCase2
+zetasEvenSpecialCase2 :: Assertion
+zetasEvenSpecialCase2
   = assertEqualUpToEps "zeta(2) = pi^2/6" epsilon
-    (approximateValue $ zetaEven !! 1)
+    (approximateValue $ zetasEven !! 1)
     (pi * pi / 6)
 
-zetaEvenSpecialCase3 :: Assertion
-zetaEvenSpecialCase3
+zetasEvenSpecialCase3 :: Assertion
+zetasEvenSpecialCase3
   = assertEqualUpToEps "zeta(4) = pi^4/90" epsilon
-    (approximateValue $ zetaEven !! 2)
+    (approximateValue $ zetasEven !! 2)
     (pi ^ 4 / 90)
 
-zetaEvenProperty1 :: Positive Int -> Bool
-zetaEvenProperty1 (Positive m)
+zetasEvenProperty1 :: Positive Int -> Bool
+zetasEvenProperty1 (Positive m)
   =  zetaM < 1
   || zetaM > zetaM1
   where
-    zetaM  = approximateValue (zetaEven !! m)
-    zetaM1 = approximateValue (zetaEven !! (m + 1))
+    zetaM  = approximateValue (zetasEven !! m)
+    zetaM1 = approximateValue (zetasEven !! (m + 1))
 
-zetaOdd' :: [Double]
-zetaOdd' = zetaOdd epsilon
+zetasEvenProperty2 :: Positive Int -> Bool
+zetasEvenProperty2 (Positive m)
+  = abs (zetaM - zetaM') < epsilon
+  where
+    zetaM  = approximateValue (zetasEven !! m)
+    zetaM' = zetas' !! (2 * m)
 
-zetaOddSpecialCase1 :: Assertion
-zetaOddSpecialCase1
+zetas' :: [Double]
+zetas' = zetas epsilon
+
+zetasSpecialCase1 :: Assertion
+zetasSpecialCase1
   = assertEqual "zeta(1) = Infinity"
-    (zetaOdd' !! 0)
+    (zetas' !! 1)
     (1 / 0)
 
-zetaOddSpecialCase2 :: Assertion
-zetaOddSpecialCase2
-  = assertEqualUpToEps "zeta(3) = 1.2020569" 1e-15
-    (zetaOdd' !! 1)
+zetasSpecialCase2 :: Assertion
+zetasSpecialCase2
+  = assertEqualUpToEps "zeta(3) = 1.2020569" epsilon
+    (zetas' !! 3)
     1.2020569031595942853997381615114499908
 
-zetaOddSpecialCase3 :: Assertion
-zetaOddSpecialCase3
-  = assertEqualUpToEps "zeta(5) = 1.0369277" 1e-15
-    (zetaOdd' !! 2)
+zetasSpecialCase3 :: Assertion
+zetasSpecialCase3
+  = assertEqualUpToEps "zeta(5) = 1.0369277" epsilon
+    (zetas' !! 5)
     1.0369277551433699263313654864570341681
 
-zetaOddProperty1 :: Positive Int -> Bool
-zetaOddProperty1 (Positive m)
-  =  zetaM < 1
-  || zetaM >= zetaM1
+zetasProperty1 :: Positive Int -> Bool
+zetasProperty1 (Positive m)
+  =  zetaM >= zetaM1
+  && zetaM1 >= 1
   where
-    zetaM  = zetaOdd' !! m
-    zetaM1 = zetaOdd' !! (m + 1)
+    zetaM  = zetas' !! m
+    zetaM1 = zetas' !! (m + 1)
 
-zetaProperty1 :: Positive Int -> Bool
-zetaProperty1 (Positive m)
-  =  zetaM < 1
-  || zetaM > zetaM1
+zetasProperty2 :: NonNegative Int -> NonNegative Int -> Bool
+zetasProperty2 (NonNegative e1) (NonNegative e2)
+  = maximum (take 25 $ drop 2 $ zipWith ((abs .) . (-)) (zetas eps1) (zetas eps2)) < eps1 + eps2
   where
-    zetaM  = approximateValue (zetaEven !! m)
-    zetaM1 = zetaOdd' !! m
-
-zetaProperty2 :: NonNegative Int -> Bool
-zetaProperty2 (NonNegative m)
-  =  zetaM < 1
-  || zetaM > zetaM1
-  where
-    zetaM  = zetaOdd' !! m
-    zetaM1 = approximateValue (zetaEven !! (m + 1))
+    eps1, eps2 :: Double
+    eps1 = 1.0 / 2 ^ e1
+    eps2 = 1.0 / 2 ^ e2
 
 testSuite :: TestTree
 testSuite = testGroup "Bilinear"
@@ -272,15 +271,15 @@ testSuite = testGroup "Bilinear"
     , testSmallAndQuick "recursive definition" bernoulliProperty2
     ]
   , testGroup "zeta"
-    [ testCase "zeta(0)"                          zetaEvenSpecialCase1
-    , testCase "zeta(2)"                          zetaEvenSpecialCase2
-    , testCase "zeta(4)"                          zetaEvenSpecialCase3
-    , testSmallAndQuick "zeta(2n) > zeta(2n+2)"   zetaEvenProperty1
-    , testCase "zeta(1)"                          zetaOddSpecialCase1
-    , testCase "zeta(3)"                          zetaOddSpecialCase2
-    , testCase "zeta(5)"                          zetaOddSpecialCase3
-    , testSmallAndQuick "zeta(2n+1) > zeta(2n+3)" zetaOddProperty1
-    , testSmallAndQuick "zeta(2n) > zeta(2n+1)"   zetaProperty1
-    , testSmallAndQuick "zeta(2n+1) > zeta(2n+2)" zetaProperty2
+    [ testCase "zeta(0)"                          zetasEvenSpecialCase1
+    , testCase "zeta(2)"                          zetasEvenSpecialCase2
+    , testCase "zeta(4)"                          zetasEvenSpecialCase3
+    , testSmallAndQuick "zeta(2n) > zeta(2n+2)"   zetasEvenProperty1
+    , testSmallAndQuick "zetasEven matches zetas" zetasEvenProperty2
+    , testCase "zeta(1)"                          zetasSpecialCase1
+    , testCase "zeta(3)"                          zetasSpecialCase2
+    , testCase "zeta(5)"                          zetasSpecialCase3
+    , testSmallAndQuick "zeta(n) > zeta(n+1)"     zetasProperty1
+    , testSmallAndQuick "precision"               zetasProperty2
     ]
   ]

--- a/test-suite/Math/NumberTheory/Recurrencies/BilinearTests.hs
+++ b/test-suite/Math/NumberTheory/Recurrencies/BilinearTests.hs
@@ -149,6 +149,84 @@ bernoulliProperty2 (NonNegative m)
          | k <- [0 .. m - 1]
          ]
 
+assertEqualUpToEps :: String -> Double -> Double -> Double -> Assertion
+assertEqualUpToEps msg eps expected actual
+  = assertBool msg (abs (expected - actual) < eps)
+
+epsilon :: Double
+epsilon = 1e-15
+
+zetaEvenSpecialCase1 :: Assertion
+zetaEvenSpecialCase1
+  = assertEqual "zeta(0) = -1/2"
+    (approximateValue $ zetaEven !! 0)
+    (-1 / 2)
+
+zetaEvenSpecialCase2 :: Assertion
+zetaEvenSpecialCase2
+  = assertEqualUpToEps "zeta(2) = pi^2/6" epsilon
+    (approximateValue $ zetaEven !! 1)
+    (pi * pi / 6)
+
+zetaEvenSpecialCase3 :: Assertion
+zetaEvenSpecialCase3
+  = assertEqualUpToEps "zeta(4) = pi^4/90" epsilon
+    (approximateValue $ zetaEven !! 2)
+    (pi ^ 4 / 90)
+
+zetaEvenProperty1 :: Positive Int -> Bool
+zetaEvenProperty1 (Positive m)
+  =  zetaM < 1
+  || zetaM > zetaM1
+  where
+    zetaM  = approximateValue (zetaEven !! m)
+    zetaM1 = approximateValue (zetaEven !! (m + 1))
+
+zetaOdd' :: [Double]
+zetaOdd' = zetaOdd epsilon
+
+zetaOddSpecialCase1 :: Assertion
+zetaOddSpecialCase1
+  = assertEqual "zeta(1) = Infinity"
+    (zetaOdd' !! 0)
+    (1 / 0)
+
+zetaOddSpecialCase2 :: Assertion
+zetaOddSpecialCase2
+  = assertEqualUpToEps "zeta(3) = 1.2020569" 1e-15
+    (zetaOdd' !! 1)
+    1.2020569031595942853997381615114499908
+
+zetaOddSpecialCase3 :: Assertion
+zetaOddSpecialCase3
+  = assertEqualUpToEps "zeta(5) = 1.0369277" 1e-15
+    (zetaOdd' !! 2)
+    1.0369277551433699263313654864570341681
+
+zetaOddProperty1 :: Positive Int -> Bool
+zetaOddProperty1 (Positive m)
+  =  zetaM < 1
+  || zetaM > zetaM1
+  where
+    zetaM  = zetaOdd' !! m
+    zetaM1 = zetaOdd' !! (m + 1)
+
+zetaProperty1 :: Positive Int -> Bool
+zetaProperty1 (Positive m)
+  =  zetaM < 1
+  || zetaM > zetaM1
+  where
+    zetaM  = approximateValue (zetaEven !! m)
+    zetaM1 = zetaOdd' !! m
+
+zetaProperty2 :: NonNegative Int -> Bool
+zetaProperty2 (NonNegative m)
+  =  zetaM < 1
+  || zetaM > zetaM1
+  where
+    zetaM  = zetaOdd' !! m
+    zetaM1 = approximateValue (zetaEven !! (m + 1))
+
 testSuite :: TestTree
 testSuite = testGroup "Bilinear"
   [ testGroup "binomial"
@@ -192,5 +270,17 @@ testSuite = testGroup "Bilinear"
     , testCase "B_1"                           bernoulliSpecialCase2
     , testSmallAndQuick "sign"                 bernoulliProperty1
     , testSmallAndQuick "recursive definition" bernoulliProperty2
+    ]
+  , testGroup "zeta"
+    [ testCase "zeta(0)"                          zetaEvenSpecialCase1
+    , testCase "zeta(2)"                          zetaEvenSpecialCase2
+    , testCase "zeta(4)"                          zetaEvenSpecialCase3
+    , testSmallAndQuick "zeta(2n) > zeta(2n+2)"   zetaEvenProperty1
+    , testCase "zeta(1)"                          zetaOddSpecialCase1
+    , testCase "zeta(3)"                          zetaOddSpecialCase2
+    , testCase "zeta(5)"                          zetaOddSpecialCase3
+    , testSmallAndQuick "zeta(2n+1) > zeta(2n+3)" zetaOddProperty1
+    , testSmallAndQuick "zeta(2n) > zeta(2n+1)"   zetaProperty1
+    , testSmallAndQuick "zeta(2n+1) > zeta(2n+2)" zetaProperty2
     ]
   ]

--- a/test-suite/Math/NumberTheory/Recurrencies/BilinearTests.hs
+++ b/test-suite/Math/NumberTheory/Recurrencies/BilinearTests.hs
@@ -149,83 +149,6 @@ bernoulliProperty2 (NonNegative m)
          | k <- [0 .. m - 1]
          ]
 
-assertEqualUpToEps :: String -> Double -> Double -> Double -> Assertion
-assertEqualUpToEps msg eps expected actual
-  = assertBool msg (abs (expected - actual) < eps)
-
-epsilon :: Double
-epsilon = 1e-14
-
-zetasEvenSpecialCase1 :: Assertion
-zetasEvenSpecialCase1
-  = assertEqual "zeta(0) = -1/2"
-    (approximateValue $ zetasEven !! 0)
-    (-1 / 2)
-
-zetasEvenSpecialCase2 :: Assertion
-zetasEvenSpecialCase2
-  = assertEqualUpToEps "zeta(2) = pi^2/6" epsilon
-    (approximateValue $ zetasEven !! 1)
-    (pi * pi / 6)
-
-zetasEvenSpecialCase3 :: Assertion
-zetasEvenSpecialCase3
-  = assertEqualUpToEps "zeta(4) = pi^4/90" epsilon
-    (approximateValue $ zetasEven !! 2)
-    (pi ^ 4 / 90)
-
-zetasEvenProperty1 :: Positive Int -> Bool
-zetasEvenProperty1 (Positive m)
-  =  zetaM < 1
-  || zetaM > zetaM1
-  where
-    zetaM  = approximateValue (zetasEven !! m)
-    zetaM1 = approximateValue (zetasEven !! (m + 1))
-
-zetasEvenProperty2 :: Positive Int -> Bool
-zetasEvenProperty2 (Positive m)
-  = abs (zetaM - zetaM') < epsilon
-  where
-    zetaM  = approximateValue (zetasEven !! m)
-    zetaM' = zetas' !! (2 * m)
-
-zetas' :: [Double]
-zetas' = zetas epsilon
-
-zetasSpecialCase1 :: Assertion
-zetasSpecialCase1
-  = assertEqual "zeta(1) = Infinity"
-    (zetas' !! 1)
-    (1 / 0)
-
-zetasSpecialCase2 :: Assertion
-zetasSpecialCase2
-  = assertEqualUpToEps "zeta(3) = 1.2020569" epsilon
-    (zetas' !! 3)
-    1.2020569031595942853997381615114499908
-
-zetasSpecialCase3 :: Assertion
-zetasSpecialCase3
-  = assertEqualUpToEps "zeta(5) = 1.0369277" epsilon
-    (zetas' !! 5)
-    1.0369277551433699263313654864570341681
-
-zetasProperty1 :: Positive Int -> Bool
-zetasProperty1 (Positive m)
-  =  zetaM >= zetaM1
-  && zetaM1 >= 1
-  where
-    zetaM  = zetas' !! m
-    zetaM1 = zetas' !! (m + 1)
-
-zetasProperty2 :: NonNegative Int -> NonNegative Int -> Bool
-zetasProperty2 (NonNegative e1) (NonNegative e2)
-  = maximum (take 25 $ drop 2 $ zipWith ((abs .) . (-)) (zetas eps1) (zetas eps2)) < eps1 + eps2
-  where
-    eps1, eps2 :: Double
-    eps1 = 1.0 / 2 ^ e1
-    eps2 = 1.0 / 2 ^ e2
-
 testSuite :: TestTree
 testSuite = testGroup "Bilinear"
   [ testGroup "binomial"
@@ -269,17 +192,5 @@ testSuite = testGroup "Bilinear"
     , testCase "B_1"                           bernoulliSpecialCase2
     , testSmallAndQuick "sign"                 bernoulliProperty1
     , testSmallAndQuick "recursive definition" bernoulliProperty2
-    ]
-  , testGroup "zeta"
-    [ testCase "zeta(0)"                          zetasEvenSpecialCase1
-    , testCase "zeta(2)"                          zetasEvenSpecialCase2
-    , testCase "zeta(4)"                          zetasEvenSpecialCase3
-    , testSmallAndQuick "zeta(2n) > zeta(2n+2)"   zetasEvenProperty1
-    , testSmallAndQuick "zetasEven matches zetas" zetasEvenProperty2
-    , testCase "zeta(1)"                          zetasSpecialCase1
-    , testCase "zeta(3)"                          zetasSpecialCase2
-    , testCase "zeta(5)"                          zetasSpecialCase3
-    , testSmallAndQuick "zeta(n) > zeta(n+1)"     zetasProperty1
-    , testSmallAndQuick "precision"               zetasProperty2
     ]
   ]

--- a/test-suite/Math/NumberTheory/ZetaTests.hs
+++ b/test-suite/Math/NumberTheory/ZetaTests.hs
@@ -1,0 +1,116 @@
+-- |
+-- Module:      Math.NumberTheory.ZetaTests
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.Zeta
+--
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.ZetaTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Math.NumberTheory.Zeta
+import Math.NumberTheory.TestUtils
+
+assertEqualUpToEps :: String -> Double -> Double -> Double -> Assertion
+assertEqualUpToEps msg eps expected actual
+  = assertBool msg (abs (expected - actual) < eps)
+
+epsilon :: Double
+epsilon = 1e-14
+
+zetasEvenSpecialCase1 :: Assertion
+zetasEvenSpecialCase1
+  = assertEqual "zeta(0) = -1/2"
+    (approximateValue $ zetasEven !! 0)
+    (-1 / 2)
+
+zetasEvenSpecialCase2 :: Assertion
+zetasEvenSpecialCase2
+  = assertEqualUpToEps "zeta(2) = pi^2/6" epsilon
+    (approximateValue $ zetasEven !! 1)
+    (pi * pi / 6)
+
+zetasEvenSpecialCase3 :: Assertion
+zetasEvenSpecialCase3
+  = assertEqualUpToEps "zeta(4) = pi^4/90" epsilon
+    (approximateValue $ zetasEven !! 2)
+    (pi ^ 4 / 90)
+
+zetasEvenProperty1 :: Positive Int -> Bool
+zetasEvenProperty1 (Positive m)
+  =  zetaM < 1
+  || zetaM > zetaM1
+  where
+    zetaM  = approximateValue (zetasEven !! m)
+    zetaM1 = approximateValue (zetasEven !! (m + 1))
+
+zetasEvenProperty2 :: Positive Int -> Bool
+zetasEvenProperty2 (Positive m)
+  = abs (zetaM - zetaM') < epsilon
+  where
+    zetaM  = approximateValue (zetasEven !! m)
+    zetaM' = zetas' !! (2 * m)
+
+zetas' :: [Double]
+zetas' = zetas epsilon
+
+zetasSpecialCase1 :: Assertion
+zetasSpecialCase1
+  = assertEqual "zeta(1) = Infinity"
+    (zetas' !! 1)
+    (1 / 0)
+
+zetasSpecialCase2 :: Assertion
+zetasSpecialCase2
+  = assertEqualUpToEps "zeta(3) = 1.2020569" epsilon
+    (zetas' !! 3)
+    1.2020569031595942853997381615114499908
+
+zetasSpecialCase3 :: Assertion
+zetasSpecialCase3
+  = assertEqualUpToEps "zeta(5) = 1.0369277" epsilon
+    (zetas' !! 5)
+    1.0369277551433699263313654864570341681
+
+zetasProperty1 :: Positive Int -> Bool
+zetasProperty1 (Positive m)
+  =  zetaM >= zetaM1
+  && zetaM1 >= 1
+  where
+    zetaM  = zetas' !! m
+    zetaM1 = zetas' !! (m + 1)
+
+zetasProperty2 :: NonNegative Int -> NonNegative Int -> Bool
+zetasProperty2 (NonNegative e1) (NonNegative e2)
+  = maximum (take 25 $ drop 2 $ zipWith ((abs .) . (-)) (zetas eps1) (zetas eps2)) < eps1 + eps2
+  where
+    eps1, eps2 :: Double
+    eps1 = 1.0 / 2 ^ e1
+    eps2 = 1.0 / 2 ^ e2
+
+testSuite :: TestTree
+testSuite = testGroup "Zeta"
+  [ testGroup "zetasEven"
+    [ testCase "zeta(0)"                          zetasEvenSpecialCase1
+    , testCase "zeta(2)"                          zetasEvenSpecialCase2
+    , testCase "zeta(4)"                          zetasEvenSpecialCase3
+    , testSmallAndQuick "zeta(2n) > zeta(2n+2)"   zetasEvenProperty1
+    , testSmallAndQuick "zetasEven matches zetas" zetasEvenProperty2
+    ]
+  , testGroup "zetas"
+    [ testCase "zeta(1)"                          zetasSpecialCase1
+    , testCase "zeta(3)"                          zetasSpecialCase2
+    , testCase "zeta(5)"                          zetasSpecialCase3
+    , testSmallAndQuick "zeta(n) > zeta(n+1)"     zetasProperty1
+    , testSmallAndQuick "precision"               zetasProperty2
+    ]
+  ]

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -28,6 +28,7 @@ import qualified Math.NumberTheory.GaussianIntegersTests as Gaussian
 
 import qualified Math.NumberTheory.ArithmeticFunctionsTests as ArithmeticFunctions
 import qualified Math.NumberTheory.UniqueFactorisationTests as UniqueFactorisation
+import qualified Math.NumberTheory.ZetaTests as Zeta
 
 main :: IO ()
 main = defaultMain tests
@@ -73,5 +74,8 @@ tests = testGroup "All"
     ]
   , testGroup "UniqueFactorisation"
     [ UniqueFactorisation.testSuite
+    ]
+  , testGroup "Zeta"
+    [ Zeta.testSuite
     ]
   ]


### PR DESCRIPTION
This PR contains an implementation of [Riemann zeta function](https://en.wikipedia.org/wiki/Riemann_zeta_function) on integer arguments. Riemann zeta function is a crucial ingredient of analytical number theory. 

The implementation is polymorphic by `Floating` type, so end user can use data types with arbitrary floating-point precision instead of `Double`. There is also a function for exact analytical values of zeta function on even arguments.

It would be cool to implement the Riemann zeta function of complex argument (not only integers), but this task requires decent numeric libraries. Namely, I have not found any Haskell implementation of [incomplete gamma function](https://en.wikipedia.org/wiki/Incomplete_gamma_function) in complex domain (not saying about arbitrary precision). Maybe next time :)