### PR TITLE
Benchmark binaryGCD and coprime against Prelude alternatives

### DIFF
--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -128,6 +128,7 @@ benchmark criterion
   if impl(ghc < 8.0)
     build-depends     : semigroups >= 0.8
   other-modules:    Math.NumberTheory.ArithmeticFunctionsBench
+                  , Math.NumberTheory.GCDBench
                   , Math.NumberTheory.MertensBench
                   , Math.NumberTheory.PowersBench
                   , Math.NumberTheory.PrimesBench

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -3,6 +3,7 @@ module Main where
 import Criterion.Main
 
 import Math.NumberTheory.ArithmeticFunctionsBench as ArithmeticFunctions
+import Math.NumberTheory.GCDBench as GCD
 import Math.NumberTheory.MertensBench as Mertens
 import Math.NumberTheory.PowersBench as Powers
 import Math.NumberTheory.PrimesBench as Primes
@@ -11,6 +12,7 @@ import Math.NumberTheory.SieveBlockBench as SieveBlock
 
 main = defaultMain
   [ ArithmeticFunctions.benchSuite
+  , GCD.benchSuite
   , Mertens.benchSuite
   , Powers.benchSuite
   , Primes.benchSuite

--- a/benchmark/Math/NumberTheory/GCDBench.hs
+++ b/benchmark/Math/NumberTheory/GCDBench.hs
@@ -1,0 +1,21 @@
+module Math.NumberTheory.GCDBench
+  ( benchSuite
+  ) where
+
+import Criterion.Main
+
+import Math.NumberTheory.GCD as A
+import Prelude as P
+  
+benchSuite = bgroup "GCD"
+  [ subSuite "large coprimes" 1073741823 100003
+  , subSuite "powers of 2" (2^12) (2^19)
+  , subSuite "power of 23" (23^3) (23^7)
+  ]
+  where subSuite :: String -> Int -> Int -> Benchmark
+        subSuite name m n = bgroup name
+          [ bench "Prelude.gcd" $ nf (P.gcd m) n
+          , bench "binaryGCD" $ nf (A.binaryGCD m) n
+          , bench "Prelude.coprime" $ nf (\n -> 1 == P.gcd m n) n
+          , bench "coprime" $ nf (A.coprime m) n
+          ]


### PR DESCRIPTION
I took a stab at #80.

So far, I have only benchmarked cases 1 and 2. These are the preliminary results on my box:
![image](https://user-images.githubusercontent.com/6616642/36649349-436f507a-1a51-11e8-9c82-2be0476ec603.png)

I'd appreciate any feedback, aspecially regarding the benchmark cases.