### PR TITLE
Lazy factorisation of huge numbers

### DIFF
--- a/Math/NumberTheory/GCD.hs
+++ b/Math/NumberTheory/GCD.hs
@@ -260,6 +260,8 @@ cw32 (W32# x#) (W32# y#) = coprimeWord# x# y#
 -- having to merge multiplicities of primes, which occurs more than in one
 -- composite factor.
 --
+-- > > splitIntoCoprimes [(140, 1), (165, 1)]
+-- > [(5,2),(28,1),(33,1)]
 -- > > splitIntoCoprimes [(360, 1), (210, 1)]
 -- > [(2,4),(3,3),(5,2),(7,1)]
 splitIntoCoprimes :: (Integral a, Num b) => [(a, b)] -> [(a, b)]

--- a/Math/NumberTheory/GCD.hs
+++ b/Math/NumberTheory/GCD.hs
@@ -20,11 +20,17 @@
 --
 -- When using this module, always compile with optimisations turned on to
 -- benefit from GHC's primops and the rewrite rules.
-{-# LANGUAGE CPP, BangPatterns, MagicHash #-}
+
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP          #-}
+{-# LANGUAGE LambdaCase   #-}
+{-# LANGUAGE MagicHash    #-}
+
 module Math.NumberTheory.GCD
     ( binaryGCD
     , extendedGCD
     , coprime
+    , splitIntoCoprimes
     ) where
 
 import Data.Bits
@@ -245,3 +251,31 @@ cw16 (W16# x#) (W16# y#) = coprimeWord# x# y#
 
 cw32 :: Word32 -> Word32 -> Bool
 cw32 (W32# x#) (W32# y#) = coprimeWord# x# y#
+
+-- | The input list is assumed to be a factorisation of some number
+-- into a list of powers of (possibly, composite) non-zero factors. The output
+-- list is a factorisation of the same number such that all factors
+-- are coprime. Such transformation is crucial to continue factorisation
+-- (lazily, in parallel or concurrent fashion) without
+-- having to merge multiplicities of primes, which occurs more than in one
+-- composite factor.
+--
+-- > > splitIntoCoprimes [(360, 1), (210, 1)]
+-- > [(2,4),(3,3),(5,2),(7,1)]
+splitIntoCoprimes :: (Integral a, Num b) => [(a, b)] -> [(a, b)]
+splitIntoCoprimes = \case
+  [] -> []
+  ((1,  _) : rest) -> splitIntoCoprimes rest
+  ((x, xm) : rest) -> case popSuchThat (\(r, _) -> gcd x r /= 1) rest of
+    Nothing            -> (x, xm) : splitIntoCoprimes rest
+    Just ((y, ym), zs) -> let g = gcd x y in splitIntoCoprimes
+      ((g, xm + ym) : (x `quot` g, xm) : (y `quot` g, ym) : zs)
+
+popSuchThat :: (a -> Bool) -> [a] -> Maybe (a, [a])
+popSuchThat predicate = go
+  where
+    go = \case
+      [] -> Nothing
+      (x : xs)
+        | predicate x -> Just (x, xs)
+        | otherwise   -> fmap (fmap (x :)) (go xs)

--- a/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
+++ b/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
@@ -51,7 +51,7 @@ module Math.NumberTheory.Primes.Factorisation.Montgomery
 
 import Control.Arrow
 import System.Random
-import Control.Monad.State.Strict
+import Control.Monad.State.Lazy
 #if __GLASGOW_HASKELL__ < 709
 import Control.Applicative
 import Data.Word

--- a/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
+++ b/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
@@ -164,6 +164,7 @@ curveFactorisation
   -> Integer                        -- ^ The number to factorise
   -> [(Integer, Int)]               -- ^ List of prime factors and exponents
 curveFactorisation primeBound primeTest prng seed mbdigs n
+    | n == 1    = []
     | ptest n   = [(n, 1)]
     | otherwise = evalState (fact n digits) seed
       where
@@ -180,6 +181,7 @@ curveFactorisation primeBound primeTest prng seed mbdigs n
         perfPw = maybe highestPower (largePFPower . integerSquareRoot') primeBound
 
         fact :: Integer -> Int -> State g [(Integer, Int)]
+        fact 1 _ = return mempty
         fact m digs = do
           let (b1, b2, ct) = findParms digs
           Factors pfs cfs <- repFact m b1 b2 ct
@@ -191,6 +193,7 @@ curveFactorisation primeBound primeTest prng seed mbdigs n
               return $ sconcat $ pfs :| nfs
 
         repFact :: Integer -> Word -> Word -> Word -> State g Factors
+        repFact 1 _ _ _ = return $ Factors [] []
         repFact m b1 b2 count =
           case perfPw m of
             (_, 1) -> workFact m b1 b2 count
@@ -199,6 +202,7 @@ curveFactorisation primeBound primeTest prng seed mbdigs n
               | otherwise -> modifyPowers (* e) <$> workFact b b1 b2 count
 
         workFact :: Integer -> Word -> Word -> Word -> State g Factors
+        workFact 1 _ _ _ = return $ Factors [] []
         workFact m _ _ 0 = return $ Factors [] [(m, 1)]
         workFact m b1 b2 count = do
           s <- rndR m

--- a/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
+++ b/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
@@ -60,7 +60,6 @@ import Data.Bits
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IM
 import Data.List (foldl')
-import Data.List.NonEmpty (NonEmpty(..))
 import Data.Maybe
 import Data.Semigroup
 

--- a/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
+++ b/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
@@ -223,9 +223,12 @@ data Factors = Factors
   , _compositeFactors :: [(Integer, Int)]
   }
 
+-- This instance is valid only if:
+-- 1) for each argument no prime factor divides any composite factor.
+-- 2) numbers, represented by arguments, are coprime.
 instance Semigroup Factors where
   Factors pfs1 cfs1 <> Factors pfs2 cfs2
-    = Factors (pfs1 `merge` pfs2) (cfs1 <> cfs2)
+    = Factors (pfs1 <> pfs2) (cfs1 <> cfs2)
 
 instance Monoid Factors where
   mempty = Factors [] []
@@ -344,16 +347,6 @@ smallFactors bd n = case shiftToOddCount n of
                         (k,r) | r == 1 -> ([(p,k)], Nothing)
                               | otherwise -> (p,k) <: go r ps
     go m [] = ([(m,1)], Nothing)
-
--- helpers: merge sorted lists
-merge :: (Ord a, Num b) => [(a, b)] -> [(a, b)] -> [(a, b)]
-merge xs [] = xs
-merge [] ys = ys
-merge xxs@(x@(p, k) : xs) yys@(y@(q, m) : ys)
-  = case p `compare` q of
-    LT -> x          : merge xs yys
-    EQ -> (p, k + m) : merge xs  ys
-    GT -> y          : merge xxs ys
 
 -- | For a given estimated decimal length of the smallest prime factor
 -- ("tier") return parameters B1, B2 and the number of curves to try

--- a/test-suite/Math/NumberTheory/GCDTests.hs
+++ b/test-suite/Math/NumberTheory/GCDTests.hs
@@ -8,6 +8,7 @@
 -- Tests for Math.NumberTheory.GCD
 --
 
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
@@ -18,7 +19,14 @@ module Math.NumberTheory.GCDTests
 
 import Test.Tasty
 
+import Control.Arrow
 import Data.Bits
+import Data.List (tails)
+#if MIN_VERSION_base(4,8,0)
+#else
+import Data.Word
+#endif
+import Numeric.Natural
 
 import Math.NumberTheory.GCD
 import Math.NumberTheory.TestUtils
@@ -42,9 +50,31 @@ extendedGCDProperty (AnySign a) (AnySign b) =
 coprimeProperty :: (Integral a, Bits a) => AnySign a -> AnySign a -> Bool
 coprimeProperty (AnySign a) (AnySign b) = coprime a b == (gcd a b == 1)
 
+splitIntoCoprimesProperty1 :: [(Positive Natural, Power Word)] -> Bool
+splitIntoCoprimesProperty1 fs' = factorback fs == factorback (splitIntoCoprimes fs)
+  where
+    fs = map (getPositive *** getPower) fs'
+    factorback = product . map (uncurry (^))
+
+splitIntoCoprimesProperty2 :: [(Positive Natural, Power Word)] -> Bool
+splitIntoCoprimesProperty2 fs' = multiplicities fs <= multiplicities (splitIntoCoprimes fs)
+  where
+    fs = map (getPositive *** getPower) fs'
+    multiplicities = sum . map snd . filter ((/= 1) . fst)
+
+splitIntoCoprimesProperty3 :: [(Positive Natural, Power Word)] -> Bool
+splitIntoCoprimesProperty3 fs' = and [ coprime x y | (x : xs) <- tails fs, y <- xs ]
+  where
+    fs = map fst $ splitIntoCoprimes $ map (getPositive *** getPower) fs'
+
 testSuite :: TestTree
 testSuite = testGroup "GCD"
   [ testSameIntegralProperty "binaryGCD"   binaryGCDProperty
   , testSameIntegralProperty "extendedGCD" extendedGCDProperty
   , testSameIntegralProperty "coprime"     coprimeProperty
+  , testGroup "splitIntoCoprimes"
+    [ testSmallAndQuick "preserves product of factors"        splitIntoCoprimesProperty1
+    , testSmallAndQuick "number of factors is non-decreasing" splitIntoCoprimesProperty2
+    , testSmallAndQuick "output factors are coprime"          splitIntoCoprimesProperty3
+    ]
   ]

--- a/test-suite/Math/NumberTheory/Primes/FactorisationTests.hs
+++ b/test-suite/Math/NumberTheory/Primes/FactorisationTests.hs
@@ -64,7 +64,7 @@ factoriseProperty5 :: Positive Integer -> Bool
 factoriseProperty5 (Positive n) = product (map (uncurry (^)) (factorise n)) == n
 
 factoriseProperty6 :: (Integer, [(Integer, Int)]) -> Assertion
-factoriseProperty6 (n, fs) = assertEqual (show n) fs (factorise n)
+factoriseProperty6 (n, fs) = assertEqual (show n) (sort fs) (sort (factorise n))
 
 testSuite :: TestTree
 testSuite = testGroup "Factorisation"

--- a/test-suite/Math/NumberTheory/Primes/FactorisationTests.hs
+++ b/test-suite/Math/NumberTheory/Primes/FactorisationTests.hs
@@ -17,6 +17,7 @@ module Math.NumberTheory.Primes.FactorisationTests
 import Test.Tasty
 import Test.Tasty.HUnit
 
+import Control.Monad (zipWithM_)
 import Data.List (nub, sort)
 
 import Math.NumberTheory.Primes.Factorisation
@@ -46,6 +47,15 @@ specialCases =
   , (16757651897802863152387219654541878166,[(2,1),(23,1),(277,1),(505353699591289,1),(2602436338718275457,1)])
   ]
 
+lazyCases :: [(Integer, [(Integer, Int)])]
+lazyCases =
+  [ ( 14145130711
+    * 10000000000000000000000000000000000000121
+    * 100000000000000000000000000000000000000000000000447
+    , [(14145130711, 1)]
+    )
+  ]
+
 factoriseProperty1 :: Assertion
 factoriseProperty1 = assertEqual "0" [] (factorise 1)
 
@@ -66,6 +76,9 @@ factoriseProperty5 (Positive n) = product (map (uncurry (^)) (factorise n)) == n
 factoriseProperty6 :: (Integer, [(Integer, Int)]) -> Assertion
 factoriseProperty6 (n, fs) = assertEqual (show n) (sort fs) (sort (factorise n))
 
+factoriseProperty7 :: (Integer, [(Integer, Int)]) -> Assertion
+factoriseProperty7 (n, fs) = zipWithM_ (assertEqual (show n)) fs (factorise n)
+
 testSuite :: TestTree
 testSuite = testGroup "Factorisation"
   [ testGroup "factorise" $
@@ -76,4 +89,6 @@ testSuite = testGroup "Factorisation"
     , testSmallAndQuick "factorback"                     factoriseProperty5
     ] ++
     map (\x -> testCase ("special case " ++ show (fst x)) (factoriseProperty6 x)) specialCases
+    ++
+    map (\x -> testCase ("laziness " ++ show (fst x)) (factoriseProperty7 x)) lazyCases
   ]


### PR DESCRIPTION
Function `factorise` is a lazy producer of small factors, but not of bigger ones. If trial division is not enough, factorisation over elliptic curve is invoked, which does not return any factor, until it finds them all. This is inconvenient and redundant in many scenarios, when computations can short-circuit as soon as several first factors were found (for instance, Mobius function). 

The proposed patch eliminate this defect. E. g., now it is possible to compute first factor of huge composite without factoring it completely:

```haskell
> head $ factorise' $ 14145130711 * 10000000000000000000000000000000000000121 * 100000000000000000000000000000000000000000000000447
(14145130711,1)
```

The only (and expected) shortcoming is that the list of factors is no longer sorted. But we never claimed it is, it has always been just an implementation detail.