### PR TITLE
Smooth numbers: tests and benchmarks

### DIFF
--- a/Math/NumberTheory/SmoothNumbers.hs
+++ b/Math/NumberTheory/SmoothNumbers.hs
@@ -30,7 +30,7 @@ import Math.NumberTheory.Primes.Sieve (primes)
 
 -- | An abstract representation of a smooth basis.
 -- It consists of a set of coprime numbers ≥2.
-newtype SmoothBasis a = SmoothBasis { unSmoothBasis :: [a] } deriving Show
+newtype SmoothBasis a = SmoothBasis { unSmoothBasis :: [a] } deriving (Eq, Show)
 
 -- | Build a 'SmoothBasis' from a set of coprime numbers ≥2.
 --

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -154,6 +154,7 @@ test-suite spec
     Math.NumberTheory.PrimesTests
     Math.NumberTheory.Recurrencies.BilinearTests
     Math.NumberTheory.Recurrencies.LinearTests
+    Math.NumberTheory.SmoothNumbersTests
     Math.NumberTheory.TestUtils
     Math.NumberTheory.TestUtils.MyCompose
     Math.NumberTheory.TestUtils.Wrappers

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -186,6 +186,7 @@ benchmark criterion
     Math.NumberTheory.PrimesBench
     Math.NumberTheory.RecurrenciesBench
     Math.NumberTheory.SieveBlockBench
+    Math.NumberTheory.SmoothNumbersBench
   type: exitcode-stdio-1.0
   main-is: Bench.hs
   default-language: Haskell2010

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -10,6 +10,7 @@ import Math.NumberTheory.PowersBench as Powers
 import Math.NumberTheory.PrimesBench as Primes
 import Math.NumberTheory.RecurrenciesBench as Recurrencies
 import Math.NumberTheory.SieveBlockBench as SieveBlock
+import Math.NumberTheory.SmoothNumbersBench as SmoothNumbers
 
 main = defaultMain
   [ ArithmeticFunctions.benchSuite
@@ -20,4 +21,5 @@ main = defaultMain
   , Primes.benchSuite
   , Recurrencies.benchSuite
   , SieveBlock.benchSuite
+  , SmoothNumbers.benchSuite
   ]

--- a/benchmark/Math/NumberTheory/SmoothNumbersBench.hs
+++ b/benchmark/Math/NumberTheory/SmoothNumbersBench.hs
@@ -1,0 +1,22 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.SmoothNumbersBench
+  ( benchSuite
+  ) where
+
+import Data.List (genericTake)
+import Data.Maybe
+import Gauge.Main
+import Numeric.Natural
+
+import Math.NumberTheory.SmoothNumbers
+
+doBench :: Integral a => a -> a
+doBench lim = sum $ genericTake lim $ smoothOver $ fromJust $ fromSmoothUpperBound lim
+
+benchSuite :: Benchmark
+benchSuite = bgroup "SmoothNumbers"
+  [ bench "100"      $ nf doBench    (100 :: Int)
+  , bench "1000"     $ nf doBench   (1000 :: Int)
+  , bench "10000"    $ nf doBench  (10000 :: Int)
+  ]

