### PR TITLE
Jacobi facelifting

### DIFF
--- a/Math/NumberTheory/Moduli/Jacobi.hs
+++ b/Math/NumberTheory/Moduli/Jacobi.hs
@@ -25,6 +25,7 @@ import Data.Bits
 #if __GLASGOW_HASKELL__ < 803
 import Data.Semigroup
 #endif
+import Numeric.Natural
 
 import Math.NumberTheory.Unsafe
 import Math.NumberTheory.Utils
@@ -62,6 +63,7 @@ negJS = \case
 -- > > jacobi 1001 9907
 -- > MinusOne
 {-# SPECIALISE jacobi :: Integer -> Integer -> JacobiSymbol,
+                         Natural -> Natural -> JacobiSymbol,
                          Int -> Int -> JacobiSymbol,
                          Word -> Word -> JacobiSymbol
   #-}
@@ -75,6 +77,7 @@ jacobi a b
 -- | Similar to 'jacobi', but the condition on the lower argument
 -- (\"denominator\") is __not__ checked.
 {-# SPECIALISE jacobi' :: Integer -> Integer -> JacobiSymbol,
+                          Natural -> Natural -> JacobiSymbol,
                           Int -> Int -> JacobiSymbol,
                           Word -> Word -> JacobiSymbol
   #-}

--- a/Math/NumberTheory/Moduli/Jacobi.hs
+++ b/Math/NumberTheory/Moduli/Jacobi.hs
@@ -77,10 +77,9 @@ jacobi' 0 _ = Zero
 jacobi' 1 _ = One
 jacobi' a b
   | a < 0     = let n = if rem4is3 b then MinusOne else One
-                    -- Blech, minBound may pose problems
-                    (z, o) = shiftToOddCount (abs $ toInteger a)
+                    (z, o) = shiftToOddCount (negate a)
                     s = if evenI z || rem8is1or7 b then n else negJS n
-                in s <> jacobi' (fromInteger o) b
+                in s <> jacobi' o b
   | a >= b    = case a `rem` b of
                   0 -> Zero
                   r -> jacPS One r b

--- a/Math/NumberTheory/Moduli/Jacobi.hs
+++ b/Math/NumberTheory/Moduli/Jacobi.hs
@@ -106,10 +106,6 @@ jacobi' a b
                     _ -> jacOL One      b a
 
 -- numerator positive and smaller than denominator
-{-# SPECIALISE jacPS :: JacobiSymbol -> Integer -> Integer -> JacobiSymbol,
-                        JacobiSymbol -> Int -> Int -> JacobiSymbol,
-                        JacobiSymbol -> Word -> Word -> JacobiSymbol
-  #-}
 jacPS :: (Integral a, Bits a) => JacobiSymbol -> a -> a -> JacobiSymbol
 jacPS j a b
   | evenI a     = case shiftToOddCount a of
@@ -120,10 +116,6 @@ jacPS j a b
   | otherwise   = jacOL (if rem4 a .&. rem4 b == 3 then (negJS j) else j) b a
 
 -- numerator odd, positive and larger than denominator
-{-# SPECIALISE jacOL :: JacobiSymbol -> Integer -> Integer -> JacobiSymbol,
-                        JacobiSymbol -> Int -> Int -> JacobiSymbol,
-                        JacobiSymbol -> Word -> Word -> JacobiSymbol
-  #-}
 jacOL :: (Integral a, Bits a) => JacobiSymbol -> a -> a -> JacobiSymbol
 jacOL j a b
   | b == 1    = j
@@ -135,24 +127,12 @@ jacOL j a b
 
 -- For large Integers, going via Int is much faster than bit-fiddling
 -- on the Integer, so we do that.
-{-# SPECIALISE evenI :: Integer -> Bool,
-                        Int -> Bool,
-                        Word -> Bool
-  #-}
 evenI :: Integral a => a -> Bool
 evenI n = fromIntegral n .&. 1 == (0 :: Int)
 
-{-# SPECIALISE rem4 :: Integer -> Int,
-                       Int -> Int,
-                       Word -> Int
-  #-}
 rem4 :: Integral a => a -> Int
 rem4 n = fromIntegral n .&. 3
 
-{-# SPECIALISE rem8 :: Integer -> Int,
-                       Int -> Int,
-                       Word -> Int
-  #-}
 rem8 :: Integral a => a -> Int
 rem8 n = fromIntegral n .&. 7
 

--- a/Math/NumberTheory/Moduli/Jacobi.hs
+++ b/Math/NumberTheory/Moduli/Jacobi.hs
@@ -1,12 +1,14 @@
 -- |
 -- Module:      Math.NumberTheory.Moduli.Jacobi
--- Copyright:   (c) 2011 Daniel Fischer, 2017 Andrew Lelechenko
+-- Copyright:   (c) 2011 Daniel Fischer, 2017-2018 Andrew Lelechenko
 -- Licence:     MIT
 -- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
 -- Stability:   Provisional
 -- Portability: Non-portable (GHC extensions)
 --
--- Jacobi symbol.
+-- <https://en.wikipedia.org/wiki/Jacobi_symbol Jacobi symbol>
+-- is a generalization of the Legendre symbol, useful for primality
+-- testing and integer factorization.
 --
 
 {-# LANGUAGE CPP        #-}
@@ -27,7 +29,8 @@ import Data.Semigroup
 import Math.NumberTheory.Unsafe
 import Math.NumberTheory.Utils
 
--- | Type for result of 'jacobi'.
+-- | Represents three possible values of
+-- <https://en.wikipedia.org/wiki/Jacobi_symbol Jacobi symbol>.
 data JacobiSymbol = MinusOne | Zero | One
   deriving (Eq, Ord, Show)
 
@@ -47,11 +50,17 @@ negJS = \case
   Zero     -> Zero
   One      -> MinusOne
 
--- | Jacobi symbol of two numbers.
---   The \"denominator\" must be odd and positive, this condition is checked.
+-- | <https://en.wikipedia.org/wiki/Jacobi_symbol Jacobi symbol> of two arguments.
+-- The lower argument (\"denominator\") must be odd and positive,
+-- this condition is checked.
 --
---   If both numbers have a common prime factor, the result
---   is @0@, otherwise it is &#177;1.
+-- If arguments have a common factor, the result
+-- is 'Zero', otherwise it is 'MinusOne' or 'One'.
+--
+-- > > jacobi 1001 9911
+-- > Zero -- arguments have a common factor 11
+-- > > jacobi 1001 9907
+-- > MinusOne
 {-# SPECIALISE jacobi :: Integer -> Integer -> JacobiSymbol,
                          Int -> Int -> JacobiSymbol,
                          Word -> Word -> JacobiSymbol
@@ -63,9 +72,8 @@ jacobi a b
   | b == 1      = One
   | otherwise   = jacobi' a b   -- b odd, > 1
 
--- Invariant: b > 1 and odd
--- | Jacobi symbol of two numbers without validity check of
---   the \"denominator\".
+-- | Similar to 'jacobi', but the condition on the lower argument
+-- (\"denominator\") is __not__ checked.
 {-# SPECIALISE jacobi' :: Integer -> Integer -> JacobiSymbol,
                           Int -> Int -> JacobiSymbol,
                           Word -> Word -> JacobiSymbol

--- a/Math/NumberTheory/Moduli/Jacobi.hs
+++ b/Math/NumberTheory/Moduli/Jacobi.hs
@@ -11,8 +11,9 @@
 -- testing and integer factorization.
 --
 
-{-# LANGUAGE CPP        #-}
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP          #-}
+{-# LANGUAGE LambdaCase   #-}
 
 module Math.NumberTheory.Moduli.Jacobi
   ( JacobiSymbol(..)
@@ -99,7 +100,7 @@ jacobi' a b
 
 -- numerator positive and smaller than denominator
 jacPS :: (Integral a, Bits a) => JacobiSymbol -> a -> a -> JacobiSymbol
-jacPS acc a b
+jacPS !acc a b
   | evenI a = case shiftToOddCount a of
     (z, o)
       | evenI z || rem8is1or7 b -> jacOL (if rem4is3 o && rem4is3 b then negJS acc else acc) b o
@@ -108,8 +109,8 @@ jacPS acc a b
 
 -- numerator odd, positive and larger than denominator
 jacOL :: (Integral a, Bits a) => JacobiSymbol -> a -> a -> JacobiSymbol
-jacOL acc _ 1 = acc
-jacOL acc a b = case a `rem` b of
+jacOL !acc _ 1 = acc
+jacOL !acc a b = case a `rem` b of
   0 -> Zero
   r -> jacPS acc r b
 

--- a/Math/NumberTheory/Moduli/Jacobi.hs
+++ b/Math/NumberTheory/Moduli/Jacobi.hs
@@ -18,7 +18,6 @@
 module Math.NumberTheory.Moduli.Jacobi
   ( JacobiSymbol(..)
   , jacobi
-  , jacobi'
   ) where
 
 import Data.Bits
@@ -73,13 +72,6 @@ jacobi a b
   | evenI b   = error "Math.NumberTheory.Moduli.jacobi: even denominator"
   | otherwise = jacobi' a b   -- b odd, > 1
 
--- | Similar to 'jacobi', but the condition on the lower argument
--- (\"denominator\") is __not__ checked.
-{-# SPECIALISE jacobi' :: Integer -> Integer -> JacobiSymbol,
-                          Natural -> Natural -> JacobiSymbol,
-                          Int -> Int -> JacobiSymbol,
-                          Word -> Word -> JacobiSymbol
-  #-}
 jacobi' :: (Integral a, Bits a) => a -> a -> JacobiSymbol
 jacobi' 0 _ = Zero
 jacobi' 1 _ = One

--- a/Math/NumberTheory/Moduli/Sqrt.hs
+++ b/Math/NumberTheory/Moduli/Sqrt.hs
@@ -43,7 +43,7 @@ import Math.NumberTheory.Utils (shiftToOddCount, splitOff)
 --   the result is @Nothing@.
 sqrtModP :: Integer -> Integer -> Maybe Integer
 sqrtModP n 2 = Just (n `mod` 2)
-sqrtModP n prime = case jacobi' n prime of
+sqrtModP n prime = case jacobi n prime of
                      MinusOne -> Nothing
                      Zero     -> Just 0
                      One      -> Just (sqrtModP' (n `mod` prime) prime)
@@ -215,7 +215,7 @@ findNonSquare n
       where
         primelist = [3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59,61,67]
                         ++ sieveFrom (68 + n `rem` 4) -- prevent sharing
-        search (p:ps) = case jacobi' p n of
+        search (p:ps) = case jacobi p n of
           MinusOne -> p
           _        -> search ps
         search _ = error "Should never have happened, prime list exhausted."

--- a/Math/NumberTheory/Primes/Testing/Probabilistic.hs
+++ b/Math/NumberTheory/Primes/Testing/Probabilistic.hs
@@ -156,7 +156,7 @@ lucasTest n
       square = isPossibleSquare2 n && r*r == n
       r = integerSquareRoot n
       d = find True 5
-      find !pos cd = case jacobi' (n `rem` cd) cd of
+      find !pos cd = case jacobi (n `rem` cd) cd of
                        MinusOne -> if pos then cd else (-cd)
                        Zero     -> if cd == n then 1 else 0
                        One      -> find (not pos) (cd+2)

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -180,6 +180,7 @@ benchmark criterion
   other-modules:
     Math.NumberTheory.ArithmeticFunctionsBench
     Math.NumberTheory.GCDBench
+    Math.NumberTheory.JacobiBench
     Math.NumberTheory.MertensBench
     Math.NumberTheory.PowersBench
     Math.NumberTheory.PrimesBench

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -4,6 +4,7 @@ import Gauge.Main
 
 import Math.NumberTheory.ArithmeticFunctionsBench as ArithmeticFunctions
 import Math.NumberTheory.GCDBench as GCD
+import Math.NumberTheory.JacobiBench as Jacobi
 import Math.NumberTheory.MertensBench as Mertens
 import Math.NumberTheory.PowersBench as Powers
 import Math.NumberTheory.PrimesBench as Primes
@@ -13,6 +14,7 @@ import Math.NumberTheory.SieveBlockBench as SieveBlock
 main = defaultMain
   [ ArithmeticFunctions.benchSuite
   , GCD.benchSuite
+  , Jacobi.benchSuite
   , Mertens.benchSuite
   , Powers.benchSuite
   , Primes.benchSuite

--- a/benchmark/Math/NumberTheory/JacobiBench.hs
+++ b/benchmark/Math/NumberTheory/JacobiBench.hs
@@ -16,11 +16,7 @@ doBench func lim = sum [ x + y | y <- [3, 5 .. lim], x <- [0..y], func x y == On
 benchSuite :: Benchmark
 benchSuite = bgroup "Jacobi"
   [ bench "jacobi/Int"      $ nf (doBench jacobi  :: Int -> Int)         2000
-  , bench "jacobi'/Int"     $ nf (doBench jacobi' :: Int -> Int)         2000
   , bench "jacobi/Word"     $ nf (doBench jacobi  :: Word -> Word)       2000
-  , bench "jacobi'/Word"    $ nf (doBench jacobi' :: Word -> Word)       2000
   , bench "jacobi/Integer"  $ nf (doBench jacobi  :: Integer -> Integer) 2000
-  , bench "jacobi'/Integer" $ nf (doBench jacobi' :: Integer -> Integer) 2000
   , bench "jacobi/Natural"  $ nf (doBench jacobi  :: Natural -> Natural) 2000
-  , bench "jacobi'/Natural" $ nf (doBench jacobi' :: Natural -> Natural) 2000
   ]

--- a/benchmark/Math/NumberTheory/JacobiBench.hs
+++ b/benchmark/Math/NumberTheory/JacobiBench.hs
@@ -1,0 +1,26 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.JacobiBench
+  ( benchSuite
+  ) where
+
+import Data.Bits
+import Gauge.Main
+import Numeric.Natural
+
+import Math.NumberTheory.Moduli.Jacobi
+
+doBench :: (Integral a, Bits a) => (a -> a -> JacobiSymbol) -> a -> a
+doBench func lim = sum [ x + y | y <- [3, 5 .. lim], x <- [0..y], func x y == One ]
+
+benchSuite :: Benchmark
+benchSuite = bgroup "Jacobi"
+  [ bench "jacobi/Int"      $ nf (doBench jacobi  :: Int -> Int)         2000
+  , bench "jacobi'/Int"     $ nf (doBench jacobi' :: Int -> Int)         2000
+  , bench "jacobi/Word"     $ nf (doBench jacobi  :: Word -> Word)       2000
+  , bench "jacobi'/Word"    $ nf (doBench jacobi' :: Word -> Word)       2000
+  , bench "jacobi/Integer"  $ nf (doBench jacobi  :: Integer -> Integer) 2000
+  , bench "jacobi'/Integer" $ nf (doBench jacobi' :: Integer -> Integer) 2000
+  , bench "jacobi/Natural"  $ nf (doBench jacobi  :: Natural -> Natural) 2000
+  , bench "jacobi'/Natural" $ nf (doBench jacobi' :: Natural -> Natural) 2000
+  ]

--- a/test-suite/Math/NumberTheory/Moduli/JacobiTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/JacobiTests.hs
@@ -23,6 +23,7 @@ import Data.Bits
 #if __GLASGOW_HASKELL__ < 803
 import Data.Semigroup
 #endif
+import Numeric.Natural
 
 import Math.NumberTheory.Moduli hiding (invertMod)
 import Math.NumberTheory.TestUtils
@@ -40,29 +41,90 @@ jacobiProperty3 (AnySign a) (MyCompose (Positive (Odd n))) = case jacobi a n of
   Zero     -> a `gcd` n /= 1
   One      -> a `gcd` n == 1
 
+doesProductOverflow :: Integral a => a -> a -> Bool
+doesProductOverflow x y = abs (toInteger (x * y)) < abs (toInteger x * toInteger y)
+
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 4
 jacobiProperty4 :: (Integral a, Bits a) => AnySign a -> AnySign a -> (MyCompose Positive Odd) a -> Bool
-jacobiProperty4 (AnySign a) (AnySign b) (MyCompose (Positive (Odd n))) = jacobi (a * b) n == jacobi a n <> jacobi b n
+jacobiProperty4 (AnySign a) (AnySign b) (MyCompose (Positive (Odd n))) =
+  doesProductOverflow a b ||
+  jacobi (a * b) n == jacobi a n <> jacobi b n
+
+jacobiProperty4_Int :: AnySign Int -> AnySign Int -> (MyCompose Positive Odd) Int -> Bool
+jacobiProperty4_Int = jacobiProperty4
+
+jacobiProperty4_Word :: AnySign Word -> AnySign Word -> (MyCompose Positive Odd) Word -> Bool
+jacobiProperty4_Word = jacobiProperty4
 
 jacobiProperty4_Integer :: AnySign Integer -> AnySign Integer -> (MyCompose Positive Odd) Integer -> Bool
 jacobiProperty4_Integer = jacobiProperty4
 
+jacobiProperty4_Natural :: AnySign Natural -> AnySign Natural -> (MyCompose Positive Odd) Natural -> Bool
+jacobiProperty4_Natural = jacobiProperty4
+
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 5
 jacobiProperty5 :: (Integral a, Bits a) => AnySign a -> (MyCompose Positive Odd) a -> (MyCompose Positive Odd) a -> Bool
-jacobiProperty5 (AnySign a) (MyCompose (Positive (Odd m))) (MyCompose (Positive (Odd n))) = jacobi a (m * n) == jacobi a m <> jacobi a n
+jacobiProperty5 (AnySign a) (MyCompose (Positive (Odd m))) (MyCompose (Positive (Odd n))) =
+  doesProductOverflow m n ||
+  jacobi a (m * n) == jacobi a m <> jacobi a n
+
+jacobiProperty5_Int :: AnySign Int -> (MyCompose Positive Odd) Int -> (MyCompose Positive Odd) Int -> Bool
+jacobiProperty5_Int = jacobiProperty5
+
+jacobiProperty5_Word :: AnySign Word -> (MyCompose Positive Odd) Word -> (MyCompose Positive Odd) Word -> Bool
+jacobiProperty5_Word = jacobiProperty5
 
 jacobiProperty5_Integer :: AnySign Integer -> (MyCompose Positive Odd) Integer -> (MyCompose Positive Odd) Integer -> Bool
 jacobiProperty5_Integer = jacobiProperty5
+
+jacobiProperty5_Natural :: AnySign Natural -> (MyCompose Positive Odd) Natural -> (MyCompose Positive Odd) Natural -> Bool
+jacobiProperty5_Natural = jacobiProperty5
 
 -- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 6
 jacobiProperty6 :: (Integral a, Bits a) => (MyCompose Positive Odd) a -> (MyCompose Positive Odd) a -> Bool
 jacobiProperty6 (MyCompose (Positive (Odd m))) (MyCompose (Positive (Odd n))) = gcd m n /= 1 || jacobi m n <> jacobi n m == (if m `mod` 4 == 1 || n `mod` 4 == 1 then One else MinusOne)
 
+-- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 7
+jacobiProperty7 :: (Integral a, Bits a) => (MyCompose Positive Odd) a -> Bool
+jacobiProperty7 (MyCompose (Positive (Odd n))) =
+  jacobi (-1) n == if n `mod` 4 == 1 then One else MinusOne
+
+jacobiProperty7_Int :: (MyCompose Positive Odd) Int -> Bool
+jacobiProperty7_Int = jacobiProperty7
+
+jacobiProperty7_Integer :: (MyCompose Positive Odd) Integer -> Bool
+jacobiProperty7_Integer = jacobiProperty7
+
+-- https://en.wikipedia.org/wiki/Jacobi_symbol#Properties, item 8
+jacobiProperty8 :: (Integral a, Bits a) => (MyCompose Positive Odd) a -> Bool
+jacobiProperty8 (MyCompose (Positive (Odd n))) =
+  even n ||
+  jacobi 2 n == if n `mod` 8 == 1 || n `mod` 8 == 7 then One else MinusOne
+
+jacobiProperty9 :: (Integral a, Bits a, Bounded a) => (MyCompose Positive Odd) a -> Bool
+jacobiProperty9 (MyCompose (Positive (Odd n))) =
+  jacobi m n == jacobi (toInteger m) (toInteger n)
+  where
+    m = minBound
+
+jacobiProperty9_Int :: (MyCompose Positive Odd) Int -> Bool
+jacobiProperty9_Int = jacobiProperty9
+
 testSuite :: TestTree
 testSuite = testGroup "Jacobi"
   [ testSameIntegralProperty "same modulo n"                jacobiProperty2
   , testSameIntegralProperty "consistent with gcd"          jacobiProperty3
-  , testSmallAndQuick        "multiplicative 1"             jacobiProperty4_Integer
-  , testSmallAndQuick        "multiplicative 2"             jacobiProperty5_Integer
+  , testSmallAndQuick        "multiplicative 1 Int"         jacobiProperty4_Int
+  , testSmallAndQuick        "multiplicative 1 Word"        jacobiProperty4_Word
+  , testSmallAndQuick        "multiplicative 1 Integer"     jacobiProperty4_Integer
+  , testSmallAndQuick        "multiplicative 1 Natural"     jacobiProperty4_Natural
+  , testSmallAndQuick        "multiplicative 2 Int"         jacobiProperty5_Int
+  , testSmallAndQuick        "multiplicative 2 Word"        jacobiProperty5_Word
+  , testSmallAndQuick        "multiplicative 2 Integer"     jacobiProperty5_Integer
+  , testSmallAndQuick        "multiplicative 2 Natural"     jacobiProperty5_Natural
   , testSameIntegralProperty "law of quadratic reciprocity" jacobiProperty6
+  , testSmallAndQuick        "-1 Int"                       jacobiProperty7_Int
+  , testSmallAndQuick        "-1 Integer"                   jacobiProperty7_Integer
+  , testIntegralProperty     "2"                            jacobiProperty8
+  , testSmallAndQuick        "minBound Int"                 jacobiProperty9_Int
   ]


### PR DESCRIPTION
This is an attempt to facelift `Math.NumberTheory.Moduli.Jacobi`. 

1. There were two functions `jacobi` and `jacobi'`, where the first one checked preconditions on arguments and the second one did not. I assume `jacobi'` was supposed to be "faster", but it is unsafe to use and clutters API. I have written benchmarks and it appeared that performance of both functions is actually pretty much the same. So I've removed `jacobi'`. 

2. As a part of #100 I've added specialised versions of `jacobi` on `Natural`.

3. As a part of #79 I tried to refactor `jac2` using `Vector`. But, taking closer look, it appeared that the code can be clarified, eliminating any need in either `Array` or `Vector`, using only simple bit tests. 

4. Elaborate comments with links to wiki and examples.