### PR TITLE
Resolves the Conflict of `Mod` between `Math.NumberTheory.Moduli` and `GHC.TypeNats` in ghc >= 8.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,15 @@ matrix:
       compiler: "GHC 8.2.2"
       addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head BENCH=enable
+      compiler: "GHC 8.4.1"
+      addons: {apt: {packages: [cabal-install-head,ghc-head],  sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=8.4.1 BENCH=enable
       compiler: "GHC HEAD"
       addons: {apt: {packages: [cabal-install-head,ghc-head],  sources: [hvr-ghc]}}
 
   allow_failures:
    - env: CABALVER=head GHCVER=head BENCH=enable
+   - env: CABALVER=head GHCVER=8.4.1 BENCH=enable
 
 before_install:
  - unset CC

--- a/GHC/TypeNats/Compat.hs
+++ b/GHC/TypeNats/Compat.hs
@@ -1,15 +1,16 @@
 {-# LANGUAGE CPP         #-}
 
 {-# OPTIONS_HADDOCK hide #-}
-
 #if MIN_VERSION_base(4,10,0)
-
 module GHC.TypeNats.Compat
   ( module GHC.TypeNats
   ) where
 
+#if MIN_VERSION_base(4,11,0)
+import GHC.TypeNats hiding (Mod)
+#else
 import GHC.TypeNats
-
+#endif
 #else
 
 module GHC.TypeNats.Compat


### PR DESCRIPTION
Coming GHC 8.4 includes type-level `Mod` function for taking modulus of type-level natural.
This conflicts `Math.NumberTheory.Moduli.Mod` of `arithmoi`, preventing `arithmoi` from compiling with GHC >= 8.4.

This pull request simply hides `GHC.TypeNats.Mod` if `base >= 4.11` in `GHC.TypeNats.Compat`.