### PR TITLE
Don't report -1 as a factor

### DIFF
--- a/Math/NumberTheory/GaussianIntegers.hs
+++ b/Math/NumberTheory/GaussianIntegers.hs
@@ -189,10 +189,11 @@ a .^ e
     s = a .^ div e 2
 
 -- |Compute the prime factorisation of a Gaussian integer. This is unique up to units (+/- 1, +/- i).
+-- Unit factors are not included in the result.
 factorise :: GaussianInteger -> [(GaussianInteger, Int)]
 factorise g = helper (Factorisation.factorise $ norm g) g
     where
-    helper [] g' = if g' == 1 then [] else [(g', 1)] -- include the unit, if it isn't 1
+    helper [] _ = []
     helper ((!p, !e) : pt) g' =
         -- For a given prime factor p of the magnitude squared...
         let (!g'', !facs) = if p `mod` 4 == 3

--- a/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
+++ b/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
@@ -78,16 +78,15 @@ import Math.NumberTheory.Primes.Testing.Probabilistic
 import Math.NumberTheory.Unsafe
 import Math.NumberTheory.Utils
 
--- | @'factorise' n@ produces the prime factorisation of @n@, including
---   a factor of @(-1)@ if @n < 0@. @'factorise' 0@ is an error and the
---   factorisation of @1@ is empty. Uses a 'StdGen' produced in an arbitrary
---   manner from the bit-pattern of @n@.
+-- | @'factorise' n@ produces the prime factorisation of @n@. @'factorise' 0@ is
+--   an error and the factorisation of @1@ is empty. Uses a 'StdGen' produced in
+--   an arbitrary manner from the bit-pattern of @n@.
 factorise :: Integer -> [(Integer,Int)]
 factorise n
-    | n < 0     = (-1,1):factorise (-n)
-    | n == 0    = error "0 has no prime factorisation"
-    | n == 1    = []
-    | otherwise = factorise' n
+    | abs n == 1 = []
+    | n < 0      = factorise (-n)
+    | n == 0     = error "0 has no prime factorisation"
+    | otherwise  = factorise' n
 
 -- | Like 'factorise', but without input checking, hence @n > 1@ is required.
 factorise' :: Integer -> [(Integer,Int)]

--- a/Math/NumberTheory/Primes/Sieve/Misc.hs
+++ b/Math/NumberTheory/Primes/Sieve/Misc.hs
@@ -123,7 +123,6 @@ fsPrimeTest fs@(FS bnd sve) n
     | otherwise = error "Out of bounds"
 
 -- | @'sieveFactor' fs n@ finds the prime factorisation of @n@ using the 'FactorSieve' @fs@.
---   For negative @n@, a factor of @-1@ is included with multiplicity @1@.
 --   After stripping any present factors @2@, the remaining cofactor @c@ (if larger
 --   than @1@) is factorised with @fs@. This is most efficient of course if @c@ does not
 --   exceed the bound with which @fs@ was constructed. If it does, trial division is performed
@@ -136,7 +135,7 @@ sieveFactor (FS bnd sve) = check
     check 0 = error "0 has no prime factorisation"
     check 1 = []
     check n
-      | n < 0       = (-1,1) : check (-n)
+      | n < 0       = check (-n)
       | n <= bound  = go2w (fromIntegral n)     -- avoid expensive Integer ops if possible
       | fromInteger n .&. (1 :: Int) == 1 = sieveLoop n
       | otherwise   = go2 n

--- a/test-suite/Math/NumberTheory/GaussianIntegersTests.hs
+++ b/test-suite/Math/NumberTheory/GaussianIntegersTests.hs
@@ -34,7 +34,7 @@ lazyCases =
 factoriseProperty1 :: Integer -> Integer -> Bool
 factoriseProperty1 x y
   =  x == 0 && y == 0
-  || g == g'
+  || abs g == abs g'
   where
     g = x :+ y
     factors = factorise g

--- a/test-suite/Math/NumberTheory/Primes/FactorisationTests.hs
+++ b/test-suite/Math/NumberTheory/Primes/FactorisationTests.hs
@@ -60,7 +60,7 @@ factoriseProperty1 :: Assertion
 factoriseProperty1 = assertEqual "0" [] (factorise 1)
 
 factoriseProperty2 :: Positive Integer -> Bool
-factoriseProperty2 (Positive n) = (-1, 1) : factorise n == factorise (negate n)
+factoriseProperty2 (Positive n) = factorise n == factorise (negate n)
 
 factoriseProperty3 :: Positive Integer -> Bool
 factoriseProperty3 (Positive n) = all (isPrime . fst) (factorise n)


### PR DESCRIPTION
Fixes #95 

Not sure if `abs g == abs g'` is the best way to go about this in the property. Feels a little too forgetful, but I'm not sure how else to reformulate the test to get it to pass.