### PR TITLE
Support GHC 8.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,12 @@ matrix:
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.1"
-      env: GHCHEAD=true
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
     - compiler: "ghc-head"
       env: GHCHEAD=true
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-head], sources: [hvr-ghc]}}
 
   allow_failures:
-    - compiler: "ghc-8.4.1"
     - compiler: "ghc-head"
 
 before_install:

--- a/Math/NumberTheory/ArithmeticFunctions/Class.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/Class.hs
@@ -21,7 +21,9 @@ module Math.NumberTheory.ArithmeticFunctions.Class
   ) where
 
 import Control.Applicative
+#if __GLASGOW_HASKELL__ < 803
 import Data.Semigroup
+#endif
 
 #if MIN_VERSION_base(4,8,0)
 #else

--- a/Math/NumberTheory/ArithmeticFunctions/Moebius.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/Moebius.hs
@@ -10,6 +10,7 @@
 --
 
 {-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE MagicHash             #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies          #-}
@@ -25,7 +26,9 @@ import Control.Monad.ST (runST)
 import Data.Bits
 import Data.Int
 import Data.Word
+#if __GLASGOW_HASKELL__ < 803
 import Data.Semigroup
+#endif
 import qualified Data.Vector.Generic         as G
 import qualified Data.Vector.Generic.Mutable as M
 import qualified Data.Vector.Primitive as P

--- a/Math/NumberTheory/Moduli/Jacobi.hs
+++ b/Math/NumberTheory/Moduli/Jacobi.hs
@@ -20,7 +20,9 @@ module Math.NumberTheory.Moduli.Jacobi
 
 import Data.Array.Unboxed
 import Data.Bits
+#if __GLASGOW_HASKELL__ < 803
 import Data.Semigroup
+#endif
 #if __GLASGOW_HASKELL__ < 709
 import Data.Word
 #endif

--- a/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
+++ b/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
@@ -61,7 +61,9 @@ import Data.IntMap (IntMap)
 import qualified Data.IntMap as IM
 import Data.List (foldl')
 import Data.Maybe
+#if __GLASGOW_HASKELL__ < 803
 import Data.Semigroup
+#endif
 
 import GHC.TypeNats.Compat
 

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -120,7 +120,7 @@ source-repository head
 benchmark criterion
   build-depends:    base
                     , arithmoi
-                    , criterion
+                    , gauge
                     , containers
                     , random
                     , integer-logarithms

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import Criterion.Main
+import Gauge.Main
 
 import Math.NumberTheory.ArithmeticFunctionsBench as ArithmeticFunctions
 import Math.NumberTheory.GCDBench as GCD

--- a/benchmark/Math/NumberTheory/ArithmeticFunctionsBench.hs
+++ b/benchmark/Math/NumberTheory/ArithmeticFunctionsBench.hs
@@ -2,7 +2,7 @@ module Math.NumberTheory.ArithmeticFunctionsBench
   ( benchSuite
   ) where
 
-import Criterion.Main
+import Gauge.Main
 import Data.Set (Set)
 
 import Math.NumberTheory.ArithmeticFunctions as A

--- a/benchmark/Math/NumberTheory/GCDBench.hs
+++ b/benchmark/Math/NumberTheory/GCDBench.hs
@@ -2,11 +2,11 @@ module Math.NumberTheory.GCDBench
   ( benchSuite
   ) where
 
-import Criterion.Main
+import Gauge.Main
 
 import Math.NumberTheory.GCD as A
 import Prelude as P
-  
+
 benchSuite = bgroup "GCD"
   [ subSuite "large coprimes" 1073741823 100003
   , subSuite "powers of 2" (2^12) (2^19)

--- a/benchmark/Math/NumberTheory/MertensBench.hs
+++ b/benchmark/Math/NumberTheory/MertensBench.hs
@@ -7,7 +7,7 @@ module Math.NumberTheory.MertensBench
   ( benchSuite
   ) where
 
-import Criterion.Main
+import Gauge.Main
 #if __GLASGOW_HASKELL__ < 709
 import Data.Word
 #endif

--- a/benchmark/Math/NumberTheory/PowersBench.hs
+++ b/benchmark/Math/NumberTheory/PowersBench.hs
@@ -4,7 +4,7 @@ module Math.NumberTheory.PowersBench
   ( benchSuite
   ) where
 
-import Criterion.Main
+import Gauge.Main
 import System.Random
 
 import Math.NumberTheory.Logarithms (integerLog2)

--- a/benchmark/Math/NumberTheory/PrimesBench.hs
+++ b/benchmark/Math/NumberTheory/PrimesBench.hs
@@ -4,7 +4,7 @@ module Math.NumberTheory.PrimesBench
   ( benchSuite
   ) where
 
-import Criterion.Main
+import Gauge.Main
 import System.Random
 
 import Math.NumberTheory.Logarithms (integerLog2)

--- a/benchmark/Math/NumberTheory/RecurrenciesBench.hs
+++ b/benchmark/Math/NumberTheory/RecurrenciesBench.hs
@@ -4,7 +4,7 @@ module Math.NumberTheory.RecurrenciesBench
   ( benchSuite
   ) where
 
-import Criterion.Main
+import Gauge.Main
 
 import Math.NumberTheory.Recurrencies.Bilinear
 

--- a/benchmark/Math/NumberTheory/SieveBlockBench.hs
+++ b/benchmark/Math/NumberTheory/SieveBlockBench.hs
@@ -8,7 +8,7 @@ module Math.NumberTheory.SieveBlockBench
   ( benchSuite
   ) where
 
-import Criterion.Main
+import Gauge.Main
 #if __GLASGOW_HASKELL__ < 803
 import Data.Semigroup
 #endif

--- a/benchmark/Math/NumberTheory/SieveBlockBench.hs
+++ b/benchmark/Math/NumberTheory/SieveBlockBench.hs
@@ -9,7 +9,9 @@ module Math.NumberTheory.SieveBlockBench
   ) where
 
 import Criterion.Main
+#if __GLASGOW_HASKELL__ < 803
 import Data.Semigroup
+#endif
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 #if __GLASGOW_HASKELL__ < 709

--- a/test-suite/Math/NumberTheory/ArithmeticFunctions/MertensTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctions/MertensTests.hs
@@ -19,7 +19,9 @@ module Math.NumberTheory.ArithmeticFunctions.MertensTests
 
 import Test.Tasty
 
+#if __GLASGOW_HASKELL__ < 803
 import Data.Semigroup
+#endif
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 #if __GLASGOW_HASKELL__ < 709

--- a/test-suite/Math/NumberTheory/ArithmeticFunctions/SieveBlockTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctions/SieveBlockTests.hs
@@ -20,7 +20,9 @@ module Math.NumberTheory.ArithmeticFunctions.SieveBlockTests
 import Test.Tasty
 import Test.Tasty.HUnit
 
+#if __GLASGOW_HASKELL__ < 803
 import Data.Semigroup
+#endif
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 #if __GLASGOW_HASKELL__ < 709

--- a/test-suite/Math/NumberTheory/ArithmeticFunctions/SieveBlockTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctions/SieveBlockTests.hs
@@ -51,6 +51,7 @@ moebiusTest m n
 moebiusSpecialCases :: [TestTree]
 moebiusSpecialCases = map (uncurry pairToTest)
   [ (1, 1)
+  , (1, 2)
   , (208, 298)
   , (1, 12835)
   , (10956, 4430)

--- a/test-suite/Math/NumberTheory/Moduli/JacobiTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/JacobiTests.hs
@@ -20,7 +20,9 @@ module Math.NumberTheory.Moduli.JacobiTests
 import Test.Tasty
 
 import Data.Bits
+#if __GLASGOW_HASKELL__ < 803
 import Data.Semigroup
+#endif
 
 import Math.NumberTheory.Moduli hiding (invertMod)
 import Math.NumberTheory.TestUtils


### PR DESCRIPTION
Just for history: our test suite triggered two bugs in GHC 8.4 alphas, filed as [#14754](https://ghc.haskell.org/trac/ghc/ticket/14754) and [#14768](https://ghc.haskell.org/trac/ghc/ticket/14768). 

I've also replaced `criterion` with `gauge`, because I got tired of dependency footprint of the former. 