### PR TITLE
Release 0.6.0.0

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,38 @@
+0.6.0.0:
+    This release supports GHC 7.8, 7.10, 8.0 and 8.2.
+
+    Breaking changes:
+
+        'Math.NumberTheory.Moduli' was split into
+        'Math.NumberTheory.Moduli.{Chinese,Class,Jacobi,Sqrt}'.
+
+        Functions 'jacobi' and 'jacobi'' return 'JacobiSymbol'
+        instead of 'Int'.
+
+        Functions 'invertMod', 'powerMod' and 'powerModInteger' were removed,
+        as well as their unchecked counterparts. Use new interface to
+        modular computations, provided by 'Math.NumberTheory.Moduli.Class'.
+
+    New functions:
+
+        Brand new 'Math.NumberTheory.Moduli.Class' (#56), providing
+        flexible and type safe modular arithmetic. Due to use of GMP built-ins
+        it is also significantly faster.
+
+        New function 'divisorsList', which is lazier than 'divisors' and
+        does not require 'Ord' constraint (#64). Thus, it can be used
+        for 'GaussianInteger'.
+
+    Improvements:
+
+        Speed up factorisation over elliptic curve up to 15x (#65).
+
+        Polymorphic 'fibonacci' and 'lucas' functions, which previously
+        were restricted to 'Integer' only (#63). This is especially useful
+        for modular computations, e. g., 'map fibonacci [1..10] :: [Mod 7]'.
+
+        Make 'totientSum' more robust and idiomatic (#58).
+
 0.5.0.1:
     Switch to QuickCheck 2.10.
 

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -1,5 +1,5 @@
 name                : arithmoi
-version             : 0.5.0.1
+version             : 0.6.0.0
 cabal-version       : >= 1.10
 author              : Daniel Fischer
 copyright           : (c) 2011 Daniel Fischer, 2016-2017 Andrew Lelechenko, Carter Schonwald
@@ -22,7 +22,7 @@ description         : A library of basic functionality needed for
 
 category            : Math, Algorithms, Number Theory
 
-tested-with         : GHC==7.8.4, GHC==7.10.3, GHC==8.0.2
+tested-with         : GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.1
 
 extra-source-files  : Changes
 
@@ -129,9 +129,9 @@ test-suite spec
   ghc-options:          -Wall
   main-is:              Test.hs
   default-language: Haskell2010
-  build-depends:        base >= 4.6 && < 5
+  build-depends:        arithmoi
+                      , base >= 4.6 && < 5
                       , containers >= 0.5 && < 0.6
-                      , arithmoi >= 0.5 && < 0.6
                       , tasty >= 0.10 && < 0.12
                       , tasty-smallcheck >= 0.8 && < 0.9
                       , tasty-quickcheck >= 0.9 && < 0.10


### PR DESCRIPTION
    Breaking changes:

        'Math.NumberTheory.Moduli' was split into
        'Math.NumberTheory.Moduli.{Chinese,Class,Jacobi,Sqrt}'.

        Functions 'jacobi' and 'jacobi'' return 'JacobiSymbol'
        instead of 'Int'.

        Functions 'invertMod', 'powerMod' and 'powerModInteger' were removed,
        as well as their unchecked counterparts. Use new interface to
        modular computations, provided by 'Math.NumberTheory.Moduli.Class'.

    New functions:

        Brand new 'Math.NumberTheory.Moduli.Class' (#56), providing
        flexible and type safe modular arithmetic. Due to use of GMP built-ins
        it is also significantly faster.

        New function 'divisorsList', which is lazier than 'divisors' and
        does not require 'Ord' constraint (#64). Thus, it can be used
        for 'GaussianInteger'.

    Improvements:

        Speed up factorisation over elliptic curve up to 15x (#65).

        Polymorphic 'fibonacci' and 'lucas' functions, which previously
        were restricted to 'Integer' only (#63). This is especially useful
        for modular computations, e. g., 'map fibonacci [1..10] :: [Mod 7]'.

        Make 'totientSum' more robust and idiomatic (#58).
