### PR TITLE
Primitive roots and cyclic groups

### DIFF
--- a/Math/NumberTheory/GCD.hs
+++ b/Math/NumberTheory/GCD.hs
@@ -264,14 +264,18 @@ cw32 (W32# x#) (W32# y#) = coprimeWord# x# y#
 -- > [(5,2),(28,1),(33,1)]
 -- > > splitIntoCoprimes [(360, 1), (210, 1)]
 -- > [(2,4),(3,3),(5,2),(7,1)]
-splitIntoCoprimes :: (Integral a, Num b) => [(a, b)] -> [(a, b)]
-splitIntoCoprimes = \case
-  [] -> []
-  ((1,  _) : rest) -> splitIntoCoprimes rest
-  ((x, xm) : rest) -> case popSuchThat (\(r, _) -> gcd x r /= 1) rest of
-    Nothing            -> (x, xm) : splitIntoCoprimes rest
-    Just ((y, ym), zs) -> let g = gcd x y in splitIntoCoprimes
-      ((g, xm + ym) : (x `quot` g, xm) : (y `quot` g, ym) : zs)
+splitIntoCoprimes :: (Integral a, Eq b, Num b) => [(a, b)] -> [(a, b)]
+splitIntoCoprimes xs = if any ((== 0) . fst) ys then [(0, 1)] else go ys
+  where
+    ys = filter (/= (0, 0)) xs
+
+    go = \case
+      [] -> []
+      ((1,  _) : rest) -> go rest
+      ((x, xm) : rest) -> case popSuchThat (\(r, _) -> gcd x r /= 1) rest of
+        Nothing            -> (x, xm) : go rest
+        Just ((y, ym), zs) -> let g = gcd x y in
+          go ((g, xm + ym) : (x `quot` g, xm) : (y `quot` g, ym) : zs)
 
 popSuchThat :: (a -> Bool) -> [a] -> Maybe (a, [a])
 popSuchThat predicate = go

--- a/Math/NumberTheory/Moduli/Class.hs
+++ b/Math/NumberTheory/Moduli/Class.hs
@@ -9,14 +9,15 @@
 -- Safe modular arithmetic with modulo on type level.
 --
 
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 
 module Math.NumberTheory.Moduli.Class
   ( -- * Known modulo
@@ -66,10 +67,14 @@ import GHC.Natural (Natural, powModNatural)
 --
 -- Note that modulo cannot be negative.
 newtype Mod (m :: Nat) = Mod Natural
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Enum)
 
 instance KnownNat m => Show (Mod m) where
   show m = "(" ++ show (getVal m) ++ " `modulo` " ++ show (getMod m) ++ ")"
+
+instance KnownNat m => Bounded (Mod m) where
+  minBound = Mod 0
+  maxBound = let mx = Mod (getNatMod mx - 1) in mx
 
 instance KnownNat m => Num (Mod m) where
   mx@(Mod x) + Mod y =

--- a/Math/NumberTheory/Moduli/Class.hs
+++ b/Math/NumberTheory/Moduli/Class.hs
@@ -40,12 +40,18 @@ module Math.NumberTheory.Moduli.Class
 import Data.Proxy
 import Data.Ratio
 import Data.Type.Equality
-#if __GLASGOW_HASKELL__ < 709
-import Data.Word
-#endif
 import GHC.Integer.GMP.Internals
 import GHC.TypeNats.Compat
-import Numeric.Natural
+
+#if __GLASGOW_HASKELL__ < 709
+import Data.Word
+import Numeric.Natural (Natural)
+
+powModNatural :: Natural -> Natural -> Natural -> Natural
+powModNatural b e m = fromInteger $ powModInteger (toInteger b) (toInteger e) (toInteger m)
+#else
+import GHC.Natural (Natural, powModNatural)
+#endif
 
 -- | Wrapper for residues modulo @m@.
 --
@@ -148,7 +154,7 @@ invertMod mx
 powMod :: (KnownNat m, Integral a) => Mod m -> a -> Mod m
 powMod mx a
   | a < 0     = error $ "^{Mod}: negative exponent"
-  | otherwise = Mod $ fromInteger $ powModInteger (getVal mx) (toInteger a) (getMod mx)
+  | otherwise = Mod $ powModNatural (getNatVal mx) (fromIntegral a) (getNatMod mx)
 {-# INLINABLE [1] powMod #-}
 
 {-# SPECIALISE [1] powMod ::

--- a/Math/NumberTheory/Moduli/PrimitiveRoot.hs
+++ b/Math/NumberTheory/Moduli/PrimitiveRoot.hs
@@ -1,0 +1,148 @@
+-- |
+-- Module:      Math.NumberTheory.Moduli.PrimitiveRoot
+-- Copyright:   (c) 2017 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- Primitive roots and cyclic groups.
+--
+
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TupleSections        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Math.NumberTheory.Moduli.PrimitiveRoot
+  ( isPrimitiveRoot
+    -- * Cyclic groups
+  , CyclicGroup(..)
+  , cyclicGroupFromModulo
+  , cyclicGroupToModulo
+  , isPrimitiveRoot'
+  ) where
+
+#if !(MIN_VERSION_base(4,8,0))
+import Control.Applicative
+import Data.Word
+#endif
+
+import Math.NumberTheory.ArithmeticFunctions (totient)
+import Math.NumberTheory.Moduli (Mod, getNatMod, getNatVal, KnownNat)
+import Math.NumberTheory.Powers.General (highestPower)
+import Math.NumberTheory.Powers.Modular
+import Math.NumberTheory.Prefactored
+import Math.NumberTheory.UniqueFactorisation
+import Math.NumberTheory.Utils.FromIntegral
+
+-- | A multiplicative group of residues is called cyclic,
+-- if there is a primitive root @g@,
+-- whose powers generates all elements.
+-- Any cyclic multiplicative group of residues
+-- falls into one of the following cases.
+data CyclicGroup a
+  = CG2 -- ^ Residues modulo 2.
+  | CG4 -- ^ Residues modulo 4.
+  | CGOddPrimePower       (Prime a) Word
+  -- ^ Residues modulo @p@^@k@ for __odd__ prime @p@.
+  | CGDoubleOddPrimePower (Prime a) Word
+  -- ^ Residues modulo 2@p@^@k@ for __odd__ prime @p@.
+
+deriving instance Show (Prime a) => Show (CyclicGroup a)
+
+-- | Check whether a multiplicative group of residues,
+-- characterized by its modulo, is cyclic and, if yes, return its form.
+--
+-- > > cyclicGroupFromModulo 4
+-- > Just CG4
+-- > > cyclicGroupFromModulo (2 * 13 ^ 3)
+-- > Just (CGDoubleOddPrimePower (PrimeNat 13) 3)
+-- > > cyclicGroupFromModulo (4 * 13)
+-- > Nothing
+cyclicGroupFromModulo
+  :: (Ord a, Integral a, UniqueFactorisation a)
+  => a
+  -> Maybe (CyclicGroup a)
+cyclicGroupFromModulo = \case
+  2 -> Just CG2
+  4 -> Just CG4
+  n
+    | n <= 1    -> Nothing
+    | odd n     -> uncurry CGOddPrimePower       <$> isPrimePower n
+    | odd halfN -> uncurry CGDoubleOddPrimePower <$> isPrimePower halfN
+    | otherwise -> Nothing
+    where
+      halfN = n `quot` 2
+
+isPrimePower
+  :: (Integral a, UniqueFactorisation a)
+  => a
+  -> Maybe (Prime a, Word)
+isPrimePower n = (, intToWord k) <$> isPrime m
+  where
+    (m, k) = highestPower n
+
+-- | Extract modulo and its factorisation from
+-- a cyclic multiplicative group of residues.
+--
+-- > > cyclicGroupToModulo CG4
+-- > Prefactored {prefValue = 4, prefFactors = [(2, 2)]}
+-- > > cyclicGroupToModulo (CGDoubleOddPrimePower (PrimeNat 13) 3)
+-- > Prefactored {prefValue = 4394, prefFactors = [(2, 1), (13, 3)]}
+cyclicGroupToModulo
+  :: (Integral a, UniqueFactorisation a)
+  => CyclicGroup a
+  -> Prefactored a
+cyclicGroupToModulo = fromFactors . \case
+  CG2                       -> [(2, 1)]
+  CG4                       -> [(2, 2)]
+  CGOddPrimePower p k       -> [(unPrime p, k)]
+  CGDoubleOddPrimePower p k -> [(2, 1), (unPrime p, k)]
+
+-- | 'isPrimitiveRoot'' @cg@ @a@ checks whether @a@ is
+-- a <https://en.wikipedia.org/wiki/Primitive_root_modulo_n primitive root>
+-- of a given cyclic multiplicative group of residues @cg@.
+--
+-- > > let Just cg = cyclicGroupFromModulo 13
+-- > > isPrimitiveRoot cg 1
+-- > False
+-- > > isPrimitiveRoot cg 2
+-- > True
+isPrimitiveRoot'
+  :: (Integral a, UniqueFactorisation a)
+  => CyclicGroup a
+  -> a
+  -> Bool
+isPrimitiveRoot' cg r = r /= 0 && gcd r (prefValue m) == 1 && all (/= 1) exps
+  where
+    -- https://en.wikipedia.org/wiki/Primitive_root_modulo_n#Finding_primitive_roots
+    m    = cyclicGroupToModulo cg
+    phi  = totient m
+    pows = map (\pk -> prefValue phi `quot` unPrime (fst pk)) (factorise phi)
+    exps = map (\p -> powMod r p (prefValue m)) pows
+
+-- | Check whether a given modular residue is
+-- a <https://en.wikipedia.org/wiki/Primitive_root_modulo_n primitive root>.
+--
+-- > > isPrimitiveRoot (1 :: Mod 13)
+-- > False
+-- > > isPrimitiveRoot (2 :: Mod 13)
+-- > True
+--
+-- Here is how to list all primitive roots:
+--
+-- > > filter isPrimitiveRoot [minBound .. maxBound] :: [Mod 13]
+-- > [(2 `modulo` 13), (6 `modulo` 13), (7 `modulo` 13), (11 `modulo` 13)]
+--
+-- This function is a convenient wrapper around 'isPrimitiveRoot''. The latter
+-- provides better control and performance, if you need them.
+isPrimitiveRoot
+  :: KnownNat n
+  => Mod n
+  -> Bool
+isPrimitiveRoot r = case cyclicGroupFromModulo (getNatMod r) of
+  Nothing -> False
+  Just cg -> isPrimitiveRoot' cg (getNatVal r)

--- a/Math/NumberTheory/Powers.hs
+++ b/Math/NumberTheory/Powers.hs
@@ -32,9 +32,13 @@ module Math.NumberTheory.Powers
   , exactRoot
   , isPerfectPower
   , highestPower
+    -- * Modular powers
+  , powMod
   ) where
 
 import Math.NumberTheory.Powers.Squares
 import Math.NumberTheory.Powers.Cubes
 import Math.NumberTheory.Powers.Fourth
 import Math.NumberTheory.Powers.General
+
+import Math.NumberTheory.Powers.Modular

--- a/Math/NumberTheory/Powers/Modular.hs
+++ b/Math/NumberTheory/Powers/Modular.hs
@@ -1,0 +1,97 @@
+-- |
+-- Module:      Math.NumberTheory.Powers.Modular
+-- Copyright:   (c) 2017 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- Modular powers (a. k. a. modular exponentiation).
+--
+
+{-# LANGUAGE CPP       #-}
+{-# LANGUAGE MagicHash #-}
+
+module Math.NumberTheory.Powers.Modular
+  ( powMod
+#if __GLASGOW_HASKELL__ > 709
+  , powModWord
+  , powModInt
+#endif
+  ) where
+
+import qualified GHC.Integer.GMP.Internals as GMP (powModInteger)
+
+#if __GLASGOW_HASKELL__ > 709
+import GHC.Exts (Word(..))
+import GHC.Natural (powModNatural)
+import qualified GHC.Integer.GMP.Internals as GMP (powModWord)
+import Math.NumberTheory.Utils.FromIntegral
+#endif
+
+-- | @powMod@ @b@ @e@ @m@ computes (@b^e@) \`mod\` @m@ in effective way.
+-- An exponent @e@ must be non-negative, a modulo @m@ must be positive.
+-- Otherwise the behaviour of @powMod@ is undefined.
+--
+-- > > powMod 2 3 5
+-- > 3
+-- > > powMod 3 12345678901234567890 1001
+-- > 1
+--
+-- See also 'Math.NumberTheory.Moduli.Class.powMod' and 'Math.NumberTheory.Moduli.Class.powSomeMod'.
+--
+-- For finite numeric types ('Int', 'Word', etc.)
+-- modulo @m@ should be such that @m^2@ does not overflow,
+-- otherwise the behaviour is undefined. If you
+-- need both to fit into machine word and to handle large moduli,
+-- take a look at 'powModInt' and 'powModWord'.
+--
+-- > > powMod 3 101 (2^60-1 :: Integer)
+-- > 1018105167100379328 -- correct
+-- > > powMod 3 101 (2^60-1 :: Int64)
+-- > 1115647832265427613 -- incorrect due to overflow
+-- > > powModInt 3 101 (2^60-1 :: Int)
+-- > 1018105167100379328 -- correct
+powMod :: (Integral a, Integral b) => a -> b -> a -> a
+powMod x y m
+  | m <= 0    = error "powModInt: non-positive modulo"
+  | y <  0    = error "powModInt: negative exponent"
+  | otherwise = f (x `rem` m) y 1 `mod` m
+  where
+    f _ 0 acc = acc
+    f b e acc = f (b * b `rem` m) (e `quot` 2)
+      (if odd e then (b * acc `rem` m) else acc)
+
+{-# INLINE [1] powMod #-}
+{-# RULES
+"powMod/Integer" powMod = powModInteger
+  #-}
+
+-- Work around https://ghc.haskell.org/trac/ghc/ticket/14085
+powModInteger :: Integer -> Integer -> Integer -> Integer
+powModInteger b e m = GMP.powModInteger (b `mod` m) e m
+
+#if __GLASGOW_HASKELL__ > 709
+{-# RULES
+"powMod/Natural" powMod = powModNatural
+"powMod/Word"    powMod = powModWord
+"powMod/Int"     powMod = powModInt
+  #-}
+
+-- | Specialised version of 'powMod', able to handle large moduli correctly.
+--
+-- > > powModWord 3 101 (2^60-1)
+-- > 1018105167100379328
+powModWord :: Word -> Word -> Word -> Word
+powModWord (W# x) (W# y) (W# m) = W# (GMP.powModWord x y m)
+
+-- | Specialised version of 'powMod', able to handle large moduli correctly.
+--
+-- > > powModInt 3 101 (2^60-1)
+-- > 1018105167100379328
+powModInt :: Int -> Int -> Int -> Int
+powModInt x y m
+  | m <= 0 = error "powModInt: non-positive modulo"
+  | y <  0 = error "powModInt: negative exponent"
+  | otherwise = wordToInt $ powModWord (intToWord (x `mod` m)) (intToWord y) (intToWord m)
+#endif

--- a/Math/NumberTheory/Prefactored.hs
+++ b/Math/NumberTheory/Prefactored.hs
@@ -125,3 +125,6 @@ instance UniqueFactorisation a => UniqueFactorisation (Prefactored a) where
   unPrime p = fromValue (unPrime p)
   factorise (Prefactored _ f)
     = concatMap (\(x, xm) -> map (second (* xm)) (factorise x)) f
+  isPrime (Prefactored _ f) = case f of
+    [(n, 1)] -> isPrime n
+    _        -> Nothing

--- a/Math/NumberTheory/Prefactored.hs
+++ b/Math/NumberTheory/Prefactored.hs
@@ -1,0 +1,127 @@
+-- |
+-- Module:      Math.NumberTheory.Prefactored
+-- Copyright:   (c) 2017 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- Type for numbers, accompanied by their factorisation.
+--
+
+{-# LANGUAGE CPP          #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Math.NumberTheory.Prefactored
+  ( Prefactored(prefValue, prefFactors)
+  , fromValue
+  , fromFactors
+  ) where
+
+import Control.Arrow
+
+import Math.NumberTheory.GCD (splitIntoCoprimes)
+import Math.NumberTheory.UniqueFactorisation
+
+#if MIN_VERSION_base(4,8,0)
+#else
+import Data.Word
+#endif
+
+-- | A container for a number and its pairwise coprime (but not neccessarily prime)
+-- factorisation.
+-- It is designed to preserve information about factors under multiplication.
+-- One can use this representation to speed up prime factorisation
+-- and computation of arithmetic functions.
+--
+-- For instance, let @p@ and @q@ be big primes:
+--
+-- > > let p, q :: Integer
+-- > >     p = 1000000000000000000000000000057
+-- > >     q = 2000000000000000000000000000071
+--
+-- It would be  difficult to compute prime factorisation of their product
+-- as is:
+-- 'factorise' would take ages. Things become different if we simply
+-- change types of @p@ and @q@ to prefactored ones:
+--
+-- > > let p, q :: Prefactored Integer
+-- > >     p = 1000000000000000000000000000057
+-- > >     q = 2000000000000000000000000000071
+--
+-- Now prime factorisation is done instantly:
+--
+-- > > factorise (p * q)
+-- > [(PrimeNat 1000000000000000000000000000057, 1), (PrimeNat 2000000000000000000000000000071, 1)]
+-- > > factorise (p^2 * q^3)
+-- > [(PrimeNat 1000000000000000000000000000057, 2), (PrimeNat 2000000000000000000000000000071, 3)]
+--
+-- Moreover, we can instantly compute 'totient' and its iterations.
+-- It works fine, because output of 'totient' is also prefactored.
+--
+-- > > prefValue $ totient (p^2 * q^3)
+-- > 8000000000000000000000000001752000000000000000000000000151322000000000000000000000006445392000000000000000000000135513014000000000000000000001126361040
+-- > > prefValue $ totient $ totient (p^2 * q^3)
+-- > 2133305798262843681544648472180210822742702690942899511234131900112583590230336435053688694839034890779375223070157301188739881477320529552945446912000
+--
+-- Let us look under the hood:
+--
+-- > > prefFactors $ totient (p^2 * q^3)
+-- > [(2, 4), (41666666666666666666666666669, 1), (3, 3), (111111111111111111111111111115, 1),
+-- > (1000000000000000000000000000057, 1), (2000000000000000000000000000071, 2)]
+-- > > prefFactors $ totient $ totient (p^2 * q^3)
+-- > [(2, 22), (39521, 1), (5, 3), (199937, 1), (3, 8), (6046667, 1), (227098769, 1),
+-- > (85331809838489, 1), (361696272343, 1), (22222222222222222222222222223, 1),
+-- > (41666666666666666666666666669, 1), (2000000000000000000000000000071, 1)]
+--
+-- Pairwise coprimality of factors is crucial, because it allows
+-- us to process them independently, possibly even
+-- in parallel or concurrent fashion.
+--
+-- Following invariant is guaranteed to hold:
+--
+-- > abs (prefValue x) = abs (product (map (uncurry (^)) (prefFactors x)))
+data Prefactored a = Prefactored
+  { prefValue   :: a
+    -- ^ Number itself.
+  , prefFactors :: [(a, Word)]
+    -- ^ List of pairwise coprime (but not neccesarily prime) factors,
+    -- accompanied by their multiplicities.
+  } deriving (Show)
+
+-- | Create 'Prefactored' from a given number.
+--
+-- > > fromValue 123
+-- > Prefactored {prefValue = 123, prefFactors = [(123, 1)]}
+fromValue :: a -> Prefactored a
+fromValue a = Prefactored a [(a, 1)]
+
+-- | Create 'Prefactored' from a given list of pairwise coprime
+-- (but not neccesarily prime) factors with multiplicities.
+-- If you cannot ensure coprimality, use 'splitIntoCoprimes'.
+--
+-- > > fromFactors (splitIntoCoprimes [(140, 1), (165, 1)])
+-- > Prefactored {prefValue = 23100, prefFactors = [(5, 2), (28, 1), (33, 1)]}
+-- > > fromFactors (splitIntoCoprimes [(140, 2), (165, 3)])
+-- > Prefactored {prefValue = 88045650000, prefFactors = [(5, 5), (28, 2), (33, 3)]}
+fromFactors :: Integral a => [(a, Word)] -> Prefactored a
+fromFactors as = Prefactored (product (map (uncurry (^)) as)) (splitIntoCoprimes as)
+
+instance (Integral a, UniqueFactorisation a) => Num (Prefactored a) where
+  Prefactored v1 _ + Prefactored v2 _
+    = fromValue (v1 + v2)
+  Prefactored v1 _ - Prefactored v2 _
+    = fromValue (v1 - v2)
+  Prefactored v1 f1 * Prefactored v2 f2
+    = Prefactored (v1 * v2) (splitIntoCoprimes (f1 ++ f2))
+  negate (Prefactored v f) = Prefactored (negate v) f
+  abs (Prefactored v f)    = Prefactored (abs v) f
+  signum (Prefactored v _) = Prefactored (signum v) []
+  fromInteger n = fromValue (fromInteger n)
+
+type instance Prime (Prefactored a) = Prime a
+
+instance UniqueFactorisation a => UniqueFactorisation (Prefactored a) where
+  unPrime p = fromValue (unPrime p)
+  factorise (Prefactored _ f)
+    = concatMap (\(x, xm) -> map (second (* xm)) (factorise x)) f

--- a/Math/NumberTheory/Primes/Types.hs
+++ b/Math/NumberTheory/Primes/Types.hs
@@ -30,13 +30,17 @@ newtype Prm = Prm { unPrm :: Word }
   deriving (Eq, Ord)
 
 instance Show Prm where
-  show (Prm p) = "Prm " ++ show p
+  showsPrec d (Prm p) r = (if d > 10 then "(" ++ s ++ ")" else s) ++ r
+    where
+      s = "Prm " ++ show p
 
 newtype PrimeNat = PrimeNat { unPrimeNat :: Natural }
   deriving (Eq, Ord)
 
 instance Show PrimeNat where
-  show (PrimeNat p) = "PrimeNat " ++ show p
+  showsPrec d (PrimeNat p) r = (if d > 10 then "(" ++ s ++ ")" else s) ++ r
+    where
+      s = "PrimeNat " ++ show p
 
 -- | Type of primes of a given unique factorisation domain.
 --

--- a/Math/NumberTheory/UniqueFactorisation.hs
+++ b/Math/NumberTheory/UniqueFactorisation.hs
@@ -26,8 +26,9 @@ import Data.Word
 #endif
 
 import Math.NumberTheory.Primes.Factorisation as F (factorise')
+import Math.NumberTheory.Primes.Testing.Probabilistic as T (isPrime)
 import Math.NumberTheory.Primes.Types (Prime, Prm(..), PrimeNat(..))
-import Math.NumberTheory.GaussianIntegers as G
+import qualified Math.NumberTheory.GaussianIntegers as G
 import Math.NumberTheory.Utils.FromIntegral
 
 import Numeric.Natural
@@ -43,6 +44,13 @@ class UniqueFactorisation a where
   unPrime   :: Prime a -> a
   factorise :: a -> [(Prime a, Word)]
 
+  isPrime   :: a -> Maybe (Prime a)
+  isPrime n = case factorise n of
+    [(p, 1)] -> Just p
+    _        -> Nothing
+
+  {-# MINIMAL unPrime, factorise #-}
+
 instance UniqueFactorisation Int where
   unPrime   = coerce wordToInt
   factorise m' = if m <= 1
@@ -50,13 +58,14 @@ instance UniqueFactorisation Int where
                 else map (coerce integerToWord *** intToWord) . F.factorise' . intToInteger $ m
                   where
                     m = abs m'
+  isPrime n = if T.isPrime (toInteger n) then Just (coerce $ intToWord $ abs n) else Nothing
 
 instance UniqueFactorisation Word where
   unPrime     = coerce
   factorise m = if m <= 1
                   then []
                   else map (coerce integerToWord *** intToWord) . F.factorise' . wordToInteger $ m
-
+  isPrime n = if T.isPrime (toInteger n) then Just (coerce n) else Nothing
 
 instance UniqueFactorisation Integer where
   unPrime      = coerce naturalToInteger
@@ -65,12 +74,14 @@ instance UniqueFactorisation Integer where
                 else map (coerce integerToNatural *** intToWord) . F.factorise' $ m
                   where
                     m = abs m'
+  isPrime n = if T.isPrime n then Just (coerce $ integerToNatural $ abs n) else Nothing
 
 instance UniqueFactorisation Natural where
   unPrime   = coerce
   factorise m = if m <= 1
                   then []
                   else map (coerce integerToNatural *** intToWord) . F.factorise' . naturalToInteger $ m
+  isPrime n = if T.isPrime (toInteger n) then Just (coerce n) else Nothing
 
 newtype GaussianPrime = GaussianPrime { _unGaussianPrime :: G.GaussianInteger }
   deriving (Eq, Show)

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -57,6 +57,7 @@ library
                           Math.NumberTheory.Moduli.Chinese
                           Math.NumberTheory.Moduli.Class
                           Math.NumberTheory.Moduli.Jacobi
+                          Math.NumberTheory.Moduli.PrimitiveRoot
                           Math.NumberTheory.Moduli.Sqrt
                           Math.NumberTheory.MoebiusInversion
                           Math.NumberTheory.MoebiusInversion.Int
@@ -167,6 +168,7 @@ test-suite spec
                   , Math.NumberTheory.Moduli.ChineseTests
                   , Math.NumberTheory.Moduli.ClassTests
                   , Math.NumberTheory.Moduli.JacobiTests
+                  , Math.NumberTheory.Moduli.PrimitiveRootTests
                   , Math.NumberTheory.Moduli.SqrtTests
                   , Math.NumberTheory.Powers.CubesTests
                   , Math.NumberTheory.MoebiusInversionTests

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -71,6 +71,7 @@ library
                           Math.NumberTheory.Powers.Cubes
                           Math.NumberTheory.Powers.Fourth
                           Math.NumberTheory.Powers.General
+                          Math.NumberTheory.Powers.Modular
                           Math.NumberTheory.Primes
                           Math.NumberTheory.Primes.Sieve
                           Math.NumberTheory.Primes.Factorisation
@@ -171,6 +172,7 @@ test-suite spec
                   , Math.NumberTheory.MoebiusInversion.IntTests
                   , Math.NumberTheory.Powers.FourthTests
                   , Math.NumberTheory.Powers.GeneralTests
+                  , Math.NumberTheory.Powers.ModularTests
                   , Math.NumberTheory.Powers.SquaresTests
                   , Math.NumberTheory.PrimesTests
                   , Math.NumberTheory.Primes.CountingTests

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -82,6 +82,7 @@ library
                           Math.NumberTheory.Primes.Heap
                           Math.NumberTheory.UniqueFactorisation
                           Math.NumberTheory.Zeta
+                          Math.NumberTheory.Prefactored
                           GHC.TypeNats.Compat
     other-modules       : Math.NumberTheory.ArithmeticFunctions.SieveBlock.Unboxed
                           Math.NumberTheory.Utils
@@ -174,6 +175,7 @@ test-suite spec
                   , Math.NumberTheory.Powers.GeneralTests
                   , Math.NumberTheory.Powers.ModularTests
                   , Math.NumberTheory.Powers.SquaresTests
+                  , Math.NumberTheory.PrefactoredTests
                   , Math.NumberTheory.PrimesTests
                   , Math.NumberTheory.Primes.CountingTests
                   , Math.NumberTheory.Primes.FactorisationTests

--- a/test-suite/Math/NumberTheory/GCDTests.hs
+++ b/test-suite/Math/NumberTheory/GCDTests.hs
@@ -18,6 +18,7 @@ module Math.NumberTheory.GCDTests
   ) where
 
 import Test.Tasty
+import Test.Tasty.HUnit
 
 import Control.Arrow
 import Data.Bits
@@ -67,6 +68,24 @@ splitIntoCoprimesProperty3 fs' = and [ coprime x y | (x : xs) <- tails fs, y <- 
   where
     fs = map fst $ splitIntoCoprimes $ map (getPositive *** getPower) fs'
 
+-- | Check that evaluation never freezes.
+splitIntoCoprimesProperty4 :: [(Integer, Word)] -> Bool
+splitIntoCoprimesProperty4 fs' = fs == fs
+  where
+    fs = splitIntoCoprimes fs'
+
+-- | This is an undefined behaviour, but at least it should not
+-- throw exceptions or loop forever.
+splitIntoCoprimesSpecialCase1 :: Assertion
+splitIntoCoprimesSpecialCase1 =
+  assertBool "should not fail" $ splitIntoCoprimesProperty4 [(0, 0), (0, 0)]
+
+-- | This is an undefined behaviour, but at least it should not
+-- throw exceptions or loop forever.
+splitIntoCoprimesSpecialCase2 :: Assertion
+splitIntoCoprimesSpecialCase2 =
+  assertBool "should not fail" $ splitIntoCoprimesProperty4 [(0, 1), (-2, 0)]
+
 testSuite :: TestTree
 testSuite = testGroup "GCD"
   [ testSameIntegralProperty "binaryGCD"   binaryGCDProperty
@@ -76,5 +95,9 @@ testSuite = testGroup "GCD"
     [ testSmallAndQuick "preserves product of factors"        splitIntoCoprimesProperty1
     , testSmallAndQuick "number of factors is non-decreasing" splitIntoCoprimesProperty2
     , testSmallAndQuick "output factors are coprime"          splitIntoCoprimesProperty3
+
+    , testCase          "does not freeze 1"                   splitIntoCoprimesSpecialCase1
+    , testCase          "does not freeze 2"                   splitIntoCoprimesSpecialCase2
+    , testSmallAndQuick "does not freeze random"              splitIntoCoprimesProperty4
     ]
   ]

--- a/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
@@ -1,0 +1,118 @@
+-- |
+-- Module:      Math.NumberTheory.Moduli.PrimitiveRootTests
+-- Copyright:   (c) 2017 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.Moduli.PrimitiveRoot
+--
+
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.Moduli.PrimitiveRootTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+
+import qualified Data.Set as S
+import Data.List (genericTake)
+import Data.Maybe
+import Numeric.Natural
+
+#if !(MIN_VERSION_base(4,8,0))
+import Data.Word
+#endif
+
+import Math.NumberTheory.ArithmeticFunctions (totient)
+import Math.NumberTheory.Moduli.Class (Mod, SomeMod(..), modulo)
+import Math.NumberTheory.Moduli.PrimitiveRoot
+import Math.NumberTheory.Prefactored (prefValue)
+import Math.NumberTheory.TestUtils
+import Math.NumberTheory.UniqueFactorisation
+
+cyclicGroupProperty1 :: (Integral a, UniqueFactorisation a, Show a) => AnySign a -> Bool
+cyclicGroupProperty1 (AnySign n) = case cyclicGroupFromModulo n of
+  Nothing -> True
+  Just cg -> prefValue (cyclicGroupToModulo cg) == n
+
+-- | Multiplicative groups modulo primes are always cyclic.
+cyclicGroupProperty2 :: (Integral a, UniqueFactorisation a) => Positive a -> Bool
+cyclicGroupProperty2 (Positive n) = case isPrime n of
+  Nothing -> True
+  Just _  -> isJust (cyclicGroupFromModulo n)
+
+-- | Multiplicative groups modulo double primes are always cyclic.
+cyclicGroupProperty3 :: (Integral a, UniqueFactorisation a) => Positive a -> Bool
+cyclicGroupProperty3 (Positive n) = case isPrime n of
+  Nothing -> True
+  Just _  -> 2 * n < n {- overflow check -}
+          || isJust (cyclicGroupFromModulo n)
+
+allUnique :: Ord a => [a] -> Bool
+allUnique = go S.empty
+  where
+    go _ []         = True
+    go acc (x : xs) = if x `S.member` acc then False else go (S.insert x acc) xs
+
+isPrimitiveRoot'Property1
+  :: (Eq a, Integral a, UniqueFactorisation a)
+  => AnySign a -> CyclicGroup a -> Bool
+isPrimitiveRoot'Property1 (AnySign n) cg
+  = gcd n (prefValue (cyclicGroupToModulo cg)) == 1
+  || not (isPrimitiveRoot' cg n)
+
+isPrimitiveRootProperty1 :: AnySign Integer -> Positive Natural -> Bool
+isPrimitiveRootProperty1 (AnySign n) (Positive m)
+  = case n `modulo` m of
+    SomeMod n' -> gcd n (toInteger m) == 1
+               || not (isPrimitiveRoot n')
+    InfMod{}   -> False
+
+isPrimitiveRootProperty2 :: Positive Natural -> Bool
+isPrimitiveRootProperty2 (Positive m)
+  = isNothing (cyclicGroupFromModulo m)
+  || case 0 `modulo` m of
+    SomeMod (_ :: Mod t) -> any isPrimitiveRoot [(minBound :: Mod t) .. maxBound]
+    InfMod{}             -> False
+
+isPrimitiveRootProperty3 :: AnySign Integer -> Positive Natural -> Bool
+isPrimitiveRootProperty3 (AnySign n) (Positive m)
+  = case n `modulo` m of
+    SomeMod n' -> not (isPrimitiveRoot n')
+               || allUnique (genericTake (totient m - 1) (iterate (* n') 1))
+    InfMod{}   -> False
+
+isPrimitiveRootProperty4 :: AnySign Integer -> Positive Natural -> Bool
+isPrimitiveRootProperty4 (AnySign n) (Positive m)
+  = isJust (cyclicGroupFromModulo m)
+  || case n `modulo` m of
+    SomeMod n' -> not (isPrimitiveRoot n')
+    InfMod{}   -> False
+
+testSuite :: TestTree
+testSuite = testGroup "Primitive root"
+  [ testGroup "CyclicGroup"
+    [ testIntegralProperty "cyclicGroupToModulo . cyclicGroupFromModulo" cyclicGroupProperty1
+    , testIntegralProperty "cyclic group mod p" cyclicGroupProperty2
+    , testIntegralProperty "cyclic group mod 2p" cyclicGroupProperty3
+    ]
+  , testGroup "isPrimitiveRoot'"
+    [ testGroup "primitive root is coprime with modulo"
+      [ testSmallAndQuick "Integer" (isPrimitiveRoot'Property1 :: AnySign Integer -> CyclicGroup Integer -> Bool)
+      , testSmallAndQuick "Natural" (isPrimitiveRoot'Property1 :: AnySign Natural -> CyclicGroup Natural -> Bool)
+      , testSmallAndQuick "Int"     (isPrimitiveRoot'Property1 :: AnySign Int     -> CyclicGroup Int     -> Bool)
+      , testSmallAndQuick "Word"    (isPrimitiveRoot'Property1 :: AnySign Word    -> CyclicGroup Word    -> Bool)
+      ]
+    ]
+  , testGroup "isPrimitiveRoot"
+    [ testSmallAndQuick "primitive root is coprime with modulo" isPrimitiveRootProperty1
+    , testSmallAndQuick "cyclic group has a primitive root"     isPrimitiveRootProperty2
+    , testSmallAndQuick "primitive root generates cyclic group" isPrimitiveRootProperty3
+    , testSmallAndQuick "no primitive root in non-cyclic group" isPrimitiveRootProperty4
+    ]
+  ]

--- a/test-suite/Math/NumberTheory/Powers/ModularTests.hs
+++ b/test-suite/Math/NumberTheory/Powers/ModularTests.hs
@@ -1,0 +1,98 @@
+-- |
+-- Module:      Math.NumberTheory.Powers.ModularTests
+-- Copyright:   (c) 2017 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.Powers.Modular
+--
+
+{-# LANGUAGE CPP #-}
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.Powers.ModularTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+#if MIN_VERSION_base(4,8,0)
+import Test.Tasty.HUnit
+#endif
+
+import Numeric.Natural
+
+import Math.NumberTheory.Powers.Modular
+import Math.NumberTheory.TestUtils
+
+#include "MachDeps.h"
+
+powMod' :: Integer -> Natural -> Integer -> Integer
+powMod' = powMod
+
+-- | Check that 'powMod' fits between 0 and m - 1.
+powModProperty1 :: NonNegative Natural -> AnySign Integer -> Positive Integer -> Bool
+powModProperty1 (NonNegative e) (AnySign b) (Positive m)
+  = let v = powMod' b e m in 0 <= v && v < m
+
+-- | Check that 'powMod'' is multiplicative by first argument.
+powModProperty2 :: NonNegative Natural -> AnySign Integer -> AnySign Integer -> Positive Integer -> Bool
+powModProperty2 (NonNegative e) (AnySign b1) (AnySign b2) (Positive m)
+  = (powMod' b1 e m * powMod' b2 e m) `mod` m == powMod' (b1 * b2) e m
+
+-- | Check that 'powMod' is additive by second argument.
+powModProperty3 :: NonNegative Natural -> NonNegative Natural -> AnySign Integer -> Positive Integer -> Bool
+powModProperty3 (NonNegative e1) (NonNegative e2) (AnySign b) (Positive m)
+  = (powMod' b e1 m * powMod' b e2 m) `mod` m == powMod' b (e1 + e2) m
+
+#if __GLASGOW_HASKELL__ > 709
+-- | Specialized to trigger 'powModInt'.
+powModProperty_Int :: AnySign Int -> NonNegative Int -> Positive Int -> Bool
+powModProperty_Int (AnySign b) (NonNegative e) (Positive m) = powModInt b e m == fromInteger (powMod' (fromIntegral b) (fromIntegral e) (fromIntegral m))
+
+-- | Specialized to trigger 'powModWord'.
+powModProperty_Word :: AnySign Word -> NonNegative Word -> Positive Word -> Bool
+powModProperty_Word (AnySign b) (NonNegative e) (Positive m) = powModWord b e m == fromInteger (powMod' (fromIntegral b) (fromIntegral e) (fromIntegral m))
+#endif
+
+-- | Specialized to trigger 'powModInteger'.
+powModProperty_Integer :: AnySign Integer -> NonNegative Integer -> Positive Integer -> Bool
+powModProperty_Integer (AnySign b) (NonNegative e) (Positive m) = powMod b e m == fromInteger (powMod' (fromIntegral b) (fromIntegral e) (fromIntegral m))
+
+-- | Specialized to trigger 'powModNatural'.
+powModProperty_Natural :: AnySign Natural -> NonNegative Natural -> Positive Natural -> Bool
+powModProperty_Natural (AnySign b) (NonNegative e) (Positive m) = powMod b e m == fromInteger (powMod' (fromIntegral b) (fromIntegral e) (fromIntegral m))
+
+#if WORD_SIZE_IN_BITS == 64 && __GLASGOW_HASKELL__ > 709
+-- | Large modulo m such that m^2 overflows.
+powModSpecialCase1_Int :: Assertion
+powModSpecialCase1_Int =
+  assertEqual "powModInt" (powModInt 3 101 (2^60-1)) 1018105167100379328
+
+-- | Large modulo m such that m^2 overflows.
+powModSpecialCase1_Word :: Assertion
+powModSpecialCase1_Word =
+  assertEqual "powModWord" (powModWord 3 101 (2^60-1)) 1018105167100379328
+#endif
+
+testSuite :: TestTree
+testSuite = testGroup "Modular"
+  [ testGroup "powMod"
+    [ testSmallAndQuick "range"                  powModProperty1
+    , testSmallAndQuick "multiplicative by base" powModProperty2
+    , testSmallAndQuick "additive by exponent"   powModProperty3
+
+#if __GLASGOW_HASKELL__ > 709
+    , testSmallAndQuick "powModInt"              powModProperty_Int
+    , testSmallAndQuick "powModWord"             powModProperty_Word
+#endif
+    , testSmallAndQuick "powModInteger"          powModProperty_Integer
+    , testSmallAndQuick "powModNatural"          powModProperty_Natural
+
+#if WORD_SIZE_IN_BITS == 64 && __GLASGOW_HASKELL__ > 709
+    , testCase          "large modulo :: Int"    powModSpecialCase1_Int
+    , testCase          "large modulo :: Word"   powModSpecialCase1_Word
+#endif
+    ]
+  ]

--- a/test-suite/Math/NumberTheory/PrefactoredTests.hs
+++ b/test-suite/Math/NumberTheory/PrefactoredTests.hs
@@ -1,0 +1,101 @@
+-- |
+-- Module:      Math.NumberTheory.PrefactoredTests
+-- Copyright:   (c) 2017 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.Prefactored
+--
+
+{-# LANGUAGE CPP #-}
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.PrefactoredTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+
+import Control.Arrow (second)
+import Data.Bits (Bits)
+import Data.List (tails)
+#if MIN_VERSION_base(4,8,0)
+#else
+import Data.Word
+#endif
+import Numeric.Natural
+
+import Math.NumberTheory.GCD (coprime, splitIntoCoprimes)
+import Math.NumberTheory.Prefactored
+import Math.NumberTheory.TestUtils
+
+isValid :: (Eq a, Bits a, Integral a) => Prefactored a -> Bool
+isValid pref
+  = abs n == abs (product (map (uncurry (^)) fs))
+  && and [ coprime g h | ((g, _) : gs) <- tails fs, (h, _) <- gs ]
+  where
+    n  = prefValue   pref
+    fs = prefFactors pref
+
+fromValueProperty :: Integer -> Bool
+fromValueProperty n = isValid pref && prefValue pref == n
+  where
+    pref = fromValue n
+
+fromFactorsProperty :: [(Integer, Power Word)] -> Bool
+fromFactorsProperty fs' = isValid pref && abs (prefValue pref) == abs (product (map (uncurry (^)) fs))
+  where
+    fs   = map (second getPower) fs'
+    pref = fromFactors (splitIntoCoprimes fs)
+
+plusProperty :: Integer -> Integer -> Bool
+plusProperty x y = isValid z && prefValue z == x + y
+  where
+    z = fromValue x + fromValue y
+
+minusProperty :: Integer -> Integer -> Bool
+minusProperty x y = isValid z && prefValue z == x - y
+  where
+    z = fromValue x - fromValue y
+
+minusNaturalProperty :: Natural -> Natural -> Bool
+minusNaturalProperty x y = x < y || (isValid z && prefValue z == x - y)
+  where
+    z = fromValue x - fromValue y
+
+multiplyProperty :: Integer -> Integer -> Bool
+multiplyProperty x y = isValid z && prefValue z == x * y
+  where
+    z = fromValue x * fromValue y
+
+negateProperty :: Integer -> Bool
+negateProperty x = isValid z && prefValue z == negate x
+  where
+    z = negate (fromValue x)
+
+absSignumProperty :: Integer -> Bool
+absSignumProperty x = isValid z && prefValue z == x
+  where
+    z = abs (fromValue x) * signum (fromValue x)
+
+fromIntegerProperty :: Integer -> Bool
+fromIntegerProperty n = isValid pref && prefValue pref == n
+  where
+    pref = fromInteger n
+
+testSuite :: TestTree
+testSuite = testGroup "Prefactored"
+  [ testSmallAndQuick "fromValue"   fromValueProperty
+  , testSmallAndQuick "fromFactors" fromFactorsProperty
+  , testGroup "Num instance"
+    [ testSmallAndQuick "plus"         plusProperty
+    , testSmallAndQuick "minus"        minusProperty
+    , testSmallAndQuick "minusNatural" minusNaturalProperty
+    , testSmallAndQuick "multiply"     multiplyProperty
+    , testSmallAndQuick "negate"       negateProperty
+    , testSmallAndQuick "absSignum"    absSignumProperty
+    , testSmallAndQuick "fromInteger"  fromIntegerProperty
+    ]
+  ]

--- a/test-suite/Math/NumberTheory/TestUtils/Wrappers.hs
+++ b/test-suite/Math/NumberTheory/TestUtils/Wrappers.hs
@@ -19,6 +19,7 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans       #-}
@@ -180,6 +181,23 @@ instance (Arbitrary a, UniqueFactorisation a) => Arbitrary (PrimeWrapper a) wher
 
 instance (Monad m, Serial m a, UniqueFactorisation a) => Serial m (PrimeWrapper a) where
   series = PrimeWrapper <$> (series :: Series m a) `suchThatMapSerial` isPrime
+
+-------------------------------------------------------------------------------
+-- UniqueFactorisation
+
+type instance Prime (Large a) = Prime a
+
+instance UniqueFactorisation a => UniqueFactorisation (Large a) where
+  unPrime p = Large (unPrime p)
+  factorise (Large x) = factorise x
+  isPrime (Large x) = isPrime x
+
+type instance Prime (Huge a) = Prime a
+
+instance UniqueFactorisation a => UniqueFactorisation (Huge a) where
+  unPrime p = Huge (unPrime p)
+  factorise (Huge x) = factorise x
+  isPrime (Huge x) = isPrime x
 
 -------------------------------------------------------------------------------
 -- Utils

--- a/test-suite/Math/NumberTheory/TestUtils/Wrappers.hs
+++ b/test-suite/Math/NumberTheory/TestUtils/Wrappers.hs
@@ -13,11 +13,13 @@
 {-# LANGUAGE DeriveFoldable             #-}
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveTraversable          #-}
+{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans       #-}
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
@@ -35,7 +37,7 @@ import Data.Traversable (Traversable)
 import Test.Tasty.QuickCheck as QC hiding (Positive, NonNegative, generate, getNonNegative, getPositive)
 import Test.SmallCheck.Series (Positive(..), NonNegative(..), Serial(..), Series)
 
-import Math.NumberTheory.Primes (isPrime, nthPrime)
+import Math.NumberTheory.UniqueFactorisation
 
 -------------------------------------------------------------------------------
 -- AnySign
@@ -167,19 +169,23 @@ instance Show1 Odd where
 -------------------------------------------------------------------------------
 -- Prime
 
-newtype Prime = Prime { getPrime :: Integer }
-  deriving (Eq, Ord, Show)
+newtype PrimeWrapper a = PrimeWrapper { getPrime :: Prime a }
 
-instance Arbitrary Prime where
-  arbitrary = do
-    n <- arbitrary
-    return $ Prime $ head $ filter isPrime [abs n ..]
+deriving instance Eq   (Prime a) => Eq   (PrimeWrapper a)
+deriving instance Ord  (Prime a) => Ord  (PrimeWrapper a)
+deriving instance Show (Prime a) => Show (PrimeWrapper a)
 
-instance Monad m => Serial m Prime where
-  series = Prime . nthPrime <$> series `suchThatSerial` (> 0)
+instance (Arbitrary a, UniqueFactorisation a) => Arbitrary (PrimeWrapper a) where
+  arbitrary = PrimeWrapper <$> (arbitrary :: Gen a) `suchThatMap` isPrime
+
+instance (Monad m, Serial m a, UniqueFactorisation a) => Serial m (PrimeWrapper a) where
+  series = PrimeWrapper <$> (series :: Series m a) `suchThatMapSerial` isPrime
 
 -------------------------------------------------------------------------------
 -- Utils
 
 suchThatSerial :: Series m a -> (a -> Bool) -> Series m a
 suchThatSerial s p = s >>= \x -> if p x then pure x else empty
+
+suchThatMapSerial :: Series m a -> (a -> Maybe b) -> Series m b
+suchThatMapSerial s p = s >>= maybe empty pure . p

--- a/test-suite/Math/NumberTheory/UniqueFactorisationTests.hs
+++ b/test-suite/Math/NumberTheory/UniqueFactorisationTests.hs
@@ -26,7 +26,7 @@ import Data.Word
 
 import Math.NumberTheory.GaussianIntegers hiding (factorise)
 import Math.NumberTheory.UniqueFactorisation
-import Math.NumberTheory.TestUtils hiding (Prime)
+import Math.NumberTheory.TestUtils
 
 import Numeric.Natural
 

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -17,6 +17,7 @@ import qualified Math.NumberTheory.MoebiusInversion.IntTests as MoebiusInversion
 import qualified Math.NumberTheory.Powers.CubesTests as Cubes
 import qualified Math.NumberTheory.Powers.FourthTests as Fourth
 import qualified Math.NumberTheory.Powers.GeneralTests as General
+import qualified Math.NumberTheory.Powers.ModularTests as Modular
 import qualified Math.NumberTheory.Powers.SquaresTests as Squares
 
 import qualified Math.NumberTheory.PrimesTests as Primes
@@ -42,6 +43,7 @@ tests = testGroup "All"
     [ Cubes.testSuite
     , Fourth.testSuite
     , General.testSuite
+    , Modular.testSuite
     , Squares.testSuite
     ]
   , testGroup "GCD"

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -20,6 +20,8 @@ import qualified Math.NumberTheory.Powers.GeneralTests as General
 import qualified Math.NumberTheory.Powers.ModularTests as Modular
 import qualified Math.NumberTheory.Powers.SquaresTests as Squares
 
+import qualified Math.NumberTheory.PrefactoredTests as Prefactored
+
 import qualified Math.NumberTheory.PrimesTests as Primes
 import qualified Math.NumberTheory.Primes.CountingTests as Counting
 import qualified Math.NumberTheory.Primes.FactorisationTests as Factorisation
@@ -63,6 +65,9 @@ tests = testGroup "All"
   , testGroup "MoebiusInversion"
     [ MoebiusInversion.testSuite
     , MoebiusInversionInt.testSuite
+    ]
+  , testGroup "Prefactored"
+    [ Prefactored.testSuite
     ]
   , testGroup "Primes"
     [ Primes.testSuite

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -9,6 +9,7 @@ import qualified Math.NumberTheory.Recurrencies.LinearTests as RecurrenciesLinea
 import qualified Math.NumberTheory.Moduli.ChineseTests as ModuliChinese
 import qualified Math.NumberTheory.Moduli.ClassTests as ModuliClass
 import qualified Math.NumberTheory.Moduli.JacobiTests as ModuliJacobi
+import qualified Math.NumberTheory.Moduli.PrimitiveRootTests as ModuliPrimitiveRoot
 import qualified Math.NumberTheory.Moduli.SqrtTests as ModuliSqrt
 
 import qualified Math.NumberTheory.MoebiusInversionTests as MoebiusInversion
@@ -60,6 +61,7 @@ tests = testGroup "All"
     [ ModuliChinese.testSuite
     , ModuliClass.testSuite
     , ModuliJacobi.testSuite
+    , ModuliPrimitiveRoot.testSuite
     , ModuliSqrt.testSuite
     ]
   , testGroup "MoebiusInversion"


### PR DESCRIPTION
This branch is aimed to provide tools dealing with primitive roots as per #62. Despite the task sounds pretty humble, it required a lot of preparations such that:
* New `Math.NumberTheory.Powers.Modular` module, providing efficient and polymorphic modular exponentiation.
* New `Math.NumberTheory.Prefactored` module, featuring new numeric data type, which stores a number with its factors.

The main module `Math.NumberTheory.Moduli.PrimitiveRoot` introduces a data type for cyclic groups or residues and routines for search of primitive roots. 