### PR TITLE
add fsLookup

### DIFF
--- a/Math/NumberTheory/Primes/Factorisation.hs
+++ b/Math/NumberTheory/Primes/Factorisation.hs
@@ -27,6 +27,7 @@ module Math.NumberTheory.Primes.Factorisation
     , FactorSieve
     , factorSieve
     , sieveFactor
+    , sieveSmallestFactor
       -- *** Trial division
     , trialDivisionTo
       -- ** Partial factorisation

--- a/Math/NumberTheory/Primes/Sieve/Misc.hs
+++ b/Math/NumberTheory/Primes/Sieve/Misc.hs
@@ -21,9 +21,9 @@ module Math.NumberTheory.Primes.Sieve.Misc
       -- ** Smallest prime factors
     , factorSieve
     , sieveFactor
+    , sieveSmallestFactor
     , fsBound
     , fsPrimeTest
-    , fsLookup
       -- ** Totients
     , totientSieve
     , sieveTotient
@@ -121,12 +121,12 @@ fsPrimeTest fs@(FS bnd sve) n
     | n <= fromIntegral bnd = sve `unsafeAt` (fromInteger (n `shiftR` 1) - 1) == 0
     | otherwise = error "Out of bounds"
 
--- | @'lookupFactor' fs n@ looks up the smallest prime factor of @n@ in a factor sieve.
+-- | @'sieveSmallestFactor' fs n@ looks up the smallest prime factor of @n@ in a factor sieve.
 --   If @n@ is larger than the sieve can handle, an error is raised.
---   Returns @None@ for @n=1@, which has no prime factors, and @Some 2@ for @n=0@.
-fsLookup :: FactorSieve -> Integer -> Maybe Integer
-fsLookup fs@(FS bnd sve) n
-    | n < 0     = fsLookup fs (-n)
+--   Returns @Just (-1)@ for negative @n@, @Just 2@ for @n == 0@, and @Nothing@ for @n == 1@.
+sieveSmallestFactor :: FactorSieve -> Integer -> Maybe Integer
+sieveSmallestFactor (FS bnd sve) n
+    | n < 0     = Just (-1)
     | n == 1    = Nothing
     | fromInteger n .&. (1 :: Int) == 0 = Just 2
     | n <= fromIntegral bnd = Just $

--- a/Math/NumberTheory/Primes/Sieve/Misc.hs
+++ b/Math/NumberTheory/Primes/Sieve/Misc.hs
@@ -23,6 +23,7 @@ module Math.NumberTheory.Primes.Sieve.Misc
     , sieveFactor
     , fsBound
     , fsPrimeTest
+    , fsLookup
       -- ** Totients
     , totientSieve
     , sieveTotient
@@ -118,6 +119,20 @@ fsPrimeTest fs@(FS bnd sve) n
     | n < 2     = False
     | fromInteger n .&. (1 :: Int) == 0 = n == 2
     | n <= fromIntegral bnd = sve `unsafeAt` (fromInteger (n `shiftR` 1) - 1) == 0
+    | otherwise = error "Out of bounds"
+
+-- | @'lookupFactor' fs n@ looks up the smallest prime factor of @n@ in a factor sieve.
+--   If @n@ is larger than the sieve can handle, an error is raised.
+--   Returns @None@ for @n=1@, which has no prime factors, and @Some 2@ for @n=0@.
+fsLookup :: FactorSieve -> Integer -> Maybe Integer
+fsLookup fs@(FS bnd sve) n
+    | n < 0     = fsLookup fs (-n)
+    | n == 1    = Nothing
+    | fromInteger n .&. (1 :: Int) == 0 = Just 2
+    | n <= fromIntegral bnd = Just $
+         case sve `unsafeAt` (fromInteger (n `shiftR` 1) - 1) of
+             0 -> n
+             p -> fromIntegral p
     | otherwise = error "Out of bounds"
 
 -- | @'sieveFactor' fs n@ finds the prime factorisation of @n@ using the 'FactorSieve' @fs@.

--- a/test-suite/Math/NumberTheory/Primes/FactorisationTests.hs
+++ b/test-suite/Math/NumberTheory/Primes/FactorisationTests.hs
@@ -67,7 +67,7 @@ factoriseProperty6 :: (Integer, [(Integer, Int)]) -> Assertion
 factoriseProperty6 (n, fs) = assertEqual (show n) fs (factorise n)
 
 sieveSmallestFactorProperty1 :: Assertion
-sieveSmallestFactorProperty1 = assertEqual "" (f <$> [-2, -1, 0, 1, 2])
+sieveSmallestFactorProperty1 = assertEqual "" (f `fmap` [-2, -1, 0, 1, 2])
                                               [Just (-1), Just (-1), Just 2, Nothing, Just 2]
   where
     f = sieveSmallestFactor (factorSieve 2)

--- a/test-suite/Math/NumberTheory/Primes/FactorisationTests.hs
+++ b/test-suite/Math/NumberTheory/Primes/FactorisationTests.hs
@@ -17,7 +17,7 @@ module Math.NumberTheory.Primes.FactorisationTests
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Data.List (nub, sort)
+import Data.List (nub, sort, find)
 
 import Math.NumberTheory.Primes.Factorisation
 import Math.NumberTheory.Primes.Testing
