### PR TITLE
Use GHC.TypeNats instead of GHC.TypeLits

### DIFF
--- a/GHC/TypeNats/Compat.hs
+++ b/GHC/TypeNats/Compat.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE CPP         #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
+#if MIN_VERSION_base(4,10,0)
+
+module GHC.TypeNats.Compat
+  ( module GHC.TypeNats
+  ) where
+
+import GHC.TypeNats
+
+#else
+
+module GHC.TypeNats.Compat
+  ( Nat
+  , KnownNat
+  , SomeNat(..)
+  , natVal
+  , someNatVal
+  , sameNat
+  ) where
+
+import GHC.TypeLits (Nat, KnownNat, SomeNat(..), sameNat)
+import qualified GHC.TypeLits as TL
+import Numeric.Natural
+
+natVal :: KnownNat n => proxy n -> Natural
+natVal = fromInteger . TL.natVal
+
+someNatVal :: Natural -> SomeNat
+someNatVal n = case TL.someNatVal (toInteger n) of
+  Nothing -> error "someNatVal: impossible negative argument"
+  Just sn -> sn
+
+#endif

--- a/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
+++ b/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
@@ -62,7 +62,7 @@ import qualified Data.IntMap as IM
 import Data.List (foldl')
 import Data.Maybe
 
-import GHC.TypeLits
+import GHC.TypeNats.Compat
 
 import Math.NumberTheory.Curves.Montgomery
 import Math.NumberTheory.Moduli.Class

--- a/Math/NumberTheory/Primes/Testing/Probabilistic.hs
+++ b/Math/NumberTheory/Primes/Testing/Probabilistic.hs
@@ -23,7 +23,7 @@ module Math.NumberTheory.Primes.Testing.Probabilistic
 import Data.Bits
 import GHC.Base
 import GHC.Integer.GMP.Internals
-import GHC.TypeLits
+import GHC.TypeNats.Compat
 
 import Math.NumberTheory.Moduli.Class
 import Math.NumberTheory.Moduli.Jacobi

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -80,6 +80,7 @@ library
                           Math.NumberTheory.Primes.Heap
                           Math.NumberTheory.UniqueFactorisation
                           Math.NumberTheory.Zeta
+                          GHC.TypeNats.Compat
     other-modules       : Math.NumberTheory.Utils
                           Math.NumberTheory.Unsafe
                           Math.NumberTheory.Primes.Counting.Impl

--- a/test-suite/Math/NumberTheory/CurvesTests.hs
+++ b/test-suite/Math/NumberTheory/CurvesTests.hs
@@ -17,7 +17,7 @@ module Math.NumberTheory.CurvesTests where
 import Test.Tasty
 import Test.Tasty.QuickCheck as QC hiding (Positive, NonNegative, generate, getNonNegative)
 
-import GHC.TypeLits
+import GHC.TypeNats.Compat
 
 import Math.NumberTheory.Curves.Montgomery
 import Math.NumberTheory.TestUtils


### PR DESCRIPTION
GHC 8.2 features new `GHC.TypeNats` module, providing a total bijection between usual and type-level naturals. Compare it with `GHC.TypeLits` (which is a thin compatibility layer from now on):

```haskell
GHC.TypeLits.someNatVal :: Integer -> Maybe SomeNat
GHC.TypeNats.someNatVal :: Natural -> SomeNat
```

The latter is much more convenient in applications and allows to avoid "impossible" cases. Here is an example from `Math.NumberTheory.Moduli.Class`:

```diff
 modulo :: Integer -> Natural -> SomeMod
-modulo n m = case someNatVal (toInteger m) of
-  Nothing                       -> error "modulo: negative modulo"
-  Just (SomeNat (_ :: Proxy t)) -> SomeMod (fromInteger n :: Mod t)
+modulo n m = case someNatVal m of
+  SomeNat (_ :: Proxy t) -> SomeMod (fromInteger n :: Mod t)
```

The purpose of the branch is to switch to `GHC.TypeNats` for GHC >= 8.2 and provide compatibility layer for older GHCs.