### PR TITLE
Moebius and Mertens functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -96,7 +96,7 @@
     Add new cabal flag check-bounds, which replaces all unsafe array functions with safe ones.
 
     Add basic functions on Gaussian integers.
-    Add Moebius mu-function.
+    Add Möbius mu-function.
 
     Forbid non-positive moduli in Math.NumberTheory.Moduli.
 
@@ -123,7 +123,7 @@
 0.4.0.1:
     Fixed Haddock bug
 0.4.0.0:
-    Added generalised Moebius inversion, to be continued
+    Added generalised Möbius inversion, to be continued
 0.3.0.0:
     Added modular square roots and Chinese remainder theorem
 0.2.0.6:

--- a/Math/NumberTheory/ArithmeticFunctions/Mertens.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/Mertens.hs
@@ -1,0 +1,75 @@
+-- |
+-- Module:      Math.NumberTheory.ArithmeticFunctions.Mertens
+-- Copyright:   (c) 2018 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- Values of <https://en.wikipedia.org/wiki/Mertens_function Mertens function>.
+--
+
+{-# LANGUAGE CPP        #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Math.NumberTheory.ArithmeticFunctions.Mertens
+  ( mertens
+  ) where
+
+import qualified Data.Vector.Unboxed as U
+#if __GLASGOW_HASKELL__ < 709
+import Data.Word
+#endif
+
+import Math.NumberTheory.Powers.Cubes
+import Math.NumberTheory.Powers.Squares
+import Math.NumberTheory.ArithmeticFunctions.Moebius
+
+-- | Compute individual values of Mertens function in O(n^(2/3)) time and space.
+--
+-- The implementation follows Theorem 3.1 from <https://arxiv.org/pdf/1610.08551.pdf Computations of the Mertens function and improved bounds on the Mertens conjecture> by G. Hurst, excluding segmentation of sieves.
+mertens :: Word -> Int
+mertens 0 = 0
+mertens 1 = 1
+mertens x = sumMultMoebius lookupMus (\n -> sfunc (x `quot` n)) [1 .. x `quot` u]
+  where
+    u = (integerSquareRoot x + 1) `max` ((integerCubeRoot x) ^ (2 :: Word) `quot` 2)
+
+    sfunc :: Word -> Int
+    sfunc y
+      = 1
+      - sum [ U.unsafeIndex mes (fromIntegral $ y `quot` n) |  n <- [y `quot` u + 1 .. kappa] ]
+      + fromIntegral kappa * U.unsafeIndex mes (fromIntegral nu)
+      - sumMultMoebius lookupMus (\n -> fromIntegral $ y `quot` n) [1 .. nu]
+      where
+        nu = integerSquareRoot y
+        kappa = y `quot` (nu + 1)
+
+    -- cacheSize ~ u
+    cacheSize :: Word
+    cacheSize = u `max` (x `quot` u) `max` integerSquareRoot x
+
+    -- 1-based index
+    mus :: U.Vector Moebius
+    mus = sieveBlockMoebius 1 cacheSize
+
+    lookupMus :: Word -> Moebius
+    lookupMus i = U.unsafeIndex mus (fromIntegral (i - 1))
+
+    -- 0-based index
+    mes :: U.Vector Int
+    mes = U.scanl' go 0 mus
+      where
+        go acc = \case
+          MoebiusN -> acc - 1
+          MoebiusZ -> acc
+          MoebiusP -> acc + 1
+
+-- | Compute sum (map (\x -> runMoebius (mu x) * f x))
+sumMultMoebius :: (Word -> Moebius) -> (Word -> Int) -> [Word] -> Int
+sumMultMoebius mu f = foldl go 0
+  where
+    go acc i = case mu i of
+      MoebiusN -> acc - f i
+      MoebiusZ -> acc
+      MoebiusP -> acc + f i

--- a/Math/NumberTheory/ArithmeticFunctions/Moebius.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/Moebius.hs
@@ -1,0 +1,109 @@
+-- |
+-- Module:      Math.NumberTheory.ArithmeticFunctions.Moebius
+-- Copyright:   (c) 2018 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- Values of <https://en.wikipedia.org/wiki/Möbius_function Möbius function>.
+--
+
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE MagicHash             #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
+
+module Math.NumberTheory.ArithmeticFunctions.Moebius
+  ( Moebius(..)
+  , runMoebius
+  ) where
+
+import Control.Monad (liftM)
+import Data.Int
+import Data.Semigroup
+import qualified Data.Vector.Generic         as G
+import qualified Data.Vector.Generic.Mutable as M
+import qualified Data.Vector.Primitive as P
+import qualified Data.Vector.Unboxed         as U
+import GHC.Exts
+import GHC.Integer.GMP.Internals
+
+-- | Represents three possible values of <https://en.wikipedia.org/wiki/Möbius_function Möbius function>.
+--
+-- 'U.Unbox' instance is designed to be used with 'Math.NumberTheory.ArithmeticFunctions.SieveBlock.sieveBlockUnboxed'.
+data Moebius
+  = MoebiusN -- ^ −1
+  | MoebiusZ -- ^  0
+  | MoebiusP -- ^  1
+  deriving (Eq, Ord, Show)
+
+-- | Convert to any numeric type.
+runMoebius :: Num a => Moebius -> a
+runMoebius m = fromInteger (S# (dataToTag# m -# 1#))
+
+fromMoebius :: Moebius -> Int8
+fromMoebius m = fromIntegral $ I# (dataToTag# m)
+{-# INLINE fromMoebius #-}
+
+toMoebius :: Int8 -> Moebius
+toMoebius i = let !(I# i#) = fromIntegral i in tagToEnum# i#
+{-# INLINE toMoebius #-}
+
+newtype instance U.MVector s Moebius = MV_Moebius (P.MVector s Int8)
+newtype instance U.Vector    Moebius = V_Moebius  (P.Vector    Int8)
+
+instance U.Unbox Moebius
+
+instance M.MVector U.MVector Moebius where
+  {-# INLINE basicLength #-}
+  {-# INLINE basicUnsafeSlice #-}
+  {-# INLINE basicOverlaps #-}
+  {-# INLINE basicUnsafeNew #-}
+  {-# INLINE basicInitialize #-}
+  {-# INLINE basicUnsafeReplicate #-}
+  {-# INLINE basicUnsafeRead #-}
+  {-# INLINE basicUnsafeWrite #-}
+  {-# INLINE basicClear #-}
+  {-# INLINE basicSet #-}
+  {-# INLINE basicUnsafeCopy #-}
+  {-# INLINE basicUnsafeGrow #-}
+  basicLength (MV_Moebius v) = M.basicLength v
+  basicUnsafeSlice i n (MV_Moebius v) = MV_Moebius $ M.basicUnsafeSlice i n v
+  basicOverlaps (MV_Moebius v1) (MV_Moebius v2) = M.basicOverlaps v1 v2
+  basicUnsafeNew n = MV_Moebius `liftM` M.basicUnsafeNew n
+  basicInitialize (MV_Moebius v) = M.basicInitialize v
+  basicUnsafeReplicate n x = MV_Moebius `liftM` M.basicUnsafeReplicate n (fromMoebius x)
+  basicUnsafeRead (MV_Moebius v) i = toMoebius `liftM` M.basicUnsafeRead v i
+  basicUnsafeWrite (MV_Moebius v) i x = M.basicUnsafeWrite v i (fromMoebius x)
+  basicClear (MV_Moebius v) = M.basicClear v
+  basicSet (MV_Moebius v) x = M.basicSet v (fromMoebius x)
+  basicUnsafeCopy (MV_Moebius v1) (MV_Moebius v2) = M.basicUnsafeCopy v1 v2
+  basicUnsafeMove (MV_Moebius v1) (MV_Moebius v2) = M.basicUnsafeMove v1 v2
+  basicUnsafeGrow (MV_Moebius v) n = MV_Moebius `liftM` M.basicUnsafeGrow v n
+
+instance G.Vector U.Vector Moebius where
+  {-# INLINE basicUnsafeFreeze #-}
+  {-# INLINE basicUnsafeThaw #-}
+  {-# INLINE basicLength #-}
+  {-# INLINE basicUnsafeSlice #-}
+  {-# INLINE basicUnsafeIndexM #-}
+  {-# INLINE elemseq #-}
+  basicUnsafeFreeze (MV_Moebius v) = V_Moebius `liftM` G.basicUnsafeFreeze v
+  basicUnsafeThaw (V_Moebius v) = MV_Moebius `liftM` G.basicUnsafeThaw v
+  basicLength (V_Moebius v) = G.basicLength v
+  basicUnsafeSlice i n (V_Moebius v) = V_Moebius $ G.basicUnsafeSlice i n v
+  basicUnsafeIndexM (V_Moebius v) i = toMoebius `liftM` G.basicUnsafeIndexM v i
+  basicUnsafeCopy (MV_Moebius mv) (V_Moebius v) = G.basicUnsafeCopy mv v
+  elemseq _ = seq
+
+instance Semigroup Moebius where
+  MoebiusZ <> _ = MoebiusZ
+  _ <> MoebiusZ = MoebiusZ
+  MoebiusP <> a = a
+  a <> MoebiusP = a
+  _ <> _ = MoebiusP
+
+instance Monoid Moebius where
+  mempty  = MoebiusP
+  mappend = (<>)

--- a/Math/NumberTheory/ArithmeticFunctions/SieveBlock.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/SieveBlock.hs
@@ -25,8 +25,8 @@ module Math.NumberTheory.ArithmeticFunctions.SieveBlock
   , sieveBlockUnboxed
   ) where
 
-import Control.Monad
-import Control.Monad.ST
+import Control.Monad (forM_)
+import Control.Monad.ST (runST)
 import Data.Coerce
 import qualified Data.Vector as V
 import qualified Data.Vector.Mutable as MV
@@ -38,11 +38,11 @@ import Data.Monoid
 import Math.NumberTheory.ArithmeticFunctions.Class
 import Math.NumberTheory.ArithmeticFunctions.SieveBlock.Unboxed
 import Math.NumberTheory.Logarithms (integerLogBase')
-import Math.NumberTheory.Primes
+import Math.NumberTheory.Primes (primes)
 import Math.NumberTheory.Primes.Types
-import Math.NumberTheory.Powers.Squares
+import Math.NumberTheory.Powers.Squares (integerSquareRoot)
 import Math.NumberTheory.Utils (splitOff#)
-import Math.NumberTheory.Utils.FromIntegral
+import Math.NumberTheory.Utils.FromIntegral (wordToInt, intToWord)
 
 -- | 'runFunctionOverBlock' @f@ @x@ @l@ evaluates an arithmetic function
 -- for integers between @x@ and @x+l-1@ and returns a vector of length @l@.
@@ -87,6 +87,7 @@ sieveBlock
   -> Word
   -> Word
   -> V.Vector a
+sieveBlock _ _ 0 = V.empty
 sieveBlock (SieveBlockConfig empty f append) lowIndex' len' = runST $ do
 
     let lowIndex :: Int
@@ -122,7 +123,7 @@ sieveBlock (SieveBlockConfig empty f append) lowIndex' len' = runST $ do
         MV.unsafeWrite as ix (W# a'#)
         MV.unsafeModify bs (\y -> y `append` V.unsafeIndex fs (I# pow#)) ix
 
-    forM_ [0 .. MV.length as - 1] $ \k -> do
+    forM_ [0 .. len - 1] $ \k -> do
       a <- MV.unsafeRead as k
       MV.unsafeModify bs (\b -> if a /= 1 then b `append` f a 1 else b) k
 

--- a/Math/NumberTheory/ArithmeticFunctions/SieveBlock.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/SieveBlock.hs
@@ -23,6 +23,7 @@ module Math.NumberTheory.ArithmeticFunctions.SieveBlock
   , additiveSieveBlockConfig
   , sieveBlock
   , sieveBlockUnboxed
+  , sieveBlockMoebius
   ) where
 
 import Control.Monad (forM_)
@@ -36,6 +37,7 @@ import Data.Monoid
 #endif
 
 import Math.NumberTheory.ArithmeticFunctions.Class
+import Math.NumberTheory.ArithmeticFunctions.Moebius (sieveBlockMoebius)
 import Math.NumberTheory.ArithmeticFunctions.SieveBlock.Unboxed
 import Math.NumberTheory.Logarithms (integerLogBase')
 import Math.NumberTheory.Primes (primes)

--- a/Math/NumberTheory/ArithmeticFunctions/SieveBlock/Unboxed.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/SieveBlock/Unboxed.hs
@@ -129,3 +129,4 @@ sieveBlockUnboxed (SieveBlockConfig empty f append) lowIndex' len' = runST $ do
 {-# SPECIALIZE sieveBlockUnboxed :: SieveBlockConfig Int  -> Word -> Word -> V.Vector Int  #-}
 {-# SPECIALIZE sieveBlockUnboxed :: SieveBlockConfig Word -> Word -> Word -> V.Vector Word #-}
 {-# SPECIALIZE sieveBlockUnboxed :: SieveBlockConfig Bool -> Word -> Word -> V.Vector Bool #-}
+{-# SPECIALIZE sieveBlockUnboxed :: SieveBlockConfig Moebius -> Word -> Word -> V.Vector Moebius #-}

--- a/Math/NumberTheory/ArithmeticFunctions/SieveBlock/Unboxed.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/SieveBlock/Unboxed.hs
@@ -22,17 +22,18 @@ module Math.NumberTheory.ArithmeticFunctions.SieveBlock.Unboxed
   , sieveBlockUnboxed
   ) where
 
-import Control.Monad
-import Control.Monad.ST
+import Control.Monad (forM_)
+import Control.Monad.ST (runST)
 import qualified Data.Vector.Unboxed as V
 import qualified Data.Vector.Unboxed.Mutable as MV
 import GHC.Exts
 
+import Math.NumberTheory.ArithmeticFunctions.Moebius (Moebius)
 import Math.NumberTheory.Logarithms (integerLogBase')
-import Math.NumberTheory.Primes
-import Math.NumberTheory.Powers.Squares
+import Math.NumberTheory.Primes (primes)
+import Math.NumberTheory.Powers.Squares (integerSquareRoot)
 import Math.NumberTheory.Utils (splitOff#)
-import Math.NumberTheory.Utils.FromIntegral
+import Math.NumberTheory.Utils.FromIntegral (wordToInt, intToWord)
 
 -- | A record, which specifies a function to evaluate over a block.
 --
@@ -83,6 +84,7 @@ sieveBlockUnboxed
   -> Word
   -> Word
   -> V.Vector a
+sieveBlockUnboxed _ _ 0 = V.empty
 sieveBlockUnboxed (SieveBlockConfig empty f append) lowIndex' len' = runST $ do
 
     let lowIndex :: Int
@@ -118,7 +120,7 @@ sieveBlockUnboxed (SieveBlockConfig empty f append) lowIndex' len' = runST $ do
         MV.unsafeWrite as ix (W# a'#)
         MV.unsafeModify bs (\y -> y `append` V.unsafeIndex fs (I# pow#)) ix
 
-    forM_ [0 .. MV.length as - 1] $ \k -> do
+    forM_ [0 .. len - 1] $ \k -> do
       a <- MV.unsafeRead as k
       MV.unsafeModify bs (\b -> if a /= 1 then b `append` f a 1 else b) k
 

--- a/Math/NumberTheory/ArithmeticFunctions/Standard.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/Standard.hs
@@ -26,7 +26,7 @@ module Math.NumberTheory.ArithmeticFunctions.Standard
   , sigma, sigmaA
   , totient, totientA
   , jordan, jordanA
-  , moebius, moebiusA
+  , moebius, moebiusA, Moebius(..), runMoebius
   , liouville, liouvilleA
     -- * Additive functions
   , additive
@@ -45,6 +45,7 @@ import qualified Data.Set as S
 import Data.Semigroup
 
 import Math.NumberTheory.ArithmeticFunctions.Class
+import Math.NumberTheory.ArithmeticFunctions.Moebius
 import Math.NumberTheory.UniqueFactorisation
 import Math.NumberTheory.Utils.FromIntegral
 
@@ -154,12 +155,12 @@ jordanHelper pa 2 = (pa - 1) * pa
 jordanHelper pa k = (pa - 1) * pa ^ wordToInt (k - 1)
 {-# INLINE jordanHelper #-}
 
-moebius :: (UniqueFactorisation n, Num a) => n -> a
+moebius :: UniqueFactorisation n => n -> Moebius
 moebius = runFunction moebiusA
 
--- | Calculates the Moebius function of an argument.
-moebiusA :: Num a => ArithmeticFunction n a
-moebiusA = ArithmeticFunction (const f) runMoebius
+-- | Calculates the Möbius function of an argument.
+moebiusA :: ArithmeticFunction n Moebius
+moebiusA = ArithmeticFunction (const f) id
   where
     f 1 = MoebiusN
     f 0 = MoebiusP
@@ -218,28 +219,6 @@ expMangoldt = runFunction expMangoldtA
 -- | The exponent of von Mangoldt function. Use @log expMangoldtA@ to recover von Mangoldt function itself.
 expMangoldtA :: forall n. (UniqueFactorisation n, Num n) => ArithmeticFunction n n
 expMangoldtA = ArithmeticFunction (\((unPrime :: Prime n -> n) -> p) _ -> MangoldtOne p) runMangoldt
-
-data Moebius
-  = MoebiusZ
-  | MoebiusP
-  | MoebiusN
-
-runMoebius :: Num a => Moebius -> a
-runMoebius m = case m of
-  MoebiusZ ->  0
-  MoebiusP ->  1
-  MoebiusN -> -1
-
-instance Semigroup Moebius where
-  MoebiusZ <> _ = MoebiusZ
-  _ <> MoebiusZ = MoebiusZ
-  MoebiusP <> a = a
-  a <> MoebiusP = a
-  _ <> _ = MoebiusP
-
-instance Monoid Moebius where
-  mempty = MoebiusP
-  mappend = (<>)
 
 data Mangoldt a
   = MangoldtZero

--- a/Math/NumberTheory/MoebiusInversion.hs
+++ b/Math/NumberTheory/MoebiusInversion.hs
@@ -6,7 +6,7 @@
 -- Stability:   Provisional
 -- Portability: Non-portable (GHC extensions)
 --
--- Generalised Moebius inversion
+-- Generalised Möbius inversion
 --
 {-# LANGUAGE BangPatterns, FlexibleContexts #-}
 module Math.NumberTheory.MoebiusInversion
@@ -22,7 +22,7 @@ import Math.NumberTheory.Powers.Squares
 import Math.NumberTheory.Unsafe
 
 -- | @totientSum n@ is, for @n > 0@, the sum of @[totient k | k <- [1 .. n]]@,
---   computed via generalised Moebius inversion.
+--   computed via generalised Möbius inversion.
 --   See <http://mathworld.wolfram.com/TotientSummatoryFunction.html> for the
 --   formula used for @totientSum@.
 totientSum :: Int -> Integer
@@ -32,10 +32,10 @@ totientSum n
   where
     triangle k = (k*(k+1)) `quot` 2
 
--- | @generalInversion g n@ evaluates the generalised Moebius inversion of @g@
+-- | @generalInversion g n@ evaluates the generalised Möbius inversion of @g@
 --   at the argument @n@.
 --
---   The generalised Moebius inversion implemented here allows an efficient
+--   The generalised Möbius inversion implemented here allows an efficient
 --   calculation of isolated values of the function @f : N -> Z@ if the function
 --   @g@ defined by
 --
@@ -43,15 +43,15 @@ totientSum n
 -- > g n = sum [f (n `quot` k) | k <- [1 .. n]]
 -- >
 --
---   can be cheaply computed. By the generalised Moebius inversion formula, then
+--   can be cheaply computed. By the generalised Möbius inversion formula, then
 --
 -- >
 -- > f n = sum [moebius k * g (n `quot` k) | k <- [1 .. n]]
 -- >
 --
 --   which allows the computation in /O/(n) steps, if the values of the
---   Moebius function are known. A slightly different formula, used here,
---   does not need the values of the Moebius function and allows the
+--   Möbius function are known. A slightly different formula, used here,
+--   does not need the values of the Möbius function and allows the
 --   computation in /O/(n^0.75) steps, using /O/(n^0.5) memory.
 --
 --   An example of a pair of such functions where the inversion allows a
@@ -78,7 +78,7 @@ totientSum n
 --   method is only appropriate to compute isolated values of @f@.
 generalInversion :: (Int -> Integer) -> Int -> Integer
 generalInversion fun n
-    | n < 1     = error "Moebius inversion only defined on positive domain"
+    | n < 1     = error "Möbius inversion only defined on positive domain"
     | n == 1    = fun 1
     | n == 2    = fun 2 - fun 1
     | n == 3    = fun 3 - 2*fun 1

--- a/Math/NumberTheory/MoebiusInversion/Int.hs
+++ b/Math/NumberTheory/MoebiusInversion/Int.hs
@@ -6,7 +6,7 @@
 -- Stability:   Provisional
 -- Portability: Non-portable (GHC extensions)
 --
--- Generalised Moebius inversion for 'Int' valued functions.
+-- Generalised Möbius inversion for 'Int' valued functions.
 --
 {-# LANGUAGE BangPatterns, FlexibleContexts #-}
 {-# OPTIONS_GHC -fspec-constr-count=8 #-}
@@ -23,7 +23,7 @@ import Math.NumberTheory.Powers.Squares
 import Math.NumberTheory.Unsafe
 
 -- | @totientSum n@ is, for @n > 0@, the sum of @[totient k | k <- [1 .. n]]@,
---   computed via generalised Moebius inversion.
+--   computed via generalised Möbius inversion.
 --   See <http://mathworld.wolfram.com/TotientSummatoryFunction.html> for the
 --   formula used for @totientSum@.
 totientSum :: Int -> Int
@@ -33,10 +33,10 @@ totientSum n
   where
     triangle k = (k*(k+1)) `quot` 2
 
--- | @generalInversion g n@ evaluates the generalised Moebius inversion of @g@
+-- | @generalInversion g n@ evaluates the generalised Möbius inversion of @g@
 --   at the argument @n@.
 --
---   The generalised Moebius inversion implemented here allows an efficient
+--   The generalised Möbius inversion implemented here allows an efficient
 --   calculation of isolated values of the function @f : N -> Z@ if the function
 --   @g@ defined by
 --
@@ -44,15 +44,15 @@ totientSum n
 -- > g n = sum [f (n `quot` k) | k <- [1 .. n]]
 -- >
 --
---   can be cheaply computed. By the generalised Moebius inversion formula, then
+--   can be cheaply computed. By the generalised Möbius inversion formula, then
 --
 -- >
 -- > f n = sum [moebius k * g (n `quot` k) | k <- [1 .. n]]
 -- >
 --
 --   which allows the computation in /O/(n) steps, if the values of the
---   Moebius function are known. A slightly different formula, used here,
---   does not need the values of the Moebius function and allows the
+--   Möbius function are known. A slightly different formula, used here,
+--   does not need the values of the Möbius function and allows the
 --   computation in /O/(n^0.75) steps, using /O/(n^0.5) memory.
 --
 --   An example of a pair of such functions where the inversion allows a
@@ -79,7 +79,7 @@ totientSum n
 --   method is only appropriate to compute isolated values of @f@.
 generalInversion :: (Int -> Int) -> Int -> Int
 generalInversion fun n
-    | n < 1     = error "Moebius inversion only defined on positive domain"
+    | n < 1     = error "Möbius inversion only defined on positive domain"
     | n == 1    = fun 1
     | n == 2    = fun 2 - fun 1
     | n == 3    = fun 3 - 2*fun 1

--- a/Math/NumberTheory/Utils/Hyperbola.hs
+++ b/Math/NumberTheory/Utils/Hyperbola.hs
@@ -1,0 +1,92 @@
+-- |
+-- Module:      Math.NumberTheory.Utils.Hyperbola
+-- Copyright:   (c) 2018 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- Highest points under hyperbola.
+--
+
+{-# LANGUAGE CPP        #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Math.NumberTheory.Utils.Hyperbola
+  ( pointsUnderHyperbola
+  ) where
+
+import Data.Bits
+
+import Math.NumberTheory.Powers.Cubes
+
+-- | Straightforward computation of
+-- [ n `quot` x | x <- [hi, hi - 1 .. lo] ].
+-- Unfortunately, such list generator performs poor,
+-- so we fall back to manual recursion.
+pointsUnderHyperbola0 :: Int -> Int -> Int -> [Int]
+pointsUnderHyperbola0 n lo hi
+  | n < 0     = error "pointsUnderHyperbola0: first argument must be non-negative"
+  | lo <= 0   = error "pointsUnderHyperbola0: second argument must be positive"
+  | otherwise = go hi
+    where
+      go x
+        | x < lo    = []
+        | otherwise = n `quot` x : go (x - 1)
+
+data Bresenham = Bresenham
+  {  bresX       :: !Int
+  ,  bresBeta    :: !Int
+  , _bresGamma   :: !Int
+  , _bresDelta1  :: !Int
+  , _bresEpsilon :: !Int
+  }
+
+initBresenham :: Int -> Int -> Bresenham
+initBresenham n x = Bresenham x beta gamma delta1 epsilon
+  where
+    beta    = n `quot` x
+    epsilon = n `rem` x
+    delta1  = n `quot` (x - 1) - beta
+    gamma   = beta - (x - 1) * delta1
+
+-- | bresenham(x+1) -> bresenham(x) for x >= (2n)^1/3
+stepBack :: Bresenham -> Bresenham
+stepBack (Bresenham x' beta' gamma' delta1' epsilon') =
+  if eps >= x
+    then (if eps >= x `shiftL` 1
+      then {- delta2 = 2 -}
+        let delta1 = delta1' + 2 in (Bresenham x (beta' + delta1) (gamma' + delta1 `shiftL` 1 - x `shiftL` 1) delta1 (eps - x `shiftL` 1))
+      else {- delta1 = 1 -}
+        let delta1 = delta1' + 1 in (Bresenham x (beta' + delta1) (gamma' + delta1 `shiftL` 1 - x) delta1 (eps - x))
+      )
+    else (if eps >= 0
+      then {- delta2 =  0 -}
+        (Bresenham x (beta' + delta1') (gamma' + delta1' `shiftL` 1) delta1' eps)
+      else {- delta2 = -1 -}
+        let delta1 = delta1' - 1 in (Bresenham x (beta' + delta1) (gamma' + delta1 `shiftL` 1 + x) delta1 (eps + x)))
+  where
+    x       = x' - 1
+    eps     = epsilon' + gamma'
+{-# INLINE stepBack #-}
+
+-- | Division-free computation of
+-- [ n `quot` x | x <- [hi, hi - 1 .. lo] ].
+-- In other words, we compute y-coordinates of highest integral points
+-- under hyperbola @x * y = n@ between @x = lo@ and @x = hi@ in reverse order.
+--
+-- The implementation follows section 5 of <https://arxiv.org/pdf/1206.3369.pdf A successive approximation algorithm for computing the divisor summatory function>
+-- by R. Sladkey.
+-- It is 2x faster than a trivial implementation for 'Int'.
+pointsUnderHyperbola :: Int -> Int -> Int -> [Int]
+pointsUnderHyperbola n lo hi
+  | n < 0        = error "pointsUnderHyperbola: first argument must be non-negative"
+  | lo <= 0      = error "pointsUnderHyperbola: second argument must be positive"
+  | hi <  lo     = []
+  | hi == lo     = [n `quot` lo]
+  | otherwise    = go (initBresenham n hi)
+  where
+    mid = (integerCubeRoot (2 * n) + 1) `max` lo
+    go h
+      | bresX h < mid = pointsUnderHyperbola0 n lo ((mid - 1) `min` hi)
+      | otherwise = bresBeta h : go (stepBack h)

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -50,6 +50,7 @@ library
 
     exposed-modules     : Math.NumberTheory.ArithmeticFunctions
                           Math.NumberTheory.ArithmeticFunctions.Class
+                          Math.NumberTheory.ArithmeticFunctions.Moebius
                           Math.NumberTheory.ArithmeticFunctions.SieveBlock
                           Math.NumberTheory.ArithmeticFunctions.Standard
                           Math.NumberTheory.Curves.Montgomery

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -50,6 +50,7 @@ library
 
     exposed-modules     : Math.NumberTheory.ArithmeticFunctions
                           Math.NumberTheory.ArithmeticFunctions.Class
+                          Math.NumberTheory.ArithmeticFunctions.Mertens
                           Math.NumberTheory.ArithmeticFunctions.Moebius
                           Math.NumberTheory.ArithmeticFunctions.SieveBlock
                           Math.NumberTheory.ArithmeticFunctions.Standard
@@ -126,6 +127,7 @@ benchmark criterion
   if impl(ghc < 8.0)
     build-depends     : semigroups >= 0.8
   other-modules:    Math.NumberTheory.ArithmeticFunctionsBench
+                  , Math.NumberTheory.MertensBench
                   , Math.NumberTheory.PowersBench
                   , Math.NumberTheory.PrimesBench
                   , Math.NumberTheory.RecurrenciesBench
@@ -161,6 +163,7 @@ test-suite spec
     build-depends     : semigroups >= 0.8
 
   other-modules :   Math.NumberTheory.ArithmeticFunctionsTests
+                  , Math.NumberTheory.ArithmeticFunctions.MertensTests
                   , Math.NumberTheory.ArithmeticFunctions.SieveBlockTests
                   , Math.NumberTheory.CurvesTests
                   , Math.NumberTheory.GaussianIntegersTests

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -123,6 +123,8 @@ benchmark criterion
                     , vector
   if impl(ghc < 7.10)
     build-depends     : nats >= 1 && <1.2
+  if impl(ghc < 8.0)
+    build-depends     : semigroups >= 0.8
   other-modules:    Math.NumberTheory.ArithmeticFunctionsBench
                   , Math.NumberTheory.PowersBench
                   , Math.NumberTheory.PrimesBench

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -90,6 +90,7 @@ library
     other-modules       : Math.NumberTheory.ArithmeticFunctions.SieveBlock.Unboxed
                           Math.NumberTheory.Utils
                           Math.NumberTheory.Utils.FromIntegral
+                          Math.NumberTheory.Utils.Hyperbola
                           Math.NumberTheory.Unsafe
                           Math.NumberTheory.Primes.Counting.Impl
                           Math.NumberTheory.Primes.Counting.Approximate

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -3,6 +3,7 @@ module Main where
 import Criterion.Main
 
 import Math.NumberTheory.ArithmeticFunctionsBench as ArithmeticFunctions
+import Math.NumberTheory.MertensBench as Mertens
 import Math.NumberTheory.PowersBench as Powers
 import Math.NumberTheory.PrimesBench as Primes
 import Math.NumberTheory.RecurrenciesBench as Recurrencies
@@ -10,6 +11,7 @@ import Math.NumberTheory.SieveBlockBench as SieveBlock
 
 main = defaultMain
   [ ArithmeticFunctions.benchSuite
+  , Mertens.benchSuite
   , Powers.benchSuite
   , Primes.benchSuite
   , Recurrencies.benchSuite

--- a/benchmark/Math/NumberTheory/ArithmeticFunctionsBench.hs
+++ b/benchmark/Math/NumberTheory/ArithmeticFunctionsBench.hs
@@ -13,6 +13,7 @@ compareFunctions name new = bench name $ nf (map new) [1..100000]
 compareSetFunctions :: String -> (Integer -> Set Integer) -> Benchmark
 compareSetFunctions name new = bench name $ nf (map new) [1..100000]
 
+benchSuite :: Benchmark
 benchSuite = bgroup "ArithmeticFunctions"
   [ compareSetFunctions "divisors" A.divisors
   , bench "divisors/int" $ nf (map A.divisorsSmall) [1 :: Int .. 100000]

--- a/benchmark/Math/NumberTheory/ArithmeticFunctionsBench.hs
+++ b/benchmark/Math/NumberTheory/ArithmeticFunctionsBench.hs
@@ -18,7 +18,7 @@ benchSuite = bgroup "ArithmeticFunctions"
   , bench "divisors/int" $ nf (map A.divisorsSmall) [1 :: Int .. 100000]
   , compareFunctions "totient" A.totient
   , compareFunctions "carmichael" A.carmichael
-  , compareFunctions "moebius" A.moebius
+  , compareFunctions "moebius" (A.runMoebius . A.moebius)
   , compareFunctions "tau" A.tau
   , compareFunctions "sigma 1" (A.sigma 1)
   , compareFunctions "sigma 2" (A.sigma 2)

--- a/benchmark/Math/NumberTheory/MertensBench.hs
+++ b/benchmark/Math/NumberTheory/MertensBench.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE CPP        #-}
+{-# LANGUAGE LambdaCase #-}
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.MertensBench
+  ( benchSuite
+  ) where
+
+import Criterion.Main
+#if __GLASGOW_HASKELL__ < 709
+import Data.Word
+#endif
+
+import Math.NumberTheory.ArithmeticFunctions.Mertens
+
+mertensBench :: Word -> Benchmark
+mertensBench n = bench (show n) (nf mertens n)
+
+benchSuite :: Benchmark
+benchSuite = bgroup "Mertens" $ map mertensBench $ take 4 $ iterate (* 10) 10000000

--- a/benchmark/Math/NumberTheory/PowersBench.hs
+++ b/benchmark/Math/NumberTheory/PowersBench.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
 module Math.NumberTheory.PowersBench
   ( benchSuite
   ) where
@@ -25,4 +27,5 @@ compareRoots bits = bgroup ("sqrt" ++ show bits)
   where
     n = genInteger 0 bits
 
+benchSuite :: Benchmark
 benchSuite = bgroup "Powers" $ map compareRoots [2300, 2400 .. 2600]

--- a/benchmark/Math/NumberTheory/PrimesBench.hs
+++ b/benchmark/Math/NumberTheory/PrimesBench.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 module Math.NumberTheory.PrimesBench
   ( benchSuite

--- a/benchmark/Math/NumberTheory/RecurrenciesBench.hs
+++ b/benchmark/Math/NumberTheory/RecurrenciesBench.hs
@@ -5,8 +5,6 @@ module Math.NumberTheory.RecurrenciesBench
   ) where
 
 import Criterion.Main
-import Numeric.Natural
-import System.Random
 
 import Math.NumberTheory.Recurrencies.Bilinear
 
@@ -21,6 +19,7 @@ benchTriangle name triangle n = bgroup name
     benchAt i j = bench ("!! " ++ show i ++ " !! " ++ show j)
                 $ nf (\(x, y) -> triangle !! x !! y :: Integer) (i, j)
 
+benchSuite :: Benchmark
 benchSuite = bgroup "Bilinear"
   [ benchTriangle "binomial"  binomial 1000
   , benchTriangle "stirling1" stirling1 100

--- a/benchmark/Math/NumberTheory/SieveBlockBench.hs
+++ b/benchmark/Math/NumberTheory/SieveBlockBench.hs
@@ -88,5 +88,6 @@ benchSuite = bgroup "SieveBlock"
   , bgroup "moebius"
     [ bench "boxed"   $ nf (V.sum . V.map runMoebius . sieveBlock        moebiusConfig 1 :: Word -> Int) blockLen
     , bench "unboxed" $ nf (U.sum . U.map runMoebius . sieveBlockUnboxed moebiusConfig 1 :: Word -> Int) blockLen
+    , bench "special" $ nf (U.sum . U.map runMoebius . sieveBlockMoebius 1 :: Word -> Int) blockLen
     ]
   ]

--- a/benchmark/Math/NumberTheory/SieveBlockBench.hs
+++ b/benchmark/Math/NumberTheory/SieveBlockBench.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 
-{-# OPTIONS_GHC -fno-warn-deprecations #-}
+{-# OPTIONS_GHC -fno-warn-deprecations  #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 module Math.NumberTheory.SieveBlockBench
   ( benchSuite
@@ -59,6 +60,7 @@ sumOldCarmichaelSieve len' = sum $ map (fromInteger . sieveCarmichael sieve) [1 
     len = toInteger len'
     sieve = carmichaelSieve len
 
+benchSuite :: Benchmark
 benchSuite = bgroup "SieveBlock"
   [ bgroup "totient"
     [ bench "old"     $ nf sumOldTotientSieve blockLen

--- a/test-suite/Math/NumberTheory/ArithmeticFunctions/MertensTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctions/MertensTests.hs
@@ -28,7 +28,6 @@ import Data.Word
 
 import Math.NumberTheory.ArithmeticFunctions
 import Math.NumberTheory.ArithmeticFunctions.Mertens
-import Math.NumberTheory.ArithmeticFunctions.Moebius (sieveBlockMoebius)
 import Math.NumberTheory.ArithmeticFunctions.SieveBlock
 import Math.NumberTheory.TestUtils
 

--- a/test-suite/Math/NumberTheory/ArithmeticFunctions/MertensTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctions/MertensTests.hs
@@ -1,0 +1,75 @@
+-- |
+-- Module:      Math.NumberTheory.ArithmeticFunctions.MertensTests
+-- Copyright:   (c) 2018 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.ArithmeticFunctions.Mertens
+--
+
+{-# LANGUAGE CPP        #-}
+{-# LANGUAGE LambdaCase #-}
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.ArithmeticFunctions.MertensTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+
+import Data.Semigroup
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+#if __GLASGOW_HASKELL__ < 709
+import Data.Word
+#endif
+
+import Math.NumberTheory.ArithmeticFunctions
+import Math.NumberTheory.ArithmeticFunctions.Mertens
+import Math.NumberTheory.ArithmeticFunctions.Moebius (sieveBlockMoebius)
+import Math.NumberTheory.ArithmeticFunctions.SieveBlock
+import Math.NumberTheory.TestUtils
+
+moebiusConfig :: SieveBlockConfig Moebius
+moebiusConfig = SieveBlockConfig
+  { sbcEmpty                = MoebiusP
+  , sbcAppend               = (<>)
+  , sbcFunctionOnPrimePower = const $ \case
+      0 -> MoebiusP
+      1 -> MoebiusN
+      _ -> MoebiusZ
+  }
+
+mertensDiffPointwise :: Word -> Word -> Int
+mertensDiffPointwise lo len = sum $ map (runMoebius . moebius) [lo + 1 .. lo + len]
+
+mertensDiffBlockSpecial :: Word -> Word -> Int
+mertensDiffBlockSpecial lo len = U.sum $ U.map runMoebius
+  $ sieveBlockMoebius (lo + 1) len
+
+mertensDiffBlockUnboxed :: Word -> Word -> Int
+mertensDiffBlockUnboxed lo len = U.sum $ U.map runMoebius
+  $ sieveBlockUnboxed moebiusConfig (lo + 1) len
+
+mertensDiffBlockBoxed :: Word -> Word -> Int
+mertensDiffBlockBoxed lo len = V.sum $ V.map runMoebius
+  $ sieveBlock moebiusConfig (lo + 1) len
+
+mertensDiff :: Word -> Word -> Int
+mertensDiff lo len = mertens (lo + len) - mertens lo
+
+propertyCompare :: (Word -> Word -> Int) -> Word -> Word -> Bool
+propertyCompare func lo' len' = mertensDiff lo len == func lo len
+  where
+    lo  = lo'  `rem` 10000000
+    len = len' `rem` 1000
+
+testSuite :: TestTree
+testSuite = testGroup "Mertens"
+  [ testSmallAndQuick "pointwise"     $ propertyCompare mertensDiffPointwise
+  , testSmallAndQuick "block special" $ propertyCompare mertensDiffBlockSpecial
+  , testSmallAndQuick "block unboxed" $ propertyCompare mertensDiffBlockUnboxed
+  , testSmallAndQuick "block boxed"   $ propertyCompare mertensDiffBlockBoxed
+  ]

--- a/test-suite/Math/NumberTheory/ArithmeticFunctions/SieveBlockTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctions/SieveBlockTests.hs
@@ -29,7 +29,6 @@ import Data.Word
 
 import Math.NumberTheory.ArithmeticFunctions
 import Math.NumberTheory.ArithmeticFunctions.SieveBlock
-import Math.NumberTheory.ArithmeticFunctions.Moebius (sieveBlockMoebius)
 
 pointwiseTest :: (Eq a, Show a) => ArithmeticFunction Word a -> Word -> Word -> IO ()
 pointwiseTest f lowIndex len = assertEqual "pointwise"

--- a/test-suite/Math/NumberTheory/ArithmeticFunctions/SieveBlockTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctions/SieveBlockTests.hs
@@ -41,10 +41,33 @@ unboxedTest config = assertEqual "unboxed"
     (sieveBlock config 1 1000)
     (U.convert $ sieveBlockUnboxed config 1 1000)
 
-moebiusTest :: IO ()
-moebiusTest = assertEqual "special"
-    (sieveBlock moebiusConfig 1 1000)
-    (U.convert $ sieveBlockMoebius 1 1000)
+moebiusTest :: Word -> Word -> Bool
+moebiusTest m n
+  = m == 0
+  || sieveBlockUnboxed moebiusConfig m n
+  == sieveBlockMoebius m n
+
+moebiusSpecialCases :: [TestTree]
+moebiusSpecialCases = map (uncurry pairToTest)
+  [ (1, 1)
+  , (208, 298)
+  , (1, 12835)
+  , (10956, 4430)
+  , (65, 16171)
+  , (120906, 19456)
+  , (33800000, 27002)
+  , (17266222643, 5051)
+  , (1000158, 48758)
+  , (1307265, 3725)
+  , (2600000, 14686)
+  , (4516141422507 - 100000, 100001)
+  , (1133551497049257 - 100000, 100001)
+  -- too long for regular runs
+  -- , (1157562178759482171 - 100000, 100001)
+  ]
+  where
+    pairToTest :: Word -> Word -> TestTree
+    pairToTest m n = testCase (show m ++ "," ++ show n) $ assertBool "should be equal" $ moebiusTest m n
 
 multiplicativeConfig :: (Word -> Word -> Word) -> SieveBlockConfig Word
 multiplicativeConfig f = SieveBlockConfig
@@ -80,5 +103,5 @@ testSuite = testGroup "SieveBlock"
     , testCase "moebius" $ unboxedTest moebiusConfig
     , testCase "totient" $ unboxedTest $ multiplicativeConfig (\p a -> (p - 1) * p ^ (a - 1))
     ]
-  , testCase "special moebius" moebiusTest
+  , testGroup "special moebius" moebiusSpecialCases
   ]

--- a/test-suite/Math/NumberTheory/ArithmeticFunctions/SieveBlockTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctions/SieveBlockTests.hs
@@ -29,6 +29,7 @@ import Data.Word
 
 import Math.NumberTheory.ArithmeticFunctions
 import Math.NumberTheory.ArithmeticFunctions.SieveBlock
+import Math.NumberTheory.ArithmeticFunctions.Moebius (sieveBlockMoebius)
 
 pointwiseTest :: (Eq a, Show a) => ArithmeticFunction Word a -> Word -> Word -> IO ()
 pointwiseTest f lowIndex len = assertEqual "pointwise"
@@ -39,6 +40,11 @@ unboxedTest :: (Eq a, U.Unbox a, Show a) => SieveBlockConfig a -> IO ()
 unboxedTest config = assertEqual "unboxed"
     (sieveBlock config 1 1000)
     (U.convert $ sieveBlockUnboxed config 1 1000)
+
+moebiusTest :: IO ()
+moebiusTest = assertEqual "special"
+    (sieveBlock moebiusConfig 1 1000)
+    (U.convert $ sieveBlockMoebius 1 1000)
 
 multiplicativeConfig :: (Word -> Word -> Word) -> SieveBlockConfig Word
 multiplicativeConfig f = SieveBlockConfig
@@ -74,4 +80,5 @@ testSuite = testGroup "SieveBlock"
     , testCase "moebius" $ unboxedTest moebiusConfig
     , testCase "totient" $ unboxedTest $ multiplicativeConfig (\p a -> (p - 1) * p ^ (a - 1))
     ]
+  , testCase "special moebius" moebiusTest
   ]

--- a/test-suite/Math/NumberTheory/ArithmeticFunctionsTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctionsTests.hs
@@ -138,21 +138,17 @@ jordan2Oeis = oeisAssertion "A007434" (jordanA 2)
   , 1728, 1584, 2208, 1536
   ]
 
--- | moebius values are [-1, 0, 1]
-moebiusProperty1 :: Natural -> Bool
-moebiusProperty1 n = runFunction moebiusA n `elem` [-1, 0, 1]
-
 -- | moebius does not require full factorisation
 moebiusLazy :: Assertion
-moebiusLazy = assertEqual "moebius" 0 (runFunction moebiusA (2^2 * (2^100000-1) :: Natural))
+moebiusLazy = assertEqual "moebius" MoebiusZ (runFunction moebiusA (2^2 * (2^100000-1) :: Natural))
 
 -- | moebius matches baseline from OEIS.
 moebiusOeis :: Assertion
 moebiusOeis = oeisAssertion "A008683" moebiusA
-  [ 1, -1, -1, 0, -1, 1, -1, 0, 0, 1, -1, 0, -1, 1, 1, 0, -1, 0, -1, 0, 1, 1, -1
-  , 0, 0, 1, 0, 0, -1, -1, -1, 0, 1, 1, 1, 0, -1, 1, 1, 0, -1, -1, -1, 0, 0, 1
-  , -1, 0, 0, 0, 1, 0, -1, 0, 1, 0, 1, 1, -1, 0, -1, 1, 0, 0, 1, -1, -1, 0, 1
-  , -1, -1, 0, -1, 1, 0, 0, 1
+  [ MoebiusP, MoebiusN, MoebiusN, MoebiusZ, MoebiusN, MoebiusP, MoebiusN, MoebiusZ, MoebiusZ, MoebiusP, MoebiusN, MoebiusZ, MoebiusN, MoebiusP, MoebiusP, MoebiusZ, MoebiusN, MoebiusZ, MoebiusN, MoebiusZ, MoebiusP, MoebiusP, MoebiusN
+  , MoebiusZ, MoebiusZ, MoebiusP, MoebiusZ, MoebiusZ, MoebiusN, MoebiusN, MoebiusN, MoebiusZ, MoebiusP, MoebiusP, MoebiusP, MoebiusZ, MoebiusN, MoebiusP, MoebiusP, MoebiusZ, MoebiusN, MoebiusN, MoebiusN, MoebiusZ, MoebiusZ, MoebiusP
+  , MoebiusN, MoebiusZ, MoebiusZ, MoebiusZ, MoebiusP, MoebiusZ, MoebiusN, MoebiusZ, MoebiusP, MoebiusZ, MoebiusP, MoebiusP, MoebiusN, MoebiusZ, MoebiusN, MoebiusP, MoebiusZ, MoebiusZ, MoebiusP, MoebiusN, MoebiusN, MoebiusZ, MoebiusP
+  , MoebiusN, MoebiusN, MoebiusZ, MoebiusN, MoebiusP, MoebiusZ, MoebiusZ, MoebiusP
   ]
 
 -- | liouville values are [-1, 1]
@@ -161,7 +157,7 @@ liouvilleProperty1 n = runFunction liouvilleA n `elem` [-1, 1]
 
 -- | moebius is zero or equal to liouville
 liouvilleProperty2 :: Natural -> Bool
-liouvilleProperty2 n = m == 0 || l == m
+liouvilleProperty2 n = m == MoebiusZ || l == runMoebius m
   where
     l = runFunction liouvilleA n
     m = runFunction moebiusA   n
@@ -261,8 +257,7 @@ testSuite = testGroup "ArithmeticFunctions"
     , testCase          "OEIS jordan_2"      jordan2Oeis
     ]
   , testGroup "Moebius"
-    [ testSmallAndQuick "moebius values" moebiusProperty1
-    , testCase          "OEIS"           moebiusOeis
+    [ testCase          "OEIS"           moebiusOeis
     , testCase          "Lazy"           moebiusLazy
     ]
   , testGroup "Liouville"

--- a/test-suite/Math/NumberTheory/MoebiusInversion/IntTests.hs
+++ b/test-suite/Math/NumberTheory/MoebiusInversion/IntTests.hs
@@ -37,7 +37,7 @@ totientSumZero = assertEqual "totientSum" 0 (totientSum 0)
 generalInversionProperty :: (Int -> Int) -> Positive Int -> Bool
 generalInversionProperty g (Positive n)
   =  g n == sum [f (n `quot` k) | k <- [1 .. n]]
-  && f n == sum [fromInteger (moebius (toInteger k)) * g (n `quot` k) | k <- [1 .. n]]
+  && f n == sum [runMoebius (moebius k) * g (n `quot` k) | k <- [1 .. n]]
   where
     f = generalInversion g
 

--- a/test-suite/Math/NumberTheory/MoebiusInversionTests.hs
+++ b/test-suite/Math/NumberTheory/MoebiusInversionTests.hs
@@ -37,7 +37,7 @@ totientSumZero = assertEqual "totientSum" 0 (totientSum 0)
 generalInversionProperty :: (Int -> Integer) -> Positive Int -> Bool
 generalInversionProperty g (Positive n)
   =  g n == sum [f (n `quot` k) | k <- [1 .. n]]
-  && f n == sum [moebius (toInteger k) * g (n `quot` k) | k <- [1 .. n]]
+  && f n == sum [runMoebius (moebius k) * g (n `quot` k) | k <- [1 .. n]]
   where
     f = generalInversion g
 

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -32,6 +32,7 @@ import qualified Math.NumberTheory.Primes.TestingTests as Testing
 import qualified Math.NumberTheory.GaussianIntegersTests as Gaussian
 
 import qualified Math.NumberTheory.ArithmeticFunctionsTests as ArithmeticFunctions
+import qualified Math.NumberTheory.ArithmeticFunctions.MertensTests as Mertens
 import qualified Math.NumberTheory.ArithmeticFunctions.SieveBlockTests as SieveBlock
 import qualified Math.NumberTheory.UniqueFactorisationTests as UniqueFactorisation
 import qualified Math.NumberTheory.ZetaTests as Zeta
@@ -83,6 +84,7 @@ tests = testGroup "All"
     ]
   , testGroup "ArithmeticFunctions"
     [ ArithmeticFunctions.testSuite
+    , Mertens.testSuite
     , SieveBlock.testSuite
     ]
   , testGroup "UniqueFactorisation"


### PR DESCRIPTION
This PR aims to fulfil Step 2 from #60: sublinear summation of Mobius function (so called [Mertens function](https://en.wikipedia.org/wiki/Mertens_function)). 

*  Introduce a special type for values of Mobius function. Mobius function returns only in -1, 0 or 1, so it is convenient to denote them by three-valued enum.
* Write a specialised, space-effective and fast version of `sieveBlock` for Mobius function. It is 5x faster than generic `sieveBlockUnboxed`.
* Implement sublinear Mertens function with time and space complexity O(n^(2/3)).

Reference: https://arxiv.org/abs/1610.08551v2