@@ -66,6 +66,26 @@ factoriseProperty5 (Positive n) = product (map (uncurry (^)) (factorise n)) == n
 factoriseProperty6 :: (Integer, [(Integer, Int)]) -> Assertion
 factoriseProperty6 (n, fs) = assertEqual (show n) fs (factorise n)
 
+sieveSmallestFactorProperty1 :: Assertion
+sieveSmallestFactorProperty1 = assertEqual "" (f <$> [-2, -1, 0, 1, 2])
+                                              [Just (-1), Just (-1), Just 2, Nothing, Just 2]
+  where
+    f = sieveSmallestFactor (factorSieve 2)
+
+sieveSmallestFactorProperty2 :: Positive Integer -> AnySign Integer -> Bool
+sieveSmallestFactorProperty2 (Positive highBound) (AnySign x)
+  = case (abs x, signum x) of
+     -- factorise error case
+     (0, _) -> sieveSmallestFactor (factorSieve highBound) 0 == Just 2
+     -- sieveSmallestFactor error case
+     (a, s) | a > highBound -> sieveSmallestFactorProperty2 (Positive a) (AnySign $ s * highBound)
+     -- general case
+     _ -> computed == expected
+       where
+         computed = sieveSmallestFactor (factorSieve highBound) x
+         expected = headMay . fmap fst $ factorise x
+         headMay = find (const True)
+
 testSuite :: TestTree
 testSuite = testGroup "Factorisation"
   [ testGroup "factorise" $
@@ -76,4 +96,8 @@ testSuite = testGroup "Factorisation"
     , testSmallAndQuick "factorback"                     factoriseProperty5
     ] ++
     map (\x -> testCase ("special case " ++ show (fst x)) (factoriseProperty6 x)) specialCases
+  , testGroup "sieveSmallestFactor" $
+    [ testCase          "edge cases"            sieveSmallestFactorProperty1
+    , testSmallAndQuick "relation to factorise" sieveSmallestFactorProperty2
+    ]
   ]

--- a/test-suite/Math/NumberTheory/Primes/SieveTests.hs
+++ b/test-suite/Math/NumberTheory/Primes/SieveTests.hs
@@ -58,6 +58,7 @@ psieveFromProperty1 (AnySign lowBound)
   where
     trim = take 1000
 
+
 testSuite :: TestTree
 testSuite = testGroup "Sieve"
   [ testCase          "primes"     primesProperty1

--- a/test-suite/Math/NumberTheory/Primes/SieveTests.hs
+++ b/test-suite/Math/NumberTheory/Primes/SieveTests.hs
@@ -21,8 +21,6 @@ import Prelude hiding (words)
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Data.List (find)
-
 import Math.NumberTheory.Primes.Sieve
 import qualified Math.NumberTheory.Primes.Heap as H
 import Math.NumberTheory.TestUtils
@@ -60,26 +58,6 @@ psieveFromProperty1 (AnySign lowBound)
   where
     trim = take 1000
 
--- definition of edge cases
-fsLookupProperty1 :: Assertion
-fsLookupProperty1 = assertEqual "" (f <$> [-2, -1, 0, 1, 2])
-                                   [Just 2, Nothing, Just 2, Nothing, Just 2]
-  where
-    f = fsLookup (factorSieve 2)
-
-fsLookupProperty2 :: Positive Integer -> AnySign Integer -> Bool
-fsLookupProperty2 (Positive highBound) (AnySign x)
-  = case (abs x, signum x) of
-     -- factorise error case
-     (0, _) -> fsLookup (factorSieve highBound) 0 == Just 2
-     -- fsLookup error case
-     (a, s) | a > highBound -> fsLookupProperty2 (Positive a) (AnySign $ s * highBound)
-     -- general case
-     _ -> computed == expected
-       where
-         computed = fsLookup (factorSieve highBound) x
-         expected = find (> 0) . fmap fst $ factorise x
-
 testSuite :: TestTree
 testSuite = testGroup "Sieve"
   [ testCase          "primes"     primesProperty1
@@ -87,8 +65,4 @@ testSuite = testGroup "Sieve"
   , testSmallAndQuick "primeSieve" primeSieveProperty1
   , testCase          "psieveList" psieveListProperty1
   , testSmallAndQuick "psieveFrom" psieveFromProperty1
-  , testGroup "fsLookup" $
-    [ testCase          "fsLookup edge cases"            fsLookupProperty1
-    , testSmallAndQuick "fsLookup gives smallest factor" fsLookupProperty2
-    ]
   ]


### PR DESCRIPTION
closes #34 

**This commit is broken** (only because Misc isn't exposed), I'm just putting it up to remind myself to come back to it and possibly gather ideas.

I only just now (re)discovered that Primes.Sieve.Misc is not exposed, which means a number of good things I can do:

* I can expose this, `fsBound`, and possibly `fsPrimeTest` from `Factorisation` where they can sit next to `factorSieve`.
* I can also name them `sieveLookup` and etc. for consistency with `sieveFactor`
* There's no need to feel commited to any unusual design choices particular to fsPrimeTest.
