### PR TITLE
Factorisation over elliptic curves

### DIFF
--- a/Math/NumberTheory/Curves/Montgomery.hs
+++ b/Math/NumberTheory/Curves/Montgomery.hs
@@ -1,0 +1,160 @@
+-- |
+-- Module:      Math.NumberTheory.Curves.Montgomery
+-- Copyright:   (c) 2017 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- Arithmetic on Montgomery elliptic curve.
+--
+
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Math.NumberTheory.Curves.Montgomery
+  ( Point
+  , pointX
+  , pointZ
+  , pointN
+  , pointA24
+  , SomePoint(..)
+  , newPoint
+  , add
+  , double
+  , multiply
+  ) where
+
+import Data.Proxy
+import GHC.Exts
+import GHC.Integer.GMP.Internals
+import GHC.Integer.Logarithms
+import GHC.TypeLits
+
+-- | We use the Montgomery form of elliptic curve:
+-- b Y² = X³ + a X² + X (mod n).
+-- See Eq. (10.3.1.1) at p. 260 of <http://www.ams.org/journals/mcom/1987-48-177/S0025-5718-1987-0866113-7/S0025-5718-1987-0866113-7.pdf Speeding the Pollard and Elliptic Curve Methods of Factorization> by P. L. Montgomery.
+--
+-- Switching to projective space by substitutions Y = y \/ z, X = x \/ z,
+-- we get b y² z = x³ + a x² z + x z² (mod n).
+-- The point on projective elliptic curve is characterized by three coordinates,
+-- but it appears that only x- and z-components matter for computations.
+-- By the same reason there is no need to store coefficient b.
+--
+-- That said, the chosen curve is represented by a24 = (a + 2) \/ 4
+-- and modulo n at type level, making points on different curves
+-- incompatible.
+data Point (a24 :: Nat) (n :: Nat) = Point
+  { pointX :: !Integer -- ^ Extract x-coordinate.
+  , pointZ :: !Integer -- ^ Extract z-coordinate.
+  }
+
+pointA24 :: forall a24 n. KnownNat a24 => Point a24 n -> Integer
+pointA24 _ = natVal (Proxy :: Proxy a24)
+
+pointN :: forall a24 n. KnownNat n => Point a24 n -> Integer
+pointN _ = natVal (Proxy :: Proxy n)
+
+-- | In projective space 'Point's are equal, if they are both at infinity
+-- or if respective ratios 'pointX' \/ 'pointZ' are equal.
+instance KnownNat n => Eq (Point a24 n) where
+  Point _ 0 == Point _ 0 = True
+  Point _ 0 == _         = False
+  _         == Point _ 0 = False
+  p@(Point x1 z1) == Point x2 z2 = let n = pointN p in x1 * z2 `mod` n == x2 * z1 `mod` n
+
+-- | For debugging.
+instance (KnownNat a24, KnownNat n) => Show (Point a24 n) where
+  show p = "(" ++ show (pointX p) ++ ", " ++ show (pointZ p) ++ ") (mod "
+    ++ show (pointN p) ++ ", a24 "
+    ++ show (pointA24 p) ++ ")"
+
+-- | Point on unknown curve.
+data SomePoint where
+  SomePoint :: (KnownNat a24, KnownNat n) => Point a24 n -> SomePoint
+
+instance Show SomePoint where
+  show (SomePoint p) = show p
+
+-- | 'newPoint' @n@ @s@ creates a point on an elliptic curve modulo @n@, uniquely determined by seed @s@.
+-- Some choices of @n@ and @s@ produce ill-parametrized curves, which is reflected by return value 'Nothing'.
+--
+-- We choose a curve by Suyama's parametrization. See Eq. (3)-(4) at p. 4
+-- of <http://www.hyperelliptic.org/tanja/SHARCS/talks06/Gaj.pdf Implementing the Elliptic Curve Method of Factoring in Reconfigurable Hardware>
+-- by K. Gaj, S. Kwon et al.
+newPoint :: Integer -> Integer -> Maybe SomePoint
+newPoint n s = do
+    a24 <- case a24num of
+      0 -> Nothing
+      _ -> case recipModInteger a24den n of
+        0 -> Nothing
+        t -> Just $ a24num * t `rem` n
+    SomeNat (_ :: Proxy a24Ty) <- someNatVal a24
+    SomeNat (_ :: Proxy nTy)   <- someNatVal n
+    return $ SomePoint (Point x z :: Point a24Ty nTy)
+  where
+    u = s * s `rem` n - 5
+    v = 4 * s
+    d = v - u
+    x = u * u * u `mod` n
+    z = v * v * v `mod` n
+    a24num = d * d * d * (3 * u + v) `rem` n
+    a24den = 16 * x * v `rem` n
+
+-- | If @p0@ + @p1@ = @p2@, then 'add' @p0@ @p1@ @p2@ equals to @p1@ + @p2@.
+-- If the precondition does not hold, return value is undefined.
+-- Remarkably such addition does not require 'KnownNat' @a24@ constraint.
+--
+-- Computations follow Algorithm 3 at p. 4
+-- of <http://www.hyperelliptic.org/tanja/SHARCS/talks06/Gaj.pdf Implementing the Elliptic Curve Method of Factoring in Reconfigurable Hardware>
+-- by K. Gaj, S. Kwon et al.
+add :: KnownNat n => Point a24 n -> Point a24 n -> Point a24 n -> Point a24 n
+add p0@(Point x0 z0) (Point x1 z1) (Point x2 z2) = Point x3 z3
+  where
+    n = pointN p0
+    a = (x1 - z1) * (x2 + z2) `rem` n
+    b = (x1 + z1) * (x2 - z2) `rem` n
+    apb = a + b
+    amb = a - b
+    c = apb * apb `rem` n
+    d = amb * amb `rem` n
+    x3 = c * z0 `mod` n
+    z3 = d * x0 `mod` n
+
+-- | Multiply by 2.
+--
+-- Computations follow Algorithm 3 at p. 4
+-- of <http://www.hyperelliptic.org/tanja/SHARCS/talks06/Gaj.pdf Implementing the Elliptic Curve Method of Factoring in Reconfigurable Hardware>
+-- by K. Gaj, S. Kwon et al.
+double :: forall a24 n. (KnownNat a24, KnownNat n) => Point a24 n -> Point a24 n
+double p@(Point x z) = Point x' z'
+  where
+    n = pointN p
+    a24 = pointA24 p
+    r = x + z
+    s = x - z
+    u = r * r `rem` n
+    v = s * s `rem` n
+    t = u - v
+    x' = u * v `mod` n
+    z' = (v + a24 * t `rem` n) * t `mod` n
+
+-- | Multiply by given number, using binary algorithm.
+multiply :: (KnownNat a24, KnownNat n) => Word -> Point a24 n -> Point a24 n
+multiply 0 _ = Point 0 0
+multiply 1 p = p
+multiply (W# w##) p =
+    case wordLog2# w## of
+      l# -> go (l# -# 1#) p (double p)
+  where
+    go 0# !p0 !p1 = case w## `and#` 1## of
+                      0## -> double p0
+                      _   -> add p p0 p1
+    go i# p0 p1 = case (uncheckedShiftRL# w## i#) `and#` 1## of
+                    0## -> go (i# -# 1#) (double p0) (add p p0 p1)
+                    _   -> go (i# -# 1#) (add p p0 p1) (double p1)

--- a/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
+++ b/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
@@ -237,7 +237,7 @@ curveFactorisation primeBound primeTest prng seed mbdigs n
 --
 --   The result is maybe a nontrivial divisor of @n@.
 montgomeryFactorisation :: KnownNat n => Word -> Word -> Mod n -> Maybe Integer
-montgomeryFactorisation b1 b2 s = case newPoint n (getVal s) of
+montgomeryFactorisation b1 b2 s = case newPoint (getVal s) n of
   Nothing             -> Nothing
   Just (SomePoint p0) -> do
     let p2 = dbln l2 p0

--- a/Math/NumberTheory/Primes/Testing/Certificates/Internal.hs
+++ b/Math/NumberTheory/Primes/Testing/Certificates/Internal.hs
@@ -328,7 +328,7 @@ findFactor n digits s = case findLoop n lo hi count s of
     (lo,hi,count) = findParms digits
 
 -- | Find a factor or say with which curve to continue.
-findLoop :: Integer -> Word -> Word -> Int -> Integer -> Either Integer Integer
+findLoop :: Integer -> Word -> Word -> Word -> Integer -> Either Integer Integer
 findLoop _ _  _  0  s = Left s
 findLoop n lo hi ct s
     | n <= s+2  = Left 6

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -145,6 +145,7 @@ test-suite spec
     build-depends     : semigroups >= 0.8
 
   other-modules :   Math.NumberTheory.ArithmeticFunctionsTests
+                  , Math.NumberTheory.CurvesTests
                   , Math.NumberTheory.GaussianIntegersTests
                   , Math.NumberTheory.GCDTests
                   , Math.NumberTheory.GCD.LowLevelTests

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -50,6 +50,7 @@ library
     exposed-modules     : Math.NumberTheory.ArithmeticFunctions
                           Math.NumberTheory.ArithmeticFunctions.Class
                           Math.NumberTheory.ArithmeticFunctions.Standard
+                          Math.NumberTheory.Curves.Montgomery
                           Math.NumberTheory.Moduli
                           Math.NumberTheory.Moduli.Chinese
                           Math.NumberTheory.Moduli.Class

--- a/test-suite/Math/NumberTheory/CurvesTests.hs
+++ b/test-suite/Math/NumberTheory/CurvesTests.hs
@@ -1,0 +1,95 @@
+-- |
+-- Module:      Math.NumberTheory.CurvesTests
+-- Copyright:   (c) 2017 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.Curves
+--
+
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.CurvesTests where
+
+import Test.Tasty
+import Test.Tasty.QuickCheck as QC hiding (Positive, NonNegative, generate, getNonNegative)
+
+import GHC.TypeLits
+
+import Math.NumberTheory.Curves.Montgomery
+import Math.NumberTheory.TestUtils
+
+#if __GLASGOW_HASKELL__ < 709
+import Data.Word
+#endif
+
+(==>?) :: Maybe a -> (a -> Property) -> Property
+x ==>? f = case x of
+  Nothing -> discard
+  Just y  -> f y
+
+isValid :: KnownNat n => Point a24 n -> Property
+isValid p
+  =    counterexample "x is not reduced by modulo"    (x >= 0 && x < n)
+  .&&. counterexample "z is not reduced by modulo"    (z >= 0 && z < n)
+  .&&. counterexample "infinity point has non-zero x" (z /= 0 || x == 0)
+  where
+    n = pointN p
+    x = pointX p
+    z = pointZ p
+
+isValid' :: KnownNat n => Point a24 n -> Bool
+isValid' p
+  =  (x >= 0 && x < n)
+  && (z >= 0 && z < n)
+  && (z /= 0 || x == 0)
+  where
+    n = pointN p
+    x = pointX p
+    z = pointZ p
+
+newPointRangeProperty :: Shrink2 (Positive Integer) -> Shrink2 Integer -> Property
+newPointRangeProperty (Shrink2 (Positive n)) (Shrink2 s) = newPoint n s ==>? \case
+  SomePoint p -> isValid p
+
+multiplyRangeProperty :: Shrink2 (Positive Integer) -> Shrink2 Integer -> Shrink2 Word -> Property
+multiplyRangeProperty (Shrink2 (Positive n)) (Shrink2 s) (Shrink2 k) = newPoint n s ==>? \case
+  SomePoint p -> isValid' p ==> isValid (multiply k p)
+
+doubleRangeProperty :: Shrink2 (Positive Integer) -> Shrink2 Integer -> Shrink2 Word -> Property
+doubleRangeProperty (Shrink2 (Positive n)) (Shrink2 s) (Shrink2 k) = newPoint n s ==>? \case
+  SomePoint p -> isValid' p ==> isValid' kp ==> isValid (double kp)
+    where
+      kp = multiply k p
+
+addRangeProperty :: Shrink2 (Positive Integer) -> Shrink2 Integer -> Shrink2 Word -> Shrink2 Word -> Property
+addRangeProperty (Shrink2 (Positive n)) (Shrink2 s) (Shrink2 k) (Shrink2 l) = newPoint n s ==>? \case
+  SomePoint p -> isValid' p ==> isValid' kp ==> isValid' lp ==> isValid' klp ==> isValid (add kp lp klp)
+    where
+      kp  = multiply  k      p
+      lp  = multiply      l  p
+      klp = multiply (k + l) p
+
+doubleAndMultiplyProperty :: Shrink2 (Positive Integer) -> Shrink2 Integer -> Shrink2 Word -> Property
+doubleAndMultiplyProperty (Shrink2 (Positive n)) (Shrink2 s) (Shrink2 k) = newPoint n s ==>? \case
+  SomePoint p
+    -> k < maxBound `div` 2 ==> double (multiply k p) === multiply (2 * k) p
+
+addAndMultiplyProperty :: Shrink2 (Positive Integer) -> Shrink2 Integer -> Shrink2 Word -> Shrink2 Word -> Property
+addAndMultiplyProperty (Shrink2 (Positive n)) (Shrink2 s) (Shrink2 k) (Shrink2 l) = newPoint n s ==>? \case
+  SomePoint p
+    -> k < maxBound `div` 3 && l < maxBound `div` 3
+    ==> add (multiply k p) (multiply l p) (multiply (k + l) p) === multiply (k + 2 * l) p
+
+testSuite :: TestTree
+testSuite = localOption (QuickCheckTests 1000) $ testGroup "Montgomery"
+  [ QC.testProperty "range of newPoint"        newPointRangeProperty
+  , QC.testProperty "range of double"          doubleRangeProperty
+  , QC.testProperty "range of add"             addRangeProperty
+  , QC.testProperty "range of multiply"        multiplyRangeProperty
+  , QC.testProperty "double matches multiply"  doubleAndMultiplyProperty
+  , QC.testProperty "add matches multiply"     addAndMultiplyProperty
+  ]

--- a/test-suite/Math/NumberTheory/CurvesTests.hs
+++ b/test-suite/Math/NumberTheory/CurvesTests.hs
@@ -35,7 +35,6 @@ isValid :: KnownNat n => Point a24 n -> Property
 isValid p
   =    counterexample "x is not reduced by modulo"    (x >= 0 && x < n)
   .&&. counterexample "z is not reduced by modulo"    (z >= 0 && z < n)
-  .&&. counterexample "infinity point has non-zero x" (z /= 0 || x == 0)
   where
     n = pointN p
     x = pointX p
@@ -45,47 +44,52 @@ isValid' :: KnownNat n => Point a24 n -> Bool
 isValid' p
   =  (x >= 0 && x < n)
   && (z >= 0 && z < n)
-  && (z /= 0 || x == 0)
   where
     n = pointN p
     x = pointX p
     z = pointZ p
 
-newPointRangeProperty :: Shrink2 (Positive Integer) -> Shrink2 Integer -> Property
-newPointRangeProperty (Shrink2 (Positive n)) (Shrink2 s) = newPoint n s ==>? \case
+newPointRangeProperty :: Shrink2 (Positive Integer) -> Shrink2 (Positive Integer) -> Property
+newPointRangeProperty (Shrink2 (Positive s)) (Shrink2 (Positive n)) = newPoint s n ==>? \case
   SomePoint p -> isValid p
 
-multiplyRangeProperty :: Shrink2 (Positive Integer) -> Shrink2 Integer -> Shrink2 Word -> Property
-multiplyRangeProperty (Shrink2 (Positive n)) (Shrink2 s) (Shrink2 k) = newPoint n s ==>? \case
+multiplyRangeProperty :: Shrink2 (Positive Integer) -> Shrink2 (Positive Integer) -> Shrink2 Word -> Property
+multiplyRangeProperty (Shrink2 (Positive s)) (Shrink2 (Positive n)) (Shrink2 k) = newPoint s n ==>? \case
   SomePoint p -> isValid' p ==> isValid (multiply k p)
 
-doubleRangeProperty :: Shrink2 (Positive Integer) -> Shrink2 Integer -> Shrink2 Word -> Property
-doubleRangeProperty (Shrink2 (Positive n)) (Shrink2 s) (Shrink2 k) = newPoint n s ==>? \case
+doubleRangeProperty :: Shrink2 (Positive Integer) -> Shrink2 (Positive Integer) -> Shrink2 Word -> Property
+doubleRangeProperty (Shrink2 (Positive s)) (Shrink2 (Positive n)) (Shrink2 k) = newPoint s n ==>? \case
   SomePoint p -> isValid' p ==> isValid' kp ==> isValid (double kp)
     where
       kp = multiply k p
 
-addRangeProperty :: Shrink2 (Positive Integer) -> Shrink2 Integer -> Shrink2 Word -> Shrink2 Word -> Property
-addRangeProperty (Shrink2 (Positive n)) (Shrink2 s) (Shrink2 k) (Shrink2 l) = newPoint n s ==>? \case
+addRangeProperty :: Shrink2 (Positive Integer) -> Shrink2 (Positive Integer) -> Shrink2 Word -> Shrink2 Word -> Property
+addRangeProperty (Shrink2 (Positive s)) (Shrink2 (Positive n)) (Shrink2 k) (Shrink2 l) = newPoint s n ==>? \case
   SomePoint p -> isValid' p ==> isValid' kp ==> isValid' lp ==> isValid' klp ==> isValid (add kp lp klp)
     where
       kp  = multiply  k      p
       lp  = multiply      l  p
       klp = multiply (k + l) p
 
-doubleAndMultiplyProperty :: Shrink2 (Positive Integer) -> Shrink2 Integer -> Shrink2 Word -> Property
-doubleAndMultiplyProperty (Shrink2 (Positive n)) (Shrink2 s) (Shrink2 k) = newPoint n s ==>? \case
+doubleAndMultiplyProperty :: Shrink2 (Positive Integer) -> Shrink2 (Positive Integer) -> Shrink2 Word -> Property
+doubleAndMultiplyProperty (Shrink2 (Positive s)) (Shrink2 (Positive n)) (Shrink2 k) = newPoint s n ==>? \case
   SomePoint p
     -> k < maxBound `div` 2 ==> double (multiply k p) === multiply (2 * k) p
 
-addAndMultiplyProperty :: Shrink2 (Positive Integer) -> Shrink2 Integer -> Shrink2 Word -> Shrink2 Word -> Property
-addAndMultiplyProperty (Shrink2 (Positive n)) (Shrink2 s) (Shrink2 k) (Shrink2 l) = newPoint n s ==>? \case
+addAndMultiplyProperty :: Shrink2 (Positive Integer) -> Shrink2 (Positive Integer) -> Shrink2 Word -> Shrink2 Word -> Property
+addAndMultiplyProperty (Shrink2 (Positive s)) (Shrink2 (Positive n)) (Shrink2 k) (Shrink2 l) = newPoint s n ==>? \case
   SomePoint p
-    -> k < maxBound `div` 3 && l < maxBound `div` 3
-    ==> add (multiply k p) (multiply l p) (multiply (k + l) p) === multiply (k + 2 * l) p
+    -> k < maxBound `div` 3 && l < maxBound `div` 3 && pointX kp /= 0 && gcd n (pointZ kp) == 1 && gcd n (pointZ lp) == 1 && gcd n (pointZ klp) == 1
+    ==> add kp lp klp === k2lp
+    where
+      kp   = multiply k           p
+      lp   = multiply l           p
+      klp  = multiply (k + l)     p
+      k2lp = multiply (k + 2 * l) p
 
 testSuite :: TestTree
-testSuite = localOption (QuickCheckTests 1000) $ testGroup "Montgomery"
+testSuite = localOption (QuickCheckMaxRatio 100) $
+  localOption (QuickCheckTests 1000) $ testGroup "Montgomery"
   [ QC.testProperty "range of newPoint"        newPointRangeProperty
   , QC.testProperty "range of double"          doubleRangeProperty
   , QC.testProperty "range of add"             addRangeProperty

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -31,6 +31,7 @@ import qualified Math.NumberTheory.GaussianIntegersTests as Gaussian
 import qualified Math.NumberTheory.ArithmeticFunctionsTests as ArithmeticFunctions
 import qualified Math.NumberTheory.UniqueFactorisationTests as UniqueFactorisation
 import qualified Math.NumberTheory.ZetaTests as Zeta
+import qualified Math.NumberTheory.CurvesTests as Curves
 
 main :: IO ()
 main = defaultMain tests
@@ -80,5 +81,8 @@ tests = testGroup "All"
     ]
   , testGroup "Zeta"
     [ Zeta.testSuite
+    ]
+  , testGroup "Curves"
+    [ Curves.testSuite
     ]
   ]


### PR DESCRIPTION
The aim of this branch is to refactor computational core of factorisation over Montogomery elliptic curve. Here is a changelog:

* Move computations on elliptic curve into separate module. Use more sophisticated types to represent points on a curve, which helps us to avoid mixing points from different curves.
* Write separate tests for arithmetic over elliptic curve.
* #21 Use B1, B2 and CC parameters as per GMP ECM table.
* #23 Fix jumping from tier to tier.
* Rewrite and simplify [Step 1](http://www.mersennewiki.org/index.php/Elliptic_Curve_Method#Step_1) of elliptic factorization. The code was overengineered and prematurely optimized, making it very hard to read and understand. It appeared that all these complications have no measurable impact on performance.
* Reimplement [Step 2](http://www.mersennewiki.org/index.php/Elliptic_Curve_Method#Step_1) in a right way. In fact previous implementation has nothing to do with Step 2, it was actually slightly modified Step 1. This has a great impact on performance, which is witnessed by the following table. For integers, which factors were found on Step 2, timings are drastically lower.

  Benchmark    | v. 0.5.0.1 | branch
  -------------|-----------:|-------:
  factorise50  |     26 ms  |   8 ms
  factorise60  |      6 ms  |   5 ms
  factorise70  |   3053 ms  | 213 ms
  factorise80  |    488 ms  | 169 ms
  factorise90  |     44 ms  |  26 ms
  factorise100 |   4373 ms  |3039 ms

  Nevertheless, there is plenty of room for further improvement. I have done some experiments, but their proper productionalization will take much more time than I have available at the moment. That said, I decided to delay them indefinitely and merge present state of affairs into master.
