### PR TITLE
Bulk evaluation of arithmetic functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.hi
+*.o
+stack.yaml

--- a/Math/NumberTheory/ArithmeticFunctions/SieveBlock.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/SieveBlock.hs
@@ -1,0 +1,102 @@
+-- |
+-- Module:      Math.NumberTheory.ArithmeticFunctions.SieveBlock
+-- Copyright:   (c) 2017 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- Bulk evaluation of arithmetic functions.
+--
+
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UnboxedTuples       #-}
+
+module Math.NumberTheory.ArithmeticFunctions.SieveBlock
+  ( runFunctionOverBlock
+  , SieveBlockConfig(..)
+  , sieveBlock
+  , sieveBlockUnboxed
+  ) where
+
+import Control.Monad
+import Control.Monad.ST
+import Data.Coerce
+import qualified Data.Vector as V
+import qualified Data.Vector.Mutable as MV
+import GHC.Exts
+#if __GLASGOW_HASKELL__ < 709
+import Data.Monoid
+#endif
+
+import Math.NumberTheory.ArithmeticFunctions.Class
+import Math.NumberTheory.ArithmeticFunctions.SieveBlock.Unboxed
+import Math.NumberTheory.Primes
+import Math.NumberTheory.Primes.Types
+import Math.NumberTheory.Powers.Squares
+import Math.NumberTheory.Utils (splitOff#)
+import Math.NumberTheory.Utils.FromIntegral
+
+runFunctionOverBlock
+  :: ArithmeticFunction Word a
+  -> Word
+  -> Word
+  -> V.Vector a
+runFunctionOverBlock (ArithmeticFunction f g) lowIndex len = V.map g $ sieveBlock $ SieveBlockConfig
+  { sbcEmpty                = mempty
+  , sbcAppend               = mappend
+  , sbcFunctionOnPrimePower = coerce f
+  , sbcBlockLowBound        = lowIndex
+  , sbcBlockLength          = len
+  }
+
+-- | Similar to 'sieveBlockUnboxed' up to flavour of 'Data.Vector'.
+sieveBlock
+  :: SieveBlockConfig a
+  -> V.Vector a
+sieveBlock (SieveBlockConfig empty append f lowIndex' len') = runST $ do
+
+    let lowIndex :: Int
+        lowIndex = wordToInt lowIndex'
+
+        len :: Int
+        len = wordToInt len'
+
+    as <- V.unsafeThaw $ V.enumFromN lowIndex' len
+    bs <- MV.replicate len empty
+
+    let highIndex :: Int
+        highIndex = lowIndex + len - 1
+
+        ps :: [Int]
+        ps = takeWhile (<= integerSquareRoot highIndex) $ map fromInteger primes
+
+        logToIx :: Double
+        logToIx = log (fromIntegral highIndex)
+
+    forM_ ps $ \p -> do
+
+      let p# :: Word#
+          !p'@(W# p#) = intToWord p
+
+          fs = V.generate
+            (floor (logToIx / log (fromIntegral p) + 0.001))
+            (\k -> f p' (intToWord k + 1))
+
+          offset :: Int
+          offset = negate lowIndex `mod` p
+
+      forM_ [offset, offset + p .. len - 1] $ \ix -> do
+        W# a# <- MV.unsafeRead as ix
+        let !(# pow#, a'# #) = splitOff# p# (a# `quotWord#` p#)
+        MV.unsafeWrite as ix (W# a'#)
+        MV.unsafeModify bs (\y -> y `append` V.unsafeIndex fs (I# pow#)) ix
+
+    forM_ [0 .. MV.length as] $ \k -> do
+      a <- MV.unsafeRead as k
+      MV.unsafeModify bs (\b -> if a /= 1 then b `append` f a 1 else b) k
+
+    V.unsafeFreeze bs

--- a/Math/NumberTheory/ArithmeticFunctions/SieveBlock/Unboxed.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/SieveBlock/Unboxed.hs
@@ -1,0 +1,92 @@
+-- |
+-- Module:      Math.NumberTheory.ArithmeticFunctions.SieveBlock.Unboxed
+-- Copyright:   (c) 2017 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- Bulk evaluation of arithmetic functions without factorisation
+-- of arguments.
+--
+
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UnboxedTuples       #-}
+
+module Math.NumberTheory.ArithmeticFunctions.SieveBlock.Unboxed
+  ( SieveBlockConfig(..)
+  , sieveBlockUnboxed
+  ) where
+
+import Control.Monad
+import Control.Monad.ST
+import qualified Data.Vector.Unboxed as V
+import qualified Data.Vector.Unboxed.Mutable as MV
+import GHC.Exts
+
+import Math.NumberTheory.Primes
+import Math.NumberTheory.Powers.Squares
+import Math.NumberTheory.Utils (splitOff#)
+import Math.NumberTheory.Utils.FromIntegral
+
+data SieveBlockConfig a = SieveBlockConfig
+  { sbcEmpty                :: a
+  , sbcAppend               :: a -> a -> a
+  , sbcFunctionOnPrimePower :: Word -> Word -> a
+  , sbcBlockLowBound        :: Word
+  , sbcBlockLength          :: Word
+  }
+
+sieveBlockUnboxed
+  :: V.Unbox a
+  => SieveBlockConfig a
+  -> V.Vector a
+sieveBlockUnboxed (SieveBlockConfig empty append f lowIndex' len') = runST $ do
+
+    let lowIndex :: Int
+        lowIndex = wordToInt lowIndex'
+
+        len :: Int
+        len = wordToInt len'
+
+    as <- V.unsafeThaw $ V.enumFromN lowIndex' len
+    bs <- MV.replicate len empty
+
+    let highIndex :: Int
+        highIndex = lowIndex + len - 1
+
+        ps :: [Int]
+        ps = takeWhile (<= integerSquareRoot highIndex) $ map fromInteger primes
+
+        logToIx :: Double
+        logToIx = log (fromIntegral highIndex)
+
+    forM_ ps $ \p -> do
+
+      let p# :: Word#
+          !p'@(W# p#) = intToWord p
+
+          fs = V.generate
+            (floor (logToIx / log (fromIntegral p) + 0.001))
+            (\k -> f p' (intToWord k + 1))
+
+          offset :: Int
+          offset = negate lowIndex `mod` p
+
+      forM_ [offset, offset + p .. len - 1] $ \ix -> do
+        W# a# <- MV.unsafeRead as ix
+        let !(# pow#, a'# #) = splitOff# p# (a# `quotWord#` p#)
+        MV.unsafeWrite as ix (W# a'#)
+        MV.unsafeModify bs (\y -> y `append` V.unsafeIndex fs (I# pow#)) ix
+
+    forM_ [0 .. MV.length as] $ \k -> do
+      a <- MV.unsafeRead as k
+      MV.unsafeModify bs (\b -> if a /= 1 then b `append` f a 1 else b) k
+
+    V.unsafeFreeze bs
+
+{-# SPECIALIZE sieveBlockUnboxed :: SieveBlockConfig Int  -> V.Vector Int  #-}
+{-# SPECIALIZE sieveBlockUnboxed :: SieveBlockConfig Word -> V.Vector Word #-}
+{-# SPECIALIZE sieveBlockUnboxed :: SieveBlockConfig Bool -> V.Vector Bool #-}

--- a/Math/NumberTheory/ArithmeticFunctions/SieveBlock/Unboxed.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/SieveBlock/Unboxed.hs
@@ -31,14 +31,40 @@ import Math.NumberTheory.Powers.Squares
 import Math.NumberTheory.Utils (splitOff#)
 import Math.NumberTheory.Utils.FromIntegral
 
+-- | A record of arguments, which specifies both a function to evaluate
+-- and block's bounds.
+--
+-- For example, here is a configuration for the totient function on block [1..1000]:
+--
+-- > SieveBlockConfig
+-- >   { sbcEmpty                = 1
+-- >   , sbcAppend               = (*)
+-- >   , sbcFunctionOnPrimePower = (\p a -> (p - 1) * p ^ (a - 1)
+-- >   , sbcBlockLowBound        = 1
+-- >   , sbcBlockLength          = 1000
+-- >   }
 data SieveBlockConfig a = SieveBlockConfig
   { sbcEmpty                :: a
+    -- ^ value of a function on 1
   , sbcAppend               :: a -> a -> a
+    -- ^ how to combine values of a function on coprime arguments
   , sbcFunctionOnPrimePower :: Word -> Word -> a
+    -- ^ how to evaluate a function on prime powers
   , sbcBlockLowBound        :: Word
+    -- ^ lower bound of the block
   , sbcBlockLength          :: Word
+    -- ^ length of the block
   }
 
+-- | Evaluate a function over a block in accordance to provided configuration.
+-- Value of @f@ at 0, if zero falls into block, is undefined.
+--
+-- Based on Algorithm M of <https://arxiv.org/pdf/1305.1639.pdf Parity of the number of primes in a given interval and algorithms of the sublinear summation> by A. V. Lelechenko. See Lemma 2 on p. 5 on its algorithmic complexity. For the majority of use-cases its time complexity is O(x^(1+ε)).
+--
+-- For example, here is an analogue of divisor function 'tau':
+--
+-- > > sieveBlockUnboxed (SieveBlockConfig 1 (*) (\_ a -> a + 1) 1 10)
+-- > [1,2,2,3,2,4,2,4,3,4]
 sieveBlockUnboxed
   :: V.Unbox a
   => SieveBlockConfig a

--- a/Math/NumberTheory/ArithmeticFunctions/SieveBlock/Unboxed.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/SieveBlock/Unboxed.hs
@@ -17,6 +17,8 @@
 
 module Math.NumberTheory.ArithmeticFunctions.SieveBlock.Unboxed
   ( SieveBlockConfig(..)
+  , multiplicativeSieveBlockConfig
+  , additiveSieveBlockConfig
   , sieveBlockUnboxed
   ) where
 
@@ -26,34 +28,44 @@ import qualified Data.Vector.Unboxed as V
 import qualified Data.Vector.Unboxed.Mutable as MV
 import GHC.Exts
 
+import Math.NumberTheory.Logarithms (integerLogBase')
 import Math.NumberTheory.Primes
 import Math.NumberTheory.Powers.Squares
 import Math.NumberTheory.Utils (splitOff#)
 import Math.NumberTheory.Utils.FromIntegral
 
--- | A record of arguments, which specifies both a function to evaluate
--- and block's bounds.
+-- | A record, which specifies a function to evaluate over a block.
 --
--- For example, here is a configuration for the totient function on block [1..1000]:
+-- For example, here is a configuration for the totient function:
 --
 -- > SieveBlockConfig
 -- >   { sbcEmpty                = 1
--- >   , sbcAppend               = (*)
 -- >   , sbcFunctionOnPrimePower = (\p a -> (p - 1) * p ^ (a - 1)
--- >   , sbcBlockLowBound        = 1
--- >   , sbcBlockLength          = 1000
+-- >   , sbcAppend               = (*)
 -- >   }
 data SieveBlockConfig a = SieveBlockConfig
   { sbcEmpty                :: a
     -- ^ value of a function on 1
-  , sbcAppend               :: a -> a -> a
-    -- ^ how to combine values of a function on coprime arguments
   , sbcFunctionOnPrimePower :: Word -> Word -> a
     -- ^ how to evaluate a function on prime powers
-  , sbcBlockLowBound        :: Word
-    -- ^ lower bound of the block
-  , sbcBlockLength          :: Word
-    -- ^ length of the block
+  , sbcAppend               :: a -> a -> a
+    -- ^ how to combine values of a function on coprime arguments
+  }
+
+-- | Create a config for a multiplicative function from its definition on prime powers.
+multiplicativeSieveBlockConfig :: Num a => (Word -> Word -> a) -> SieveBlockConfig a
+multiplicativeSieveBlockConfig f = SieveBlockConfig
+  { sbcEmpty                = 1
+  , sbcFunctionOnPrimePower = f
+  , sbcAppend               = (*)
+  }
+
+-- | Create a config for an additive function from its definition on prime powers.
+additiveSieveBlockConfig :: Num a => (Word -> Word -> a) -> SieveBlockConfig a
+additiveSieveBlockConfig f = SieveBlockConfig
+  { sbcEmpty                = 0
+  , sbcFunctionOnPrimePower = f
+  , sbcAppend               = (+)
   }
 
 -- | Evaluate a function over a block in accordance to provided configuration.
@@ -68,8 +80,10 @@ data SieveBlockConfig a = SieveBlockConfig
 sieveBlockUnboxed
   :: V.Unbox a
   => SieveBlockConfig a
+  -> Word
+  -> Word
   -> V.Vector a
-sieveBlockUnboxed (SieveBlockConfig empty append f lowIndex' len') = runST $ do
+sieveBlockUnboxed (SieveBlockConfig empty f append) lowIndex' len' = runST $ do
 
     let lowIndex :: Int
         lowIndex = wordToInt lowIndex'
@@ -86,16 +100,13 @@ sieveBlockUnboxed (SieveBlockConfig empty append f lowIndex' len') = runST $ do
         ps :: [Int]
         ps = takeWhile (<= integerSquareRoot highIndex) $ map fromInteger primes
 
-        logToIx :: Double
-        logToIx = log (fromIntegral highIndex)
-
     forM_ ps $ \p -> do
 
       let p# :: Word#
           !p'@(W# p#) = intToWord p
 
           fs = V.generate
-            (floor (logToIx / log (fromIntegral p) + 0.001))
+            (integerLogBase' (toInteger p) (toInteger highIndex))
             (\k -> f p' (intToWord k + 1))
 
           offset :: Int
@@ -113,6 +124,6 @@ sieveBlockUnboxed (SieveBlockConfig empty append f lowIndex' len') = runST $ do
 
     V.unsafeFreeze bs
 
-{-# SPECIALIZE sieveBlockUnboxed :: SieveBlockConfig Int  -> V.Vector Int  #-}
-{-# SPECIALIZE sieveBlockUnboxed :: SieveBlockConfig Word -> V.Vector Word #-}
-{-# SPECIALIZE sieveBlockUnboxed :: SieveBlockConfig Bool -> V.Vector Bool #-}
+{-# SPECIALIZE sieveBlockUnboxed :: SieveBlockConfig Int  -> Word -> Word -> V.Vector Int  #-}
+{-# SPECIALIZE sieveBlockUnboxed :: SieveBlockConfig Word -> Word -> Word -> V.Vector Word #-}
+{-# SPECIALIZE sieveBlockUnboxed :: SieveBlockConfig Bool -> Word -> Word -> V.Vector Bool #-}

--- a/Math/NumberTheory/ArithmeticFunctions/Standard.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/Standard.hs
@@ -46,6 +46,7 @@ import Data.Semigroup
 
 import Math.NumberTheory.ArithmeticFunctions.Class
 import Math.NumberTheory.UniqueFactorisation
+import Math.NumberTheory.Utils.FromIntegral
 
 import Numeric.Natural
 
@@ -54,9 +55,6 @@ import Numeric.Natural
 import Data.Foldable
 import Data.Word
 #endif
-
-wordToInt :: Word -> Int
-wordToInt = fromIntegral
 
 -- | Create a multiplicative function from the function on prime's powers. See examples below.
 multiplicative :: Num a => (Prime n -> Word -> a) -> ArithmeticFunction n a

--- a/Math/NumberTheory/Primes/Sieve/Misc.hs
+++ b/Math/NumberTheory/Primes/Sieve/Misc.hs
@@ -46,6 +46,8 @@ import Math.NumberTheory.Primes.Factorisation.Montgomery
 import Math.NumberTheory.Unsafe
 import Math.NumberTheory.Utils
 
+{-# DEPRECATED FactorSieve, TotientSieve, CarmichaelSieve, factorSieve, sieveFactor, fsBound, fsPrimeTest, totientSieve, sieveTotient, carmichaelSieve, sieveCarmichael "Use new interface for sieves, provided by \"Math.NumberTheory.ArithmeticFunctions.SieveBlock\"" #-}
+
 {-
 IMPORTANT NOTICE: Not all sieves use the same layout!
 

--- a/Math/NumberTheory/Primes/Testing.hs
+++ b/Math/NumberTheory/Primes/Testing.hs
@@ -7,6 +7,9 @@
 -- Portability: Non-portable (GHC extensions)
 --
 -- Primality tests.
+
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
 module Math.NumberTheory.Primes.Testing
     ( -- * Standard tests
       isPrime
@@ -27,6 +30,8 @@ import Math.NumberTheory.Primes.Testing.Probabilistic
 import Math.NumberTheory.Primes.Testing.Certified
 import Math.NumberTheory.Primes.Factorisation.TrialDivision
 import Math.NumberTheory.Primes.Sieve.Misc
+
+{-# DEPRECATED fsIsPrime "Use new interface for sieves, provided by Math.NumberTheory.ArithmeticFunctions.SieveBlock" #-}
 
 -- | Test primality using a 'FactorSieve'. If @n@ is out of bounds
 --   of the sieve, fall back to 'isPrime'.

--- a/Math/NumberTheory/Primes/Types.hs
+++ b/Math/NumberTheory/Primes/Types.hs
@@ -1,0 +1,49 @@
+-- |
+-- Module:      Math.NumberTheory.Primes.Types
+-- Copyright:   (c) 2017 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- This is an internal module, defining types for primes.
+-- Should not be exposed to users.
+--
+
+{-# LANGUAGE CPP          #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Math.NumberTheory.Primes.Types
+  ( Prime
+  , Prm(..)
+  , PrimeNat(..)
+  ) where
+
+#if MIN_VERSION_base(4,8,0)
+#else
+import Data.Word
+#endif
+
+import Numeric.Natural
+
+newtype Prm = Prm { unPrm :: Word }
+  deriving (Eq, Ord)
+
+instance Show Prm where
+  show (Prm p) = "Prm " ++ show p
+
+newtype PrimeNat = PrimeNat { unPrimeNat :: Natural }
+  deriving (Eq, Ord)
+
+instance Show PrimeNat where
+  show (PrimeNat p) = "PrimeNat " ++ show p
+
+-- | Type of primes of a given unique factorisation domain.
+--
+-- @abs (unPrime n) == unPrime n@ must hold for all @n@ of type @Prime t@
+type family Prime (f :: *) :: *
+
+type instance Prime Int     = Prm
+type instance Prime Word    = Prm
+type instance Prime Integer = PrimeNat
+type instance Prime Natural = PrimeNat

--- a/Math/NumberTheory/UniqueFactorisation.hs
+++ b/Math/NumberTheory/UniqueFactorisation.hs
@@ -26,29 +26,11 @@ import Data.Word
 #endif
 
 import Math.NumberTheory.Primes.Factorisation as F (factorise')
+import Math.NumberTheory.Primes.Types (Prime, Prm(..), PrimeNat(..))
 import Math.NumberTheory.GaussianIntegers as G
 import Math.NumberTheory.Utils.FromIntegral
 
 import Numeric.Natural
-
-newtype SmallPrime = SmallPrime { _unSmallPrime :: Word }
-  deriving (Eq, Ord, Show)
-
-newtype BigPrime = BigPrime { _unBigPrime :: Natural }
-  deriving (Eq, Ord, Show)
-
--- | Type of primes of a given unique factorisation domain.
--- When the domain has exactly one unit, @Prime t = t@,
--- but when units are multiple more restricted types
--- (or at least newtypes) should be specified.
---
--- @abs (unPrime n) == unPrime n@ must hold for all @n@ of type @Prime t@
-type family Prime (f :: *) :: *
-
-type instance Prime Int     = SmallPrime
-type instance Prime Word    = SmallPrime
-type instance Prime Integer = BigPrime
-type instance Prime Natural = BigPrime
 
 type instance Prime G.GaussianInteger = GaussianPrime
 

--- a/Math/NumberTheory/UniqueFactorisation.hs
+++ b/Math/NumberTheory/UniqueFactorisation.hs
@@ -27,6 +27,7 @@ import Data.Word
 
 import Math.NumberTheory.Primes.Factorisation as F (factorise')
 import Math.NumberTheory.GaussianIntegers as G
+import Math.NumberTheory.Utils.FromIntegral
 
 import Numeric.Natural
 
@@ -97,27 +98,3 @@ instance UniqueFactorisation G.GaussianInteger where
 
   factorise 0 = []
   factorise g = map (coerce *** intToWord) $ filter (\(h, _) -> abs h /= 1) $ G.factorise g
-
------------
--- Utils
-
-wordToInt :: Word -> Int
-wordToInt = fromIntegral
-
-wordToInteger :: Word -> Integer
-wordToInteger = fromIntegral
-
-intToWord :: Int -> Word
-intToWord = fromIntegral
-
-intToInteger :: Int -> Integer
-intToInteger = fromIntegral
-
-naturalToInteger :: Natural -> Integer
-naturalToInteger = fromIntegral
-
-integerToNatural :: Integer -> Natural
-integerToNatural = fromIntegral
-
-integerToWord :: Integer -> Word
-integerToWord = fromIntegral

--- a/Math/NumberTheory/Utils.hs
+++ b/Math/NumberTheory/Utils.hs
@@ -20,6 +20,7 @@ module Math.NumberTheory.Utils
     , bitCountWord#
     , uncheckedShiftR
     , splitOff
+    , splitOff#
     ) where
 
 #include "MachDeps.h"
@@ -199,3 +200,14 @@ splitOff p n = go 0 n
       (q, 0) -> go (k + 1) q
       _      -> (k, m)
 {-# INLINABLE splitOff #-}
+
+-- | It is difficult to convince GHC to unbox output of 'splitOff' and 'splitOff.go',
+-- so we fallback to a specialized unboxed version to minimize allocations.
+splitOff# :: Word# -> Word# -> (# Int#, Word# #)
+splitOff# _ 0## = (# 0#, 0## #)
+splitOff# p n = go 0# n
+  where
+    go k m = case m `quotRemWord#` p of
+      (# q, 0## #) -> go (k +# 1#) q
+      _            -> (# k, m #)
+{-# INLINABLE splitOff# #-}

--- a/Math/NumberTheory/Utils.hs
+++ b/Math/NumberTheory/Utils.hs
@@ -191,14 +191,11 @@ trailZeros# w =
                 case (v2 `plusWord#` uncheckedShiftRL# v2 4#) `and#` mf## of
                   v3 -> word2Int# (uncheckedShiftRL# (v3 `timesWord#` m1##) sd#)
 
--- {-# SPECIALISE splitOff :: Integer -> Integer -> (Int, Integer),
---                            Int -> Int -> (Int, Int),
---                            Word -> Word -> (Int, Word)
---   #-}
-{-# INLINABLE splitOff #-}
-splitOff :: Integral a => a -> a -> (Int, a)
+splitOff :: Integer -> Integer -> (Int, Integer)
+splitOff _ 0 = (0, 0) -- prevent infinite loop
 splitOff p n = go 0 n
   where
     go !k m = case m `quotRem` p of
-                (q,r) | r == 0 -> go (k+1) q
-                      | otherwise -> (k,m)
+      (q, 0) -> go (k + 1) q
+      _      -> (k, m)
+{-# INLINABLE splitOff #-}

--- a/Math/NumberTheory/Utils/FromIntegral.hs
+++ b/Math/NumberTheory/Utils/FromIntegral.hs
@@ -1,0 +1,55 @@
+-- |
+-- Module:      Math.NumberTheory.Utils.FromIntegral
+-- Copyright:   (c) 2017 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- Monomorphic `fromIntegral`.
+--
+
+{-# LANGUAGE CPP                 #-}
+
+module Math.NumberTheory.Utils.FromIntegral
+  ( wordToInt
+  , wordToInteger
+  , intToWord
+  , intToInteger
+  , naturalToInteger
+  , integerToNatural
+  , integerToWord
+  ) where
+
+import Numeric.Natural
+#if __GLASGOW_HASKELL__ < 709
+import Data.Word
+#endif
+
+wordToInt :: Word -> Int
+wordToInt = fromIntegral
+{-# INLINE wordToInt #-}
+
+wordToInteger :: Word -> Integer
+wordToInteger = fromIntegral
+{-# INLINE wordToInteger #-}
+
+intToWord :: Int -> Word
+intToWord = fromIntegral
+{-# INLINE intToWord #-}
+
+intToInteger :: Int -> Integer
+intToInteger = fromIntegral
+{-# INLINE intToInteger #-}
+
+naturalToInteger :: Natural -> Integer
+naturalToInteger = fromIntegral
+{-# INLINE naturalToInteger #-}
+
+integerToNatural :: Integer -> Natural
+integerToNatural = fromIntegral
+{-# INLINE integerToNatural #-}
+
+integerToWord :: Integer -> Word
+integerToWord = fromIntegral
+{-# INLINE integerToWord #-}

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -93,6 +93,7 @@ library
                           Math.NumberTheory.Primes.Testing.Probabilistic
                           Math.NumberTheory.Primes.Testing.Certified
                           Math.NumberTheory.Primes.Testing.Certificates.Internal
+                          Math.NumberTheory.Primes.Types
     other-extensions          : BangPatterns
 
     ghc-options         : -O2 -Wall

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -42,6 +42,7 @@ library
                         , mtl >= 2.0 && < 2.3
                         , exact-pi >= 0.4.1.1
                         , integer-logarithms >= 1.0
+                        , vector >= 0.12
     if impl(ghc < 7.10)
       build-depends     : nats >= 1 && <1.2
     if impl(ghc < 8.0)
@@ -49,6 +50,7 @@ library
 
     exposed-modules     : Math.NumberTheory.ArithmeticFunctions
                           Math.NumberTheory.ArithmeticFunctions.Class
+                          Math.NumberTheory.ArithmeticFunctions.SieveBlock
                           Math.NumberTheory.ArithmeticFunctions.Standard
                           Math.NumberTheory.Curves.Montgomery
                           Math.NumberTheory.Moduli
@@ -80,7 +82,8 @@ library
                           Math.NumberTheory.UniqueFactorisation
                           Math.NumberTheory.Zeta
                           GHC.TypeNats.Compat
-    other-modules       : Math.NumberTheory.Utils
+    other-modules       : Math.NumberTheory.ArithmeticFunctions.SieveBlock.Unboxed
+                          Math.NumberTheory.Utils
                           Math.NumberTheory.Utils.FromIntegral
                           Math.NumberTheory.Unsafe
                           Math.NumberTheory.Primes.Counting.Impl

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -81,6 +81,7 @@ library
                           Math.NumberTheory.Zeta
                           GHC.TypeNats.Compat
     other-modules       : Math.NumberTheory.Utils
+                          Math.NumberTheory.Utils.FromIntegral
                           Math.NumberTheory.Unsafe
                           Math.NumberTheory.Primes.Counting.Impl
                           Math.NumberTheory.Primes.Counting.Approximate

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -146,12 +146,14 @@ test-suite spec
                       , smallcheck >= 1.1 && < 1.2
                       , transformers >= 0.5
                       , integer-gmp < 1.1
+                      , vector
   if impl(ghc < 7.10)
     build-depends     : nats >= 1 && <1.2
   if impl(ghc < 8.0)
     build-depends     : semigroups >= 0.8
 
   other-modules :   Math.NumberTheory.ArithmeticFunctionsTests
+                  , Math.NumberTheory.ArithmeticFunctions.SieveBlockTests
                   , Math.NumberTheory.CurvesTests
                   , Math.NumberTheory.GaussianIntegersTests
                   , Math.NumberTheory.GCDTests

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -116,12 +116,14 @@ benchmark criterion
                     , containers
                     , random
                     , integer-logarithms
+                    , vector
   if impl(ghc < 7.10)
     build-depends     : nats >= 1 && <1.2
   other-modules:    Math.NumberTheory.ArithmeticFunctionsBench
                   , Math.NumberTheory.PowersBench
                   , Math.NumberTheory.PrimesBench
                   , Math.NumberTheory.RecurrenciesBench
+                  , Math.NumberTheory.SieveBlockBench
   hs-source-dirs:   benchmark
   main-is:          Bench.hs
   type:             exitcode-stdio-1.0

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -6,10 +6,12 @@ import Math.NumberTheory.ArithmeticFunctionsBench as ArithmeticFunctions
 import Math.NumberTheory.PowersBench as Powers
 import Math.NumberTheory.PrimesBench as Primes
 import Math.NumberTheory.RecurrenciesBench as Recurrencies
+import Math.NumberTheory.SieveBlockBench as SieveBlock
 
 main = defaultMain
   [ ArithmeticFunctions.benchSuite
   , Powers.benchSuite
   , Primes.benchSuite
   , Recurrencies.benchSuite
+  , SieveBlock.benchSuite
   ]

--- a/benchmark/Math/NumberTheory/SieveBlockBench.hs
+++ b/benchmark/Math/NumberTheory/SieveBlockBench.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE CPP #-}
+
+module Math.NumberTheory.SieveBlockBench
+  ( benchSuite
+  ) where
+
+import Criterion.Main
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+#if __GLASGOW_HASKELL__ < 709
+import Data.Word
+#endif
+
+import Math.NumberTheory.ArithmeticFunctions.SieveBlock
+import Math.NumberTheory.Primes.Factorisation (totientSieve, sieveTotient, carmichaelSieve, sieveCarmichael)
+
+blockLen :: Word
+blockLen = 10^6
+
+totientHelper :: Word -> Word -> Word
+totientHelper p 1 = p - 1
+totientHelper p 2 = (p - 1) * p
+totientHelper p k = (p - 1) * p ^ (k - 1)
+
+totientBlockConfig :: SieveBlockConfig Word
+totientBlockConfig = SieveBlockConfig
+  { sbcEmpty                = 1
+  , sbcAppend               = (*)
+  , sbcFunctionOnPrimePower = totientHelper
+  , sbcBlockLowBound        = 1
+  , sbcBlockLength          = blockLen
+  }
+
+sumOldTotientSieve :: Word -> Word
+sumOldTotientSieve len' = sum $ map (fromInteger . sieveTotient sieve) [1 .. len]
+  where
+    len = toInteger len'
+    sieve = totientSieve len
+
+carmichaelHelper :: Word -> Word -> Word
+carmichaelHelper 2 1 = 1
+carmichaelHelper 2 2 = 2
+carmichaelHelper 2 k = 2 ^ (k - 2)
+carmichaelHelper p 1 = p - 1
+carmichaelHelper p 2 = (p - 1) * p
+carmichaelHelper p k = (p - 1) * p ^ (k - 1)
+
+carmichaelBlockConfig :: SieveBlockConfig Word
+carmichaelBlockConfig = SieveBlockConfig
+  { sbcEmpty                = 1
+  -- There is a specialized 'gcd' for Word, but not 'lcm'.
+  , sbcAppend               = (\x y -> (x `quot` (gcd x y)) * y)
+  , sbcFunctionOnPrimePower = carmichaelHelper
+  , sbcBlockLowBound        = 1
+  , sbcBlockLength          = blockLen
+  }
+
+sumOldCarmichaelSieve :: Word -> Word
+sumOldCarmichaelSieve len' = sum $ map (fromInteger . sieveCarmichael sieve) [1 .. len]
+  where
+    len = toInteger len'
+    sieve = carmichaelSieve len
+
+benchSuite = bgroup "SieveBlock"
+  [ bgroup "totient"
+    [ bench "old"     $ nf sumOldTotientSieve blockLen
+    , bench "boxed"   $ nf (V.sum . sieveBlock) totientBlockConfig
+    , bench "unboxed" $ nf (U.sum . sieveBlockUnboxed) totientBlockConfig
+    ]
+  , bgroup "carmichael"
+    [ bench "old"     $ nf sumOldCarmichaelSieve blockLen
+    , bench "boxed"   $ nf (V.sum . sieveBlock)        carmichaelBlockConfig
+    , bench "unboxed" $ nf (U.sum . sieveBlockUnboxed) carmichaelBlockConfig
+    ]
+  ]

--- a/benchmark/Math/NumberTheory/SieveBlockBench.hs
+++ b/benchmark/Math/NumberTheory/SieveBlockBench.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP #-}
 
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
 module Math.NumberTheory.SieveBlockBench
   ( benchSuite
   ) where

--- a/benchmark/Math/NumberTheory/SieveBlockBench.hs
+++ b/benchmark/Math/NumberTheory/SieveBlockBench.hs
@@ -29,8 +29,6 @@ totientBlockConfig = SieveBlockConfig
   { sbcEmpty                = 1
   , sbcAppend               = (*)
   , sbcFunctionOnPrimePower = totientHelper
-  , sbcBlockLowBound        = 1
-  , sbcBlockLength          = blockLen
   }
 
 sumOldTotientSieve :: Word -> Word
@@ -53,8 +51,6 @@ carmichaelBlockConfig = SieveBlockConfig
   -- There is a specialized 'gcd' for Word, but not 'lcm'.
   , sbcAppend               = (\x y -> (x `quot` (gcd x y)) * y)
   , sbcFunctionOnPrimePower = carmichaelHelper
-  , sbcBlockLowBound        = 1
-  , sbcBlockLength          = blockLen
   }
 
 sumOldCarmichaelSieve :: Word -> Word
@@ -66,12 +62,12 @@ sumOldCarmichaelSieve len' = sum $ map (fromInteger . sieveCarmichael sieve) [1 
 benchSuite = bgroup "SieveBlock"
   [ bgroup "totient"
     [ bench "old"     $ nf sumOldTotientSieve blockLen
-    , bench "boxed"   $ nf (V.sum . sieveBlock) totientBlockConfig
-    , bench "unboxed" $ nf (U.sum . sieveBlockUnboxed) totientBlockConfig
+    , bench "boxed"   $ nf (V.sum . sieveBlock        totientBlockConfig 1) blockLen
+    , bench "unboxed" $ nf (U.sum . sieveBlockUnboxed totientBlockConfig 1) blockLen
     ]
   , bgroup "carmichael"
     [ bench "old"     $ nf sumOldCarmichaelSieve blockLen
-    , bench "boxed"   $ nf (V.sum . sieveBlock)        carmichaelBlockConfig
-    , bench "unboxed" $ nf (U.sum . sieveBlockUnboxed) carmichaelBlockConfig
+    , bench "boxed"   $ nf (V.sum . sieveBlock        carmichaelBlockConfig 1) blockLen
+    , bench "unboxed" $ nf (U.sum . sieveBlockUnboxed carmichaelBlockConfig 1) blockLen
     ]
   ]

--- a/test-suite/Math/NumberTheory/ArithmeticFunctions/SieveBlockTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctions/SieveBlockTests.hs
@@ -1,0 +1,66 @@
+-- |
+-- Module:      Math.NumberTheory.ArithmeticFunctions.SieveBlockTests
+-- Copyright:   (c) 2016 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.ArithmeticFunctions.SieveBlock
+--
+
+{-# LANGUAGE CPP       #-}
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.ArithmeticFunctions.SieveBlockTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+#if __GLASGOW_HASKELL__ < 709
+import Data.Word
+#endif
+
+import Math.NumberTheory.ArithmeticFunctions
+import Math.NumberTheory.ArithmeticFunctions.SieveBlock
+
+pointwiseTest :: (Eq a, Show a) => ArithmeticFunction Word a -> Word -> Word -> IO ()
+pointwiseTest f lowIndex len = assertEqual "pointwise"
+    (runFunctionOverBlock f lowIndex len)
+    (V.generate (fromIntegral len) (runFunction f . (+ lowIndex) . fromIntegral))
+
+unboxedTest :: (Eq a, U.Unbox a, Show a) => SieveBlockConfig a -> IO ()
+unboxedTest config = assertEqual "unboxed"
+    (U.convert $ sieveBlock config)
+    (sieveBlockUnboxed config)
+
+multiplicativeConfig :: (Word -> Word -> Word) -> SieveBlockConfig Word
+multiplicativeConfig f = SieveBlockConfig
+  { sbcEmpty                = 1
+  , sbcAppend               = (*)
+  , sbcFunctionOnPrimePower = f
+  , sbcBlockLowBound        = 1
+  , sbcBlockLength          = 1000
+  }
+
+testSuite :: TestTree
+testSuite = testGroup "SieveBlock"
+  [ testGroup "pointwise"
+    [ testCase "divisors"   $ pointwiseTest divisorsA   1 1000
+    , testCase "tau"        $ pointwiseTest tauA        1 1000
+    , testCase "totient"    $ pointwiseTest totientA    1 1000
+    , testCase "moebius"    $ pointwiseTest moebiusA    1 1000
+    , testCase "smallOmega" $ pointwiseTest smallOmegaA 1 1000
+    , testCase "bigOmega"   $ pointwiseTest bigOmegaA   1 1000
+    , testCase "carmichael" $ pointwiseTest carmichaelA 1 1000
+    ]
+  , testGroup "unboxed"
+    [ testCase "id"      $ unboxedTest $ multiplicativeConfig (^)
+    , testCase "tau"     $ unboxedTest $ multiplicativeConfig (const id)
+    , testCase "totient" $ unboxedTest $ multiplicativeConfig (\p a -> (p - 1) * p ^ (a - 1))
+    ]
+  ]

--- a/test-suite/Math/NumberTheory/ArithmeticFunctions/SieveBlockTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctions/SieveBlockTests.hs
@@ -35,16 +35,14 @@ pointwiseTest f lowIndex len = assertEqual "pointwise"
 
 unboxedTest :: (Eq a, U.Unbox a, Show a) => SieveBlockConfig a -> IO ()
 unboxedTest config = assertEqual "unboxed"
-    (U.convert $ sieveBlock config)
-    (sieveBlockUnboxed config)
+    (U.convert $ sieveBlock config 1 1000)
+    (sieveBlockUnboxed config 1 1000)
 
 multiplicativeConfig :: (Word -> Word -> Word) -> SieveBlockConfig Word
 multiplicativeConfig f = SieveBlockConfig
   { sbcEmpty                = 1
   , sbcAppend               = (*)
   , sbcFunctionOnPrimePower = f
-  , sbcBlockLowBound        = 1
-  , sbcBlockLength          = 1000
   }
 
 testSuite :: TestTree

--- a/test-suite/Math/NumberTheory/ArithmeticFunctionsTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctionsTests.hs
@@ -10,6 +10,7 @@
 
 {-# LANGUAGE CPP       #-}
 
+{-# OPTIONS_GHC -fno-warn-deprecations  #-}
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 module Math.NumberTheory.ArithmeticFunctionsTests

--- a/test-suite/Math/NumberTheory/PrimesTests.hs
+++ b/test-suite/Math/NumberTheory/PrimesTests.hs
@@ -8,6 +8,7 @@
 -- Tests for Math.NumberTheory.Primes
 --
 
+{-# OPTIONS_GHC -fno-warn-deprecations  #-}
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 module Math.NumberTheory.PrimesTests

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -28,6 +28,7 @@ import qualified Math.NumberTheory.Primes.TestingTests as Testing
 import qualified Math.NumberTheory.GaussianIntegersTests as Gaussian
 
 import qualified Math.NumberTheory.ArithmeticFunctionsTests as ArithmeticFunctions
+import qualified Math.NumberTheory.ArithmeticFunctions.SieveBlockTests as SieveBlock
 import qualified Math.NumberTheory.UniqueFactorisationTests as UniqueFactorisation
 import qualified Math.NumberTheory.ZetaTests as Zeta
 import qualified Math.NumberTheory.CurvesTests as Curves
@@ -73,6 +74,7 @@ tests = testGroup "All"
     ]
   , testGroup "ArithmeticFunctions"
     [ ArithmeticFunctions.testSuite
+    , SieveBlock.testSuite
     ]
   , testGroup "UniqueFactorisation"
     [ UniqueFactorisation.testSuite


### PR DESCRIPTION
This patch features a fast bulk evaluation of arithmetic functions. It replaces `FactorSieve`, `TotientSieve`, `CarmichaelSieve` with a unified and extendable interface and makes results freely explorable. 

It is a first step to #60, because it introduces an almost linear algorithm to sum up any arithmetic function. It also resolves #36: new unboxed sieves are about 2x faster and can be used for any function, not only totient and Carmichael ones. It allows to get the smallest prime factor of a number, which was requested in #34 and #67.