### PR TITLE
Remove a function composition from totientSum by using a better choice for triangle

### DIFF
--- a/Math/NumberTheory/MoebiusInversion.hs
+++ b/Math/NumberTheory/MoebiusInversion.hs
@@ -23,11 +23,14 @@ import Math.NumberTheory.Unsafe
 
 -- | @totientSum n@ is, for @n > 0@, the sum of @[totient k | k <- [1 .. n]]@,
 --   computed via generalised Moebius inversion.
---   Arguments less than 1 cause an error to be raised.
+--   See <http://mathworld.wolfram.com/TotientSummatoryFunction.html> for the
+--   formula used for @totientSum@.
 totientSum :: Int -> Integer
-totientSum = (+1) . generalInversion (triangle . fromIntegral)
+totientSum n
+  | n < 1 = 0
+  | otherwise = generalInversion (triangle . fromIntegral) n
   where
-    triangle n = (n*(n-1)) `quot` 2
+    triangle k = (k*(k+1)) `quot` 2
 
 -- | @generalInversion g n@ evaluates the generalised Moebius inversion of @g@
 --   at the argument @n@.

--- a/Math/NumberTheory/MoebiusInversion/Int.hs
+++ b/Math/NumberTheory/MoebiusInversion/Int.hs
@@ -24,11 +24,14 @@ import Math.NumberTheory.Unsafe
 
 -- | @totientSum n@ is, for @n > 0@, the sum of @[totient k | k <- [1 .. n]]@,
 --   computed via generalised Moebius inversion.
---   Arguments less than 1 cause an error to be raised.
+--   See <http://mathworld.wolfram.com/TotientSummatoryFunction.html> for the
+--   formula used for @totientSum@.
 totientSum :: Int -> Int
-totientSum = (+1) . generalInversion triangle
+totientSum n
+  | n < 1 = 0
+  | otherwise = generalInversion (triangle . fromIntegral) n
   where
-    triangle n = (n*(n-1)) `quot` 2
+    triangle k = (k*(k+1)) `quot` 2
 
 -- | @generalInversion g n@ evaluates the generalised Moebius inversion of @g@
 --   at the argument @n@.

--- a/test-suite/Math/NumberTheory/MoebiusInversion/IntTests.hs
+++ b/test-suite/Math/NumberTheory/MoebiusInversion/IntTests.hs
@@ -28,6 +28,12 @@ totientSumProperty (Positive n) = toInteger (totientSum n) == sum (map totient [
 totientSumSpecialCase1 :: Assertion
 totientSumSpecialCase1 = assertEqual "totientSum" 4496 (totientSum 121)
 
+totientSumSpecialCase2 :: Assertion
+totientSumSpecialCase2 = assertEqual "totientSum" 0 (totientSum (-9001))
+
+totientSumZero :: Assertion
+totientSumZero = assertEqual "totientSum" 0 (totientSum 0)
+
 generalInversionProperty :: (Int -> Int) -> Positive Int -> Bool
 generalInversionProperty g (Positive n)
   =  g n == sum [f (n `quot` k) | k <- [1 .. n]]
@@ -40,6 +46,8 @@ testSuite = testGroup "Int"
   [ testGroup "totientSum"
     [ testSmallAndQuick "matches definitions" totientSumProperty
     , testCase          "special case 1"      totientSumSpecialCase1
+    , testCase          "special case 2"      totientSumSpecialCase2
+    , testCase          "zero"                totientSumZero
     ]
   , QC.testProperty "generalInversion" generalInversionProperty
   ]

--- a/test-suite/Math/NumberTheory/MoebiusInversionTests.hs
+++ b/test-suite/Math/NumberTheory/MoebiusInversionTests.hs
@@ -28,6 +28,12 @@ totientSumProperty (Positive n) = totientSum n == sum (map totient [1 .. toInteg
 totientSumSpecialCase1 :: Assertion
 totientSumSpecialCase1 = assertEqual "totientSum" 4496 (totientSum 121)
 
+totientSumSpecialCase2 :: Assertion
+totientSumSpecialCase2 = assertEqual "totientSum" 0 (totientSum (-9001))
+
+totientSumZero :: Assertion
+totientSumZero = assertEqual "totientSum" 0 (totientSum 0)
+
 generalInversionProperty :: (Int -> Integer) -> Positive Int -> Bool
 generalInversionProperty g (Positive n)
   =  g n == sum [f (n `quot` k) | k <- [1 .. n]]
@@ -40,6 +46,8 @@ testSuite = testGroup "MoebiusInversion"
   [ testGroup "totientSum"
     [ testSmallAndQuick "matches definitions" totientSumProperty
     , testCase          "special case 1"      totientSumSpecialCase1
+    , testCase          "special case 2"      totientSumSpecialCase2
+    , testCase          "zero"                totientSumZero
     ]
   , QC.testProperty "generalInversion" generalInversionProperty
   ]


### PR DESCRIPTION
This also better matches the formula described in [mathworld](http://mathworld.wolfram.com/TotientSummatoryFunction.html).
On the other hand, ``totientSum = (`div` 2) . (+1) . generalInversion ((^2) . fromIntegral)`` is another candidate by following the formula from [wikipedia](https://en.wikipedia.org/wiki/Euler%27s_totient_function#Other_formulae), which kills a where clause as well.

The latter *might* offer very minor performance improvements due to shuffling around of arithmetic operations.

I chose to keep using the triangle inversion formula because that was the previously used formula.