--- a/test-suite/Math/NumberTheory/SmoothNumbersTests.hs
+++ b/test-suite/Math/NumberTheory/SmoothNumbersTests.hs
@@ -1,0 +1,65 @@
+-- |
+-- Module:      Math.NumberTheory.SmoothNumbersTests
+-- Copyright:   (c) 2018 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+-- Stability:   Provisional
+--
+-- Tests for Math.NumberTheory.SmoothNumbersTests
+--
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.SmoothNumbersTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+
+import Data.List (genericDrop)
+import qualified Data.Set as S
+import Numeric.Natural
+
+import Math.NumberTheory.SmoothNumbers
+import Math.NumberTheory.TestUtils
+
+fromSetListProperty :: Integral a => [a] -> Bool
+fromSetListProperty xs = fromSet (S.fromList xs) == fromList xs
+
+fromSmoothUpperBoundProperty :: (Show a, Integral a) => Positive a -> Bool
+fromSmoothUpperBoundProperty (Positive n') = case fromSmoothUpperBound n of
+    Nothing -> n < 2
+    Just sb -> head (genericDrop (n - 1) (smoothOver sb)) == n
+  where
+    n = n' `mod` 5000
+
+smoothOverInRangeProperty :: Integral a => SmoothBasis a -> Positive a -> Positive a -> Bool
+smoothOverInRangeProperty s (Positive lo') (Positive diff')
+  = xs == ys
+  where
+    lo   = lo'   `mod` 2^18
+    diff = diff' `mod` 2^18
+    hi   = lo + diff
+    xs   = smoothOverInRange   s lo hi
+    ys   = smoothOverInRangeBF s lo hi
+
+testSuite :: TestTree
+testSuite = testGroup "SmoothNumbers"
+  [ testGroup "fromSet == fromList"
+    [ testSmallAndQuick "Int"     (fromSetListProperty :: [Int] -> Bool)
+    , testSmallAndQuick "Word"    (fromSetListProperty :: [Word] -> Bool)
+    , testSmallAndQuick "Integer" (fromSetListProperty :: [Integer] -> Bool)
+    , testSmallAndQuick "Natural" (fromSetListProperty :: [Natural] -> Bool)
+    ]
+  , testIntegralProperty "fromSmoothUpperBound" fromSmoothUpperBoundProperty
+  , testGroup "smoothOverInRange == smoothOverInRangeBF"
+    [ testSmallAndQuick "Int"
+      (smoothOverInRangeProperty :: SmoothBasis Int -> Positive Int -> Positive Int -> Bool)
+    , testSmallAndQuick "Word"
+      (smoothOverInRangeProperty :: SmoothBasis Word -> Positive Word -> Positive Word -> Bool)
+    , testSmallAndQuick "Integer"
+      (smoothOverInRangeProperty :: SmoothBasis Integer -> Positive Integer -> Positive Integer -> Bool)
+    , testSmallAndQuick "Natural"
+      (smoothOverInRangeProperty :: SmoothBasis Natural -> Positive Natural -> Positive Natural -> Bool)
+    ]
+  ]

--- a/test-suite/Math/NumberTheory/TestUtils.hs
+++ b/test-suite/Math/NumberTheory/TestUtils.hs
@@ -46,7 +46,7 @@ module Math.NumberTheory.TestUtils
 import Test.SmallCheck.Series (cons2)
 import Test.Tasty
 import Test.Tasty.SmallCheck as SC
-import Test.Tasty.QuickCheck as QC hiding (Positive, NonNegative, generate, getNonNegative)
+import Test.Tasty.QuickCheck as QC hiding (Positive, getPositive, NonNegative, generate, getNonNegative)
 
 import Test.SmallCheck.Series (Positive(..), NonNegative(..), Serial(..), Series, generate, (\/))
 
@@ -56,6 +56,7 @@ import Numeric.Natural
 
 import Math.NumberTheory.GaussianIntegers (GaussianInteger(..))
 import Math.NumberTheory.Moduli.PrimitiveRoot (CyclicGroup(..))
+import qualified Math.NumberTheory.SmoothNumbers as SN
 import Math.NumberTheory.UniqueFactorisation (UniqueFactorisation, Prime, unPrime)
 
 import Math.NumberTheory.TestUtils.MyCompose
@@ -102,6 +103,15 @@ isOddPrime
   => PrimeWrapper a
   -> Maybe (Prime a)
 isOddPrime (PrimeWrapper p) = if (unPrime p :: a) == 2 then Nothing else Just p
+
+-------------------------------------------------------------------------------
+-- SmoothNumbers
+
+instance (Integral a, Arbitrary a) => Arbitrary (SN.SmoothBasis a) where
+  arbitrary = (fmap getPositive <$> arbitrary) `suchThatMap` SN.fromList
+
+instance (Monad m, Integral a, Serial m a) => Serial m (SN.SmoothBasis a) where
+  series = (fmap getPositive <$> series) `suchThatMapSerial` SN.fromList
 
 -------------------------------------------------------------------------------
 

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -37,6 +37,7 @@ import qualified Math.NumberTheory.ArithmeticFunctions.SieveBlockTests as SieveB
 import qualified Math.NumberTheory.UniqueFactorisationTests as UniqueFactorisation
 import qualified Math.NumberTheory.ZetaTests as Zeta
 import qualified Math.NumberTheory.CurvesTests as Curves
+import qualified Math.NumberTheory.SmoothNumbersTests as SmoothNumbers
 
 main :: IO ()
 main = defaultMain tests
@@ -86,4 +87,5 @@ tests = testGroup "All"
   , UniqueFactorisation.testSuite
   , Zeta.testSuite
   , Curves.testSuite
+  , SmoothNumbers.testSuite
   ]

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -69,9 +69,7 @@ tests = testGroup "All"
     [ MoebiusInversion.testSuite
     , MoebiusInversionInt.testSuite
     ]
-  , testGroup "Prefactored"
-    [ Prefactored.testSuite
-    ]
+  , Prefactored.testSuite
   , testGroup "Primes"
     [ Primes.testSuite
     , Counting.testSuite
@@ -79,21 +77,13 @@ tests = testGroup "All"
     , Sieve.testSuite
     , Testing.testSuite
     ]
-  , testGroup "Gaussian"
-    [ Gaussian.testSuite
-    ]
+  , Gaussian.testSuite
   , testGroup "ArithmeticFunctions"
     [ ArithmeticFunctions.testSuite
     , Mertens.testSuite
     , SieveBlock.testSuite
     ]
-  , testGroup "UniqueFactorisation"
-    [ UniqueFactorisation.testSuite
-    ]
-  , testGroup "Zeta"
-    [ Zeta.testSuite
-    ]
-  , testGroup "Curves"
-    [ Curves.testSuite
-    ]
+  , UniqueFactorisation.testSuite
+  , Zeta.testSuite
+  , Curves.testSuite
   ]


### PR DESCRIPTION
This branch continues #91, adding some basic tests and benchmarks for `Math.NumberTheory.SmoothNumbers`.

@grandpascorpion would you mind to review?