### PR TITLE
Add more usable interface to Sqrt module

### DIFF
--- a/Math/NumberTheory/GaussianIntegers.hs
+++ b/Math/NumberTheory/GaussianIntegers.hs
@@ -36,7 +36,7 @@ module Math.NumberTheory.GaussianIntegers (
 ) where
 
 import qualified Math.NumberTheory.Moduli as Moduli
-import Math.NumberTheory.Moduli.Sqrt (FieldCharacterictic(..), toFieldCharacteristic)
+import Math.NumberTheory.Moduli.Sqrt (FieldCharacteristic(..), unPrime, toFieldCharacteristic)
 import qualified Math.NumberTheory.Powers as Powers
 import qualified Math.NumberTheory.Primes.Factorisation as Factorisation
 import qualified Math.NumberTheory.Primes.Sieve as Sieve
@@ -139,7 +139,7 @@ primes = [ g
                 else
                     if p == 2
                     then [1 :+ 1]
-                    else let x :+ y = findPrime' (FieldCharacterictic p 1)
+                    else let x :+ y = findPrime' (fromMaybeError "Impossible error" $ toFieldCharacteristic p) -- safe actually
                          in [x :+ y, y :+ x]
          ]
 
@@ -162,9 +162,10 @@ findPrime p
     | otherwise = error "p must be congruent to 3 (mod 4)"
 
 -- |Find a Gaussian integer whose norm is the given prime number.
-findPrime' :: FieldCharacterictic -> GaussianInteger
-findPrime' (FieldCharacterictic p 1) =
-    let (Just c) = Moduli.sqrtModMaybe (-1) (FieldCharacterictic p 1)
+findPrime' :: FieldCharacteristic -> GaussianInteger
+findPrime' (FieldCharacteristic prime 1) =
+    let (Just c) = Moduli.sqrtModMaybe (-1) (FieldCharacteristic prime 1)
+        p = unPrime prime
         k  = Powers.integerSquareRoot p
         bs = [1 .. k]
         asbs = map (\b' -> ((b' * c) `mod` p, b')) bs

--- a/Math/NumberTheory/GaussianIntegers.hs
+++ b/Math/NumberTheory/GaussianIntegers.hs
@@ -30,7 +30,6 @@ module Math.NumberTheory.GaussianIntegers (
     primes,
     gcdG,
     gcdG',
-    findPrime,
     findPrime',
     factorise,
 ) where
@@ -155,13 +154,6 @@ gcdG' g h
     | otherwise = gcdG' h (abs (g `modG` h))
 
 -- |Find a Gaussian integer whose norm is the given prime number.
--- Checks the precondition that p is prime and that p `mod` 4 /= 3.
-findPrime :: Integer -> GaussianInteger
-findPrime p
-    | p == 2 || (p `mod` 4 == 1) = findPrime' (fromMaybeError "p must be prime" $ toFieldCharacteristic p)
-    | otherwise = error "p must be congruent to 3 (mod 4)"
-
--- |Find a Gaussian integer whose norm is the given prime number.
 findPrime' :: FieldCharacteristic -> GaussianInteger
 findPrime' (FieldCharacteristic prime 1) =
     let (Just c) = Moduli.sqrtModMaybe (-1) (FieldCharacteristic prime 1)
@@ -171,6 +163,7 @@ findPrime' (FieldCharacteristic prime 1) =
         asbs = map (\b' -> ((b' * c) `mod` p, b')) bs
         (a, b) = head [ (a', b') | (a', b') <- asbs, a' <= k]
     in a :+ b
+findPrime' (FieldCharacteristic _prime _pow) = error "Not a prime number as argument to findPrime'"
 
 -- |Raise a Gaussian integer to a given power.
 (.^) :: (Integral a) => GaussianInteger -> a -> GaussianInteger

--- a/Math/NumberTheory/GaussianIntegers.hs
+++ b/Math/NumberTheory/GaussianIntegers.hs
@@ -164,7 +164,7 @@ findPrime p
 -- check the precondition.
 findPrime' :: Integer -> GaussianInteger
 findPrime' p =
-    let (Just c) = Moduli.sqrtModP (-1) p
+    let (Just c) = Moduli.sqrtModMaybe (-1) p
         k  = Powers.integerSquareRoot p
         bs = [1 .. k]
         asbs = map (\b' -> ((b' * c) `mod` p, b')) bs

--- a/Math/NumberTheory/GaussianIntegers.hs
+++ b/Math/NumberTheory/GaussianIntegers.hs
@@ -138,7 +138,7 @@ primes = [ g
                 else
                     if p == 2
                     then [1 :+ 1]
-                    else let x :+ y = findPrime' (fromMaybeError "Impossible error" $ toFieldCharacteristic p) -- safe actually
+                    else let x :+ y = findPrime' (toFieldCharacteristic (PrimeNat p) 1) -- safe actually
                          in [x :+ y, y :+ x]
          ]
 
@@ -201,7 +201,7 @@ factorise g = helper (Factorisation.factorise $ norm g) g
                 -- otherwise: find a Gaussian prime gp for which `norm gp ==
                 -- p`. Then do trial divisions to find out how many times g' is
                 -- divisible by gp or its conjugate.
-                let gp = findPrime' (fromMaybeError "p must be prime" $ toFieldCharacteristic p)
+                let gp = findPrime' (toFieldCharacteristic (PrimeNat p) 1)
                 in trialDivide g' [gp, abs $ conjugate gp]
         in facs ++ helper pt g''
 
@@ -228,8 +228,3 @@ countEvenDivisions g pf = helper g 0
     helper g' acc
         | g' `modG` pf == 0 = helper (g' `divG` pf) (1 + acc)
         | otherwise     = (acc, g')
-
--- Custom version of @'fromJust'@.
-fromMaybeError :: String -> Maybe a -> a
-fromMaybeError msg Nothing = error msg
-fromMaybeError _ (Just v) = v

--- a/Math/NumberTheory/Moduli/Sqrt.hs
+++ b/Math/NumberTheory/Moduli/Sqrt.hs
@@ -84,13 +84,24 @@ toQuadraticResidue p'@(unPrime -> p) n
 
 -- * Interface functions with preconditions checking.
 
+-- | Gets quadratic residue modulo prime and computes it's square root.
+--   Preconditions: @'n'@ is quadratic residue modulo @'p'@, @'p'@ is prime.
+--   All preconditions are cheched earlier and reflected to signature.
 sqrtModExact :: QuadraticResidue -> Integer
 sqrtModExact (QuadraticResidue (unPrime -> p) n) = sqrtModP' n p
 
+-- | Gets integer and computes its square root in field with given characteristic - because it exists only in field.
+--   Returns all roots.
+--   Preconditions: p is prime and second argument itself is valid characteristic (it's guaranteed by type).
+--   All preconditions are cheched earlier and reflected to signature.
 sqrtModList :: Integer -> FieldCharacteristic -> [Integer]
 sqrtModList n (FieldCharacteristic (unPrime -> p) 1) = sqrtModPList n p
 sqrtModList n (FieldCharacteristic (unPrime -> p) pow) = sqrtModPPList n (p,pow)
 
+-- | Gets integer and computes its square root in field with given characteristic - because it exists only in field.
+--   Returns only one root or none.
+--   Preconditions: p is prime and second argument itself is valid characteristic (it's guaranteed by type).
+--   All preconditions are cheched earlier and reflected to signature.
 sqrtModMaybe :: Integer -> FieldCharacteristic -> Maybe Integer
 sqrtModMaybe n (FieldCharacteristic (unPrime -> p) 1) = sqrtModP n p
 sqrtModMaybe n (FieldCharacteristic (unPrime -> p) pow) = sqrtModPP n (p,pow)

--- a/Math/NumberTheory/Moduli/Sqrt.hs
+++ b/Math/NumberTheory/Moduli/Sqrt.hs
@@ -17,6 +17,8 @@ module Math.NumberTheory.Moduli.Sqrt
   ( -- Constructor and @'unPrime'@ are exported in order to do pattern-matching.
     FieldCharacteristic(..)
   , unPrime
+  -- Exported for testing purposes. Normally should not be used.
+  , primeF
   , toFieldCharacteristic
   , sqrtModList
   , sqrtModMaybe

--- a/Math/NumberTheory/Moduli/Sqrt.hs
+++ b/Math/NumberTheory/Moduli/Sqrt.hs
@@ -14,11 +14,8 @@
 {-# LANGUAGE CPP          #-}
 
 module Math.NumberTheory.Moduli.Sqrt
-  ( -- Constructor and @'unPrime'@ are exported in order to do pattern-matching.
+  ( -- Constructor is exported in order to do pattern-matching.
     FieldCharacteristic(..)
-  , unPrime
-  -- Exported for testing purposes. Normally should not be used.
-  , primeF
   , toFieldCharacteristic
   , sqrtModList
   , sqrtModMaybe
@@ -206,22 +203,22 @@ sqM2P n e
 --   @product [p^k | (p,k) <- primePowers]@ if one exists and all primes
 --   are distinct.
 --   The list must be non-empty, @n@ must be coprime with all primes.
-sqrtModF :: Integer -> [(Integer,Int)] -> Maybe Integer
+sqrtModF :: Integer -> [FieldCharacteristic] -> Maybe Integer
 sqrtModF _ []  = Nothing
-sqrtModF n pps = do roots <- mapM (sqrtModPP n) pps
-                    chineseRemainder $ zip roots (map (uncurry (^)) pps)
+sqrtModF n pps = do roots <- mapM (sqrtModPP n . (\(FieldCharacteristic (unPrime -> p) pow) -> (p,pow))) pps
+                    chineseRemainder $ zip roots (map (uncurry (^) . (\(FieldCharacteristic (unPrime -> p) pow) -> (p,pow))) pps)
 
 -- | @sqrtModFList n primePowers@ calculates all square roots of @n@ modulo
 --   @product [p^k | (p,k) <- primePowers]@ if all primes are distinct.
 --   The list must be non-empty, @n@ must be coprime with all primes.
-sqrtModFList :: Integer -> [(Integer,Int)] -> [Integer]
+sqrtModFList :: Integer -> [FieldCharacteristic] -> [Integer]
 sqrtModFList _ []  = []
 sqrtModFList n pps = map fst $ foldl1 (liftM2 comb) cs
   where
     ms :: [Integer]
-    ms = map (uncurry (^)) pps
+    ms = map (uncurry (^) . (\(FieldCharacteristic (unPrime -> p) pow) -> (p,pow))) pps
     rs :: [[Integer]]
-    rs = map (sqrtModPPList n) pps
+    rs = map (sqrtModPPList n . (\(FieldCharacteristic (unPrime -> p) pow) -> (p,pow))) pps
     cs :: [[(Integer,Integer)]]
     cs = zipWith (\l m -> map (\x -> (x,m)) l) rs ms
     comb t1@(_,m1) t2@(_,m2) = (chineseRemainder2 t1 t2,m1*m2)

--- a/Math/NumberTheory/Moduli/Sqrt.hs
+++ b/Math/NumberTheory/Moduli/Sqrt.hs
@@ -15,8 +15,7 @@
 module Math.NumberTheory.Moduli.Sqrt
   ( sqrtModList
   , sqrtModMaybe
-  -- Still exported since we do not check for quadraticity of residue. The only use case - p: p = 4k + 3. 
-  , sqrtModP' --FIXME
+  , sqrtModSharp
   , sqrtModF
   , sqrtModFList
   ) where
@@ -43,12 +42,22 @@ data FieldCharacterictic = Invalid
 checkPrimePower :: Integer -> Maybe (Integer, Int)
 checkPrimePower = headMay . factorise
 
+-- * Interface functions with preconditions checking.
+
 checkPreconditions :: Integer -> FieldCharacterictic
 checkPreconditions p
   | isPrime p = Prime
   | otherwise = case checkPrimePower p of
       Nothing -> Invalid
       Just (prime,pow) -> PrimePower prime pow
+
+sqrtModSharp :: Integer -> Integer -> Integer
+sqrtModSharp n p
+  -- Euler's criterion.
+  | isPrime p = if n^((p-1) `div` p) `mod` p == 1
+      then sqrtModP' n p
+      else error "Quadratic nonresidue as argument - in this case use sqrtModList."
+  | otherwise = error "Given characteristic is invalid for the field - cannot compute square roots."
 
 sqrtModList :: Integer -> Integer -> [Integer]
 sqrtModList n p = case checkPreconditions p of

--- a/Math/NumberTheory/Moduli/Sqrt.hs
+++ b/Math/NumberTheory/Moduli/Sqrt.hs
@@ -25,6 +25,7 @@ module Math.NumberTheory.Moduli.Sqrt
   , sqrtModFList
   ) where
 
+import Control.Arrow (first)
 import Control.Monad (liftM2)
 import Data.Bits
 import Data.Coerce
@@ -55,8 +56,7 @@ primeF = coerce integerToNatural
 -- | Check if value is power of some prime.
 checkPrimePower :: Integer -> Maybe (Prime Integer, Int)
 checkPrimePower p
-  -- FIXME: @'mapFst'@ function presents in @'Data.Monoid.State'@
-  | isPrime . fst . highestPower $ p = Just . (\(f,s) -> (primeF f, s)) . highestPower $ p
+  | isPrime . fst . highestPower $ p = Just . first primeF . highestPower $ p
   | otherwise = Nothing
 
 -- | Check if argument is valid characteristic of finite field.

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -44,8 +44,7 @@ library
     integer-logarithms >=1.0,
     mtl >=2.0 && <2.3,
     random >=1.0 && <1.2,
-    vector >= 0.12,
-    safe
+    vector >= 0.12
   if impl(ghc <8.0)
     build-depends:
       semigroups >=0.8

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -44,7 +44,8 @@ library
     integer-logarithms >=1.0,
     mtl >=2.0 && <2.3,
     random >=1.0 && <1.2,
-    vector >= 0.12
+    vector >= 0.12,
+    safe
   if impl(ghc <8.0)
     build-depends:
       semigroups >=0.8

--- a/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
@@ -27,10 +27,6 @@ import Math.NumberTheory.Moduli hiding (invertMod, unPrime)
 import Math.NumberTheory.UniqueFactorisation (unPrime, isPrime)
 import Math.NumberTheory.TestUtils
 
-fromJustCustom :: Maybe a -> a
-fromJustCustom Nothing = error "Not a prime"
-fromJustCustom (Just a) = a
-
 unwrapP :: PrimeWrapper Integer -> Integer
 unwrapP (PrimeWrapper p) = unPrime p
 
@@ -42,39 +38,39 @@ unwrapPP (p, Power e) = (unwrapP p, e)
 -- | Check that 'sqrtMod' is defined iff a quadratic residue exists.
 --   Also check that the result is a solution of input modular equation.
 sqrtModPProperty :: AnySign Integer -> PrimeWrapper Integer -> Bool
-sqrtModPProperty (AnySign n) (unwrapP -> p) = case sqrtModMaybe n (fromJustCustom . toFieldCharacteristic $ p) of
+sqrtModPProperty (AnySign n) (unwrapP -> p) = case sqrtModMaybe n (FieldCharacteristic (primeF p) 1) of
   Nothing -> jacobi n p == MinusOne
   Just rt -> (p == 2 || jacobi n p /= MinusOne) && rt ^ 2 `mod` p == n `mod` p
 
 sqrtModPListProperty :: AnySign Integer -> PrimeWrapper Integer -> Bool
-sqrtModPListProperty (AnySign n) (unwrapP -> p) = all (\rt -> rt ^ 2 `mod` p == n `mod` p) (sqrtModList n (fromJustCustom . toFieldCharacteristic $ p))
+sqrtModPListProperty (AnySign n) (unwrapP -> p) = all (\rt -> rt ^ 2 `mod` p == n `mod` p) (sqrtModList n (FieldCharacteristic (primeF p) 1))
 
 sqrtModP'Property :: Positive Integer -> PrimeWrapper Integer -> Bool
 sqrtModP'Property (Positive n) (unwrapP -> p) = (p /= 2 && jacobi n p /= One) || rt ^ 2 `mod` p == n `mod` p
   where
-    rt = sqrtModExact n (fromJustCustom . toFieldCharacteristic $ p)
+    rt = sqrtModExact n (FieldCharacteristic (primeF p) 1)
 
 tonelliShanksProperty1 :: Positive Integer -> PrimeWrapper Integer -> Bool
 tonelliShanksProperty1 (Positive n) (unwrapP -> p) = p `mod` 4 /= 1 || jacobi n p /= One || rt ^ 2 `mod` p == n `mod` p
   where
-    rt = sqrtModExact n (fromJustCustom . toFieldCharacteristic $ p)
+    rt = sqrtModExact n (FieldCharacteristic (primeF p) 1)
 
 tonelliShanksProperty2 :: PrimeWrapper Integer -> Bool
 tonelliShanksProperty2 (unwrapP -> p) = p `mod` 4 /= 1 || rt ^ 2 `mod` p == n `mod` p
   where
     n  = head $ filter (\s -> jacobi s p == One) [2..p-1]
-    rt = sqrtModExact n (fromJustCustom . toFieldCharacteristic $ p)
+    rt = sqrtModExact n (FieldCharacteristic (primeF p) 1)
 
 tonelliShanksSpecialCases :: Assertion
 tonelliShanksSpecialCases =
   assertEqual "OEIS A002224" [6, 32, 219, 439, 1526, 2987, 22193, 11740, 13854, 91168, 326277, 232059, 3230839, 4379725, 11754394, 32020334, 151024619, 345641931, 373671108, 1857111865, 8110112775, 4184367042] rts
   where
     ps = [17, 73, 241, 1009, 2689, 8089, 33049, 53881, 87481, 483289, 515761, 1083289, 3818929, 9257329, 22000801, 48473881, 175244281, 427733329, 898716289, 8114538721, 9176747449, 23616331489]
-    rts = map (\p -> sqrtModExact 2 (fromJustCustom . toFieldCharacteristic $ p)) ps
+    rts = map (\p -> sqrtModExact 2 (FieldCharacteristic (primeF p) 1)) ps
 
 sqrtModPPProperty :: AnySign Integer -> (PrimeWrapper Integer, Power Int) -> Bool
 sqrtModPPProperty (AnySign n) (unwrapP -> p, Power e) =
-  gcd n p > 1 || case sqrtModMaybe n (fromJustCustom . toFieldCharacteristic $ p ^ e) of
+  gcd n p > 1 || case sqrtModMaybe n (FieldCharacteristic (primeF p) e) of
     Nothing -> True
     Just rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)
 
@@ -83,15 +79,15 @@ sqrtModPPBase2Property n e = sqrtModPPProperty n (PrimeWrapper $ fromJust $ isPr
 
 sqrtModPPSpecialCase1 :: Assertion
 sqrtModPPSpecialCase1 =
-  assertEqual "sqrtModPP 16 2 2 = 4" (Just 0) (sqrtModMaybe 16 (fromJustCustom . toFieldCharacteristic $ 2 ^ 2))
+  assertEqual "sqrtModPP 16 2 2 = 4" (Just 0) (sqrtModMaybe 16 (FieldCharacteristic (primeF 2) 2))
 
 sqrtModPPSpecialCase2 :: Assertion
 sqrtModPPSpecialCase2 =
-  assertEqual "sqrtModPP 16 3 2 = 4" (Just 4) (sqrtModMaybe 16 (fromJustCustom . toFieldCharacteristic $ 3 ^ 2))
+  assertEqual "sqrtModPP 16 3 2 = 4" (Just 4) (sqrtModMaybe 16 (FieldCharacteristic (primeF 3) 2))
 
 sqrtModPPListProperty :: AnySign Integer -> (PrimeWrapper Integer, Power Int) -> Bool
 sqrtModPPListProperty (AnySign n) (unwrapP -> p, Power e) = gcd n p > 1
-  || all (\rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) (sqrtModList n (fromJustCustom . toFieldCharacteristic $ p ^ e))
+  || all (\rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) (sqrtModList n (FieldCharacteristic (primeF p) e))
 
 sqrtModFProperty :: AnySign Integer -> [(PrimeWrapper Integer, Power Int)] -> Bool
 sqrtModFProperty (AnySign n) (map unwrapPP -> pes) = case sqrtModF n pes of

--- a/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
@@ -48,25 +48,25 @@ sqrtModPListProperty (AnySign n) (unwrapP -> p) = all (\rt -> rt ^ 2 `mod` p == 
 sqrtModP'Property :: Positive Integer -> PrimeWrapper Integer -> Bool
 sqrtModP'Property (Positive n) (unwrapP -> p) = (p /= 2 && jacobi n p /= One) || rt ^ 2 `mod` p == n `mod` p
   where
-    rt = sqrtModSharp n p
+    rt = sqrtModExact n p
 
 tonelliShanksProperty1 :: Positive Integer -> PrimeWrapper Integer -> Bool
 tonelliShanksProperty1 (Positive n) (unwrapP -> p) = p `mod` 4 /= 1 || jacobi n p /= One || rt ^ 2 `mod` p == n `mod` p
   where
-    rt = sqrtModSharp n p
+    rt = sqrtModExact n p
 
 tonelliShanksProperty2 :: PrimeWrapper Integer -> Bool
 tonelliShanksProperty2 (unwrapP -> p) = p `mod` 4 /= 1 || rt ^ 2 `mod` p == n `mod` p
   where
     n  = head $ filter (\s -> jacobi s p == One) [2..p-1]
-    rt = sqrtModSharp n p
+    rt = sqrtModExact n p
 
 tonelliShanksSpecialCases :: Assertion
 tonelliShanksSpecialCases =
   assertEqual "OEIS A002224" [6, 32, 219, 439, 1526, 2987, 22193, 11740, 13854, 91168, 326277, 232059, 3230839, 4379725, 11754394, 32020334, 151024619, 345641931, 373671108, 1857111865, 8110112775, 4184367042] rts
   where
     ps = [17, 73, 241, 1009, 2689, 8089, 33049, 53881, 87481, 483289, 515761, 1083289, 3818929, 9257329, 22000801, 48473881, 175244281, 427733329, 898716289, 8114538721, 9176747449, 23616331489]
-    rts = map (\p -> sqrtModSharp 2 p) ps
+    rts = map (\p -> sqrtModExact 2 p) ps
 
 sqrtModPPProperty :: AnySign Integer -> (PrimeWrapper Integer, Power Int) -> Bool
 sqrtModPPProperty (AnySign n) (unwrapP -> p, Power e) = gcd n p > 1 || case sqrtModMaybe n (p ^ e) of

--- a/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
@@ -38,38 +38,38 @@ unwrapPP (p, Power e) = (unwrapP p, e)
 -- | Check that 'sqrtMod' is defined iff a quadratic residue exists.
 --   Also check that the result is a solution of input modular equation.
 sqrtModPProperty :: AnySign Integer -> PrimeWrapper Integer -> Bool
-sqrtModPProperty (AnySign n) (unwrapP -> p) = case sqrtModMaybe n p of
+sqrtModPProperty (AnySign n) (unwrapP -> p) = case sqrtModMaybe n (FieldCharacterictic p 1) of
   Nothing -> jacobi n p == MinusOne
   Just rt -> (p == 2 || jacobi n p /= MinusOne) && rt ^ 2 `mod` p == n `mod` p
 
 sqrtModPListProperty :: AnySign Integer -> PrimeWrapper Integer -> Bool
-sqrtModPListProperty (AnySign n) (unwrapP -> p) = all (\rt -> rt ^ 2 `mod` p == n `mod` p) (sqrtModList n p)
+sqrtModPListProperty (AnySign n) (unwrapP -> p) = all (\rt -> rt ^ 2 `mod` p == n `mod` p) (sqrtModList n (FieldCharacterictic p 1))
 
 sqrtModP'Property :: Positive Integer -> PrimeWrapper Integer -> Bool
 sqrtModP'Property (Positive n) (unwrapP -> p) = (p /= 2 && jacobi n p /= One) || rt ^ 2 `mod` p == n `mod` p
   where
-    rt = sqrtModExact n p
+    rt = sqrtModExact n (FieldCharacterictic p 1)
 
 tonelliShanksProperty1 :: Positive Integer -> PrimeWrapper Integer -> Bool
 tonelliShanksProperty1 (Positive n) (unwrapP -> p) = p `mod` 4 /= 1 || jacobi n p /= One || rt ^ 2 `mod` p == n `mod` p
   where
-    rt = sqrtModExact n p
+    rt = sqrtModExact n (FieldCharacterictic p 1)
 
 tonelliShanksProperty2 :: PrimeWrapper Integer -> Bool
 tonelliShanksProperty2 (unwrapP -> p) = p `mod` 4 /= 1 || rt ^ 2 `mod` p == n `mod` p
   where
     n  = head $ filter (\s -> jacobi s p == One) [2..p-1]
-    rt = sqrtModExact n p
+    rt = sqrtModExact n (FieldCharacterictic p 1)
 
 tonelliShanksSpecialCases :: Assertion
 tonelliShanksSpecialCases =
   assertEqual "OEIS A002224" [6, 32, 219, 439, 1526, 2987, 22193, 11740, 13854, 91168, 326277, 232059, 3230839, 4379725, 11754394, 32020334, 151024619, 345641931, 373671108, 1857111865, 8110112775, 4184367042] rts
   where
     ps = [17, 73, 241, 1009, 2689, 8089, 33049, 53881, 87481, 483289, 515761, 1083289, 3818929, 9257329, 22000801, 48473881, 175244281, 427733329, 898716289, 8114538721, 9176747449, 23616331489]
-    rts = map (\p -> sqrtModExact 2 p) ps
+    rts = map (\p -> sqrtModExact 2 (FieldCharacterictic p 1)) ps
 
 sqrtModPPProperty :: AnySign Integer -> (PrimeWrapper Integer, Power Int) -> Bool
-sqrtModPPProperty (AnySign n) (unwrapP -> p, Power e) = gcd n p > 1 || case sqrtModMaybe n (p ^ e) of
+sqrtModPPProperty (AnySign n) (unwrapP -> p, Power e) = gcd n p > 1 || case sqrtModMaybe n (FieldCharacterictic p e) of
   Nothing -> True
   Just rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)
 
@@ -78,15 +78,15 @@ sqrtModPPBase2Property n e = sqrtModPPProperty n (PrimeWrapper $ fromJust $ isPr
 
 sqrtModPPSpecialCase1 :: Assertion
 sqrtModPPSpecialCase1 =
-  assertEqual "sqrtModPP 16 2 2 = 4" (Just 0) (sqrtModMaybe 16 (2 ^ 2))
+  assertEqual "sqrtModPP 16 2 2 = 4" (Just 0) (sqrtModMaybe 16 (FieldCharacterictic 2 2))
 
 sqrtModPPSpecialCase2 :: Assertion
 sqrtModPPSpecialCase2 =
-  assertEqual "sqrtModPP 16 3 2 = 4" (Just 4) (sqrtModMaybe 16 (3 ^ 2))
+  assertEqual "sqrtModPP 16 3 2 = 4" (Just 4) (sqrtModMaybe 16 (FieldCharacterictic 3 2))
 
 sqrtModPPListProperty :: AnySign Integer -> (PrimeWrapper Integer, Power Int) -> Bool
 sqrtModPPListProperty (AnySign n) (unwrapP -> p, Power e) = gcd n p > 1
-  || all (\rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) (sqrtModList n (p ^ e))
+  || all (\rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) (sqrtModList n (FieldCharacterictic p e))
 
 sqrtModFProperty :: AnySign Integer -> [(PrimeWrapper Integer, Power Int)] -> Bool
 sqrtModFProperty (AnySign n) (map unwrapPP -> pes) = case sqrtModF n pes of

--- a/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
@@ -20,17 +20,18 @@ module Math.NumberTheory.Moduli.SqrtTests
 import Test.Tasty
 import Test.Tasty.HUnit
 
+import Control.Arrow (first)
 import Data.List (nub)
 import Data.Maybe (fromJust)
 
-import Math.NumberTheory.Moduli hiding (invertMod, unPrime)
-import Math.NumberTheory.UniqueFactorisation (unPrime, isPrime)
+import Math.NumberTheory.Moduli hiding (invertMod)
+import Math.NumberTheory.UniqueFactorisation (unPrime, isPrime, Prime)
 import Math.NumberTheory.TestUtils
 
-unwrapP :: PrimeWrapper Integer -> Integer
-unwrapP (PrimeWrapper p) = unPrime p
+unwrapP :: PrimeWrapper Integer -> Prime Integer
+unwrapP (PrimeWrapper p) = p
 
-unwrapPP :: (PrimeWrapper Integer, Power Int) -> (Integer, Int)
+unwrapPP :: (PrimeWrapper Integer, Power Int) -> (Prime Integer, Int)
 unwrapPP (p, Power e) = (unwrapP p, e)
 
 -- FIXME: update names. Maybe not - they describe specific behavior inside interfaces.
@@ -38,39 +39,39 @@ unwrapPP (p, Power e) = (unwrapP p, e)
 -- | Check that 'sqrtMod' is defined iff a quadratic residue exists.
 --   Also check that the result is a solution of input modular equation.
 sqrtModPProperty :: AnySign Integer -> PrimeWrapper Integer -> Bool
-sqrtModPProperty (AnySign n) (unwrapP -> p) = case sqrtModMaybe n (FieldCharacteristic (primeF p) 1) of
+sqrtModPProperty (AnySign n) (unwrapP -> p'@(unPrime -> p)) = case sqrtModMaybe n (FieldCharacteristic p' 1) of
   Nothing -> jacobi n p == MinusOne
   Just rt -> (p == 2 || jacobi n p /= MinusOne) && rt ^ 2 `mod` p == n `mod` p
 
 sqrtModPListProperty :: AnySign Integer -> PrimeWrapper Integer -> Bool
-sqrtModPListProperty (AnySign n) (unwrapP -> p) = all (\rt -> rt ^ 2 `mod` p == n `mod` p) (sqrtModList n (FieldCharacteristic (primeF p) 1))
+sqrtModPListProperty (AnySign n) (unwrapP -> p'@(unPrime -> p)) = all (\rt -> rt ^ 2 `mod` p == n `mod` p) (sqrtModList n (FieldCharacteristic p' 1))
 
 sqrtModP'Property :: Positive Integer -> PrimeWrapper Integer -> Bool
-sqrtModP'Property (Positive n) (unwrapP -> p) = (p /= 2 && jacobi n p /= One) || rt ^ 2 `mod` p == n `mod` p
+sqrtModP'Property (Positive n) (unwrapP -> p'@(unPrime -> p)) = (p /= 2 && jacobi n p /= One) || rt ^ 2 `mod` p == n `mod` p
   where
-    rt = sqrtModExact n (FieldCharacteristic (primeF p) 1)
+    rt = sqrtModExact n (FieldCharacteristic p' 1)
 
 tonelliShanksProperty1 :: Positive Integer -> PrimeWrapper Integer -> Bool
-tonelliShanksProperty1 (Positive n) (unwrapP -> p) = p `mod` 4 /= 1 || jacobi n p /= One || rt ^ 2 `mod` p == n `mod` p
+tonelliShanksProperty1 (Positive n) (unwrapP -> p'@(unPrime -> p)) = p `mod` 4 /= 1 || jacobi n p /= One || rt ^ 2 `mod` p == n `mod` p
   where
-    rt = sqrtModExact n (FieldCharacteristic (primeF p) 1)
+    rt = sqrtModExact n (FieldCharacteristic p' 1)
 
 tonelliShanksProperty2 :: PrimeWrapper Integer -> Bool
-tonelliShanksProperty2 (unwrapP -> p) = p `mod` 4 /= 1 || rt ^ 2 `mod` p == n `mod` p
+tonelliShanksProperty2 (unwrapP -> p'@(unPrime -> p)) = p `mod` 4 /= 1 || rt ^ 2 `mod` p == n `mod` p
   where
     n  = head $ filter (\s -> jacobi s p == One) [2..p-1]
-    rt = sqrtModExact n (FieldCharacteristic (primeF p) 1)
+    rt = sqrtModExact n (FieldCharacteristic p' 1)
 
 tonelliShanksSpecialCases :: Assertion
 tonelliShanksSpecialCases =
   assertEqual "OEIS A002224" [6, 32, 219, 439, 1526, 2987, 22193, 11740, 13854, 91168, 326277, 232059, 3230839, 4379725, 11754394, 32020334, 151024619, 345641931, 373671108, 1857111865, 8110112775, 4184367042] rts
   where
     ps = [17, 73, 241, 1009, 2689, 8089, 33049, 53881, 87481, 483289, 515761, 1083289, 3818929, 9257329, 22000801, 48473881, 175244281, 427733329, 898716289, 8114538721, 9176747449, 23616331489]
-    rts = map (\p -> sqrtModExact 2 (FieldCharacteristic (primeF p) 1)) ps
+    rts = map (\p -> sqrtModExact 2 (fromJust . toFieldCharacteristic $ p)) ps
 
 sqrtModPPProperty :: AnySign Integer -> (PrimeWrapper Integer, Power Int) -> Bool
-sqrtModPPProperty (AnySign n) (unwrapP -> p, Power e) =
-  gcd n p > 1 || case sqrtModMaybe n (FieldCharacteristic (primeF p) e) of
+sqrtModPPProperty (AnySign n) (unwrapP -> p'@(unPrime -> p), Power e) =
+  gcd n p > 1 || case sqrtModMaybe n (FieldCharacteristic p' e) of
     Nothing -> True
     Just rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)
 
@@ -79,32 +80,33 @@ sqrtModPPBase2Property n e = sqrtModPPProperty n (PrimeWrapper $ fromJust $ isPr
 
 sqrtModPPSpecialCase1 :: Assertion
 sqrtModPPSpecialCase1 =
-  assertEqual "sqrtModPP 16 2 2 = 4" (Just 0) (sqrtModMaybe 16 (FieldCharacteristic (primeF 2) 2))
+  assertEqual "sqrtModPP 16 2 2 = 4" (Just 0) (sqrtModMaybe 16 (fromJust . toFieldCharacteristic $ 2 ^ 2))
 
 sqrtModPPSpecialCase2 :: Assertion
 sqrtModPPSpecialCase2 =
-  assertEqual "sqrtModPP 16 3 2 = 4" (Just 4) (sqrtModMaybe 16 (FieldCharacteristic (primeF 3) 2))
+  assertEqual "sqrtModPP 16 3 2 = 4" (Just 4) (sqrtModMaybe 16 (fromJust . toFieldCharacteristic $ 3 ^ 2))
 
 sqrtModPPListProperty :: AnySign Integer -> (PrimeWrapper Integer, Power Int) -> Bool
-sqrtModPPListProperty (AnySign n) (unwrapP -> p, Power e) = gcd n p > 1
-  || all (\rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) (sqrtModList n (FieldCharacteristic (primeF p) e))
+sqrtModPPListProperty (AnySign n) (unwrapP -> p'@(unPrime -> p), Power e) = gcd n p > 1
+  || all (\rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) (sqrtModList n (FieldCharacteristic p' e))
 
 sqrtModFProperty :: AnySign Integer -> [(PrimeWrapper Integer, Power Int)] -> Bool
-sqrtModFProperty (AnySign n) (map unwrapPP -> pes) = case sqrtModF n pes of
+sqrtModFProperty (AnySign n) (map unwrapPP -> pes'@(map (first unPrime) -> pes)) = case sqrtModF n (map (uncurry FieldCharacteristic) pes') of
   Nothing -> True
   Just rt -> all (\(p, e) -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) pes
 
 sqrtModFListProperty :: AnySign Integer -> [(PrimeWrapper Integer, Power Int)] -> Bool
-sqrtModFListProperty (AnySign n) (map unwrapPP -> pes)
+sqrtModFListProperty (AnySign n) (map unwrapPP -> pes'@(map (first unPrime) -> pes))
   = nub ps /= ps || all
     (\rt -> all (\(p, e) -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) pes)
-    (sqrtModFList n pes)
+    (sqrtModFList n (map (uncurry FieldCharacteristic) pes'))
   where
     ps = map fst pes
 
 sqrtModFListSpecialCase :: Assertion
 sqrtModFListSpecialCase =
-  assertEqual "sqrtModPPList 0 [(2,1), (3,1), (5,1)]" [0] (sqrtModFList 0 [(2,1), (3,1), (5,1)])
+  assertEqual "sqrtModPPList 0 [(2,1), (3,1), (5,1)]" [0]
+    (sqrtModFList 0 (map (fromJust . toFieldCharacteristic . (\(a,b) -> a ^ b)) [(2,1), (3,1), (5,1)]))
 
 testSuite :: TestTree
 testSuite = testGroup "Sqrt"

--- a/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
@@ -36,12 +36,12 @@ unwrapPP (p, Power e) = (unwrapP p, e)
 -- | Check that 'sqrtMod' is defined iff a quadratic residue exists.
 --   Also check that the result is a solution of input modular equation.
 sqrtModPProperty :: AnySign Integer -> PrimeWrapper Integer -> Bool
-sqrtModPProperty (AnySign n) (unwrapP -> p) = case sqrtModP n p of
+sqrtModPProperty (AnySign n) (unwrapP -> p) = case sqrtModMaybe n p of
   Nothing -> jacobi n p == MinusOne
   Just rt -> (p == 2 || jacobi n p /= MinusOne) && rt ^ 2 `mod` p == n `mod` p
 
 sqrtModPListProperty :: AnySign Integer -> PrimeWrapper Integer -> Bool
-sqrtModPListProperty (AnySign n) (unwrapP -> p) = all (\rt -> rt ^ 2 `mod` p == n `mod` p) (sqrtModPList n p)
+sqrtModPListProperty (AnySign n) (unwrapP -> p) = all (\rt -> rt ^ 2 `mod` p == n `mod` p) (sqrtModList n p)
 
 sqrtModP'Property :: Positive Integer -> PrimeWrapper Integer -> Bool
 sqrtModP'Property (Positive n) (unwrapP -> p) = (p /= 2 && jacobi n p /= One) || rt ^ 2 `mod` p == n `mod` p
@@ -67,7 +67,7 @@ tonelliShanksSpecialCases =
     rts = map (\p -> tonelliShanks 2 p) ps
 
 sqrtModPPProperty :: AnySign Integer -> (PrimeWrapper Integer, Power Int) -> Bool
-sqrtModPPProperty (AnySign n) (unwrapP -> p, Power e) = gcd n p > 1 || case sqrtModPP n (p, e) of
+sqrtModPPProperty (AnySign n) (unwrapP -> p, Power e) = gcd n p > 1 || case sqrtModMaybe n (p ^ e) of
   Nothing -> True
   Just rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)
 
@@ -76,15 +76,15 @@ sqrtModPPBase2Property n e = sqrtModPPProperty n (PrimeWrapper $ fromJust $ isPr
 
 sqrtModPPSpecialCase1 :: Assertion
 sqrtModPPSpecialCase1 =
-  assertEqual "sqrtModPP 16 2 2 = 4" (Just 0) (sqrtModPP 16 (2, 2))
+  assertEqual "sqrtModPP 16 2 2 = 4" (Just 0) (sqrtModMaybe 16 (2 ^ 2))
 
 sqrtModPPSpecialCase2 :: Assertion
 sqrtModPPSpecialCase2 =
-  assertEqual "sqrtModPP 16 3 2 = 4" (Just 4) (sqrtModPP 16 (3, 2))
+  assertEqual "sqrtModPP 16 3 2 = 4" (Just 4) (sqrtModMaybe 16 (3 ^ 2))
 
 sqrtModPPListProperty :: AnySign Integer -> (PrimeWrapper Integer, Power Int) -> Bool
 sqrtModPPListProperty (AnySign n) (unwrapP -> p, Power e) = gcd n p > 1
-  || all (\rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) (sqrtModPPList n (p, e))
+  || all (\rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) (sqrtModList n (p ^ e))
 
 sqrtModFProperty :: AnySign Integer -> [(PrimeWrapper Integer, Power Int)] -> Bool
 sqrtModFProperty (AnySign n) (map unwrapPP -> pes) = case sqrtModF n pes of

--- a/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
@@ -33,6 +33,8 @@ unwrapP (PrimeWrapper p) = unPrime p
 unwrapPP :: (PrimeWrapper Integer, Power Int) -> (Integer, Int)
 unwrapPP (p, Power e) = (unwrapP p, e)
 
+-- FIXME: update names. Maybe not - they describe specific behavior inside interfaces.
+
 -- | Check that 'sqrtMod' is defined iff a quadratic residue exists.
 --   Also check that the result is a solution of input modular equation.
 sqrtModPProperty :: AnySign Integer -> PrimeWrapper Integer -> Bool
@@ -46,25 +48,25 @@ sqrtModPListProperty (AnySign n) (unwrapP -> p) = all (\rt -> rt ^ 2 `mod` p == 
 sqrtModP'Property :: Positive Integer -> PrimeWrapper Integer -> Bool
 sqrtModP'Property (Positive n) (unwrapP -> p) = (p /= 2 && jacobi n p /= One) || rt ^ 2 `mod` p == n `mod` p
   where
-    rt = sqrtModP' n p
+    rt = sqrtModSharp n p
 
 tonelliShanksProperty1 :: Positive Integer -> PrimeWrapper Integer -> Bool
 tonelliShanksProperty1 (Positive n) (unwrapP -> p) = p `mod` 4 /= 1 || jacobi n p /= One || rt ^ 2 `mod` p == n `mod` p
   where
-    rt = tonelliShanks n p
+    rt = sqrtModSharp n p
 
 tonelliShanksProperty2 :: PrimeWrapper Integer -> Bool
 tonelliShanksProperty2 (unwrapP -> p) = p `mod` 4 /= 1 || rt ^ 2 `mod` p == n `mod` p
   where
     n  = head $ filter (\s -> jacobi s p == One) [2..p-1]
-    rt = tonelliShanks n p
+    rt = sqrtModSharp n p
 
 tonelliShanksSpecialCases :: Assertion
 tonelliShanksSpecialCases =
   assertEqual "OEIS A002224" [6, 32, 219, 439, 1526, 2987, 22193, 11740, 13854, 91168, 326277, 232059, 3230839, 4379725, 11754394, 32020334, 151024619, 345641931, 373671108, 1857111865, 8110112775, 4184367042] rts
   where
     ps = [17, 73, 241, 1009, 2689, 8089, 33049, 53881, 87481, 483289, 515761, 1083289, 3818929, 9257329, 22000801, 48473881, 175244281, 427733329, 898716289, 8114538721, 9176747449, 23616331489]
-    rts = map (\p -> tonelliShanks 2 p) ps
+    rts = map (\p -> sqrtModSharp 2 p) ps
 
 sqrtModPPProperty :: AnySign Integer -> (PrimeWrapper Integer, Power Int) -> Bool
 sqrtModPPProperty (AnySign n) (unwrapP -> p, Power e) = gcd n p > 1 || case sqrtModMaybe n (p ^ e) of

--- a/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
@@ -23,9 +23,13 @@ import Test.Tasty.HUnit
 import Data.List (nub)
 import Data.Maybe (fromJust)
 
-import Math.NumberTheory.Moduli hiding (invertMod)
+import Math.NumberTheory.Moduli hiding (invertMod, unPrime)
 import Math.NumberTheory.UniqueFactorisation (unPrime, isPrime)
 import Math.NumberTheory.TestUtils
+
+fromJustCustom :: Maybe a -> a
+fromJustCustom Nothing = error "Not a prime"
+fromJustCustom (Just a) = a
 
 unwrapP :: PrimeWrapper Integer -> Integer
 unwrapP (PrimeWrapper p) = unPrime p
@@ -38,55 +42,56 @@ unwrapPP (p, Power e) = (unwrapP p, e)
 -- | Check that 'sqrtMod' is defined iff a quadratic residue exists.
 --   Also check that the result is a solution of input modular equation.
 sqrtModPProperty :: AnySign Integer -> PrimeWrapper Integer -> Bool
-sqrtModPProperty (AnySign n) (unwrapP -> p) = case sqrtModMaybe n (FieldCharacterictic p 1) of
+sqrtModPProperty (AnySign n) (unwrapP -> p) = case sqrtModMaybe n (fromJustCustom . toFieldCharacteristic $ p) of
   Nothing -> jacobi n p == MinusOne
   Just rt -> (p == 2 || jacobi n p /= MinusOne) && rt ^ 2 `mod` p == n `mod` p
 
 sqrtModPListProperty :: AnySign Integer -> PrimeWrapper Integer -> Bool
-sqrtModPListProperty (AnySign n) (unwrapP -> p) = all (\rt -> rt ^ 2 `mod` p == n `mod` p) (sqrtModList n (FieldCharacterictic p 1))
+sqrtModPListProperty (AnySign n) (unwrapP -> p) = all (\rt -> rt ^ 2 `mod` p == n `mod` p) (sqrtModList n (fromJustCustom . toFieldCharacteristic $ p))
 
 sqrtModP'Property :: Positive Integer -> PrimeWrapper Integer -> Bool
 sqrtModP'Property (Positive n) (unwrapP -> p) = (p /= 2 && jacobi n p /= One) || rt ^ 2 `mod` p == n `mod` p
   where
-    rt = sqrtModExact n (FieldCharacterictic p 1)
+    rt = sqrtModExact n (fromJustCustom . toFieldCharacteristic $ p)
 
 tonelliShanksProperty1 :: Positive Integer -> PrimeWrapper Integer -> Bool
 tonelliShanksProperty1 (Positive n) (unwrapP -> p) = p `mod` 4 /= 1 || jacobi n p /= One || rt ^ 2 `mod` p == n `mod` p
   where
-    rt = sqrtModExact n (FieldCharacterictic p 1)
+    rt = sqrtModExact n (fromJustCustom . toFieldCharacteristic $ p)
 
 tonelliShanksProperty2 :: PrimeWrapper Integer -> Bool
 tonelliShanksProperty2 (unwrapP -> p) = p `mod` 4 /= 1 || rt ^ 2 `mod` p == n `mod` p
   where
     n  = head $ filter (\s -> jacobi s p == One) [2..p-1]
-    rt = sqrtModExact n (FieldCharacterictic p 1)
+    rt = sqrtModExact n (fromJustCustom . toFieldCharacteristic $ p)
 
 tonelliShanksSpecialCases :: Assertion
 tonelliShanksSpecialCases =
   assertEqual "OEIS A002224" [6, 32, 219, 439, 1526, 2987, 22193, 11740, 13854, 91168, 326277, 232059, 3230839, 4379725, 11754394, 32020334, 151024619, 345641931, 373671108, 1857111865, 8110112775, 4184367042] rts
   where
     ps = [17, 73, 241, 1009, 2689, 8089, 33049, 53881, 87481, 483289, 515761, 1083289, 3818929, 9257329, 22000801, 48473881, 175244281, 427733329, 898716289, 8114538721, 9176747449, 23616331489]
-    rts = map (\p -> sqrtModExact 2 (FieldCharacterictic p 1)) ps
+    rts = map (\p -> sqrtModExact 2 (fromJustCustom . toFieldCharacteristic $ p)) ps
 
 sqrtModPPProperty :: AnySign Integer -> (PrimeWrapper Integer, Power Int) -> Bool
-sqrtModPPProperty (AnySign n) (unwrapP -> p, Power e) = gcd n p > 1 || case sqrtModMaybe n (FieldCharacterictic p e) of
-  Nothing -> True
-  Just rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)
+sqrtModPPProperty (AnySign n) (unwrapP -> p, Power e) =
+  gcd n p > 1 || case sqrtModMaybe n (fromJustCustom . toFieldCharacteristic $ p ^ e) of
+    Nothing -> True
+    Just rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)
 
 sqrtModPPBase2Property :: AnySign Integer -> Power Int -> Bool
 sqrtModPPBase2Property n e = sqrtModPPProperty n (PrimeWrapper $ fromJust $ isPrime (2 :: Integer), e)
 
 sqrtModPPSpecialCase1 :: Assertion
 sqrtModPPSpecialCase1 =
-  assertEqual "sqrtModPP 16 2 2 = 4" (Just 0) (sqrtModMaybe 16 (FieldCharacterictic 2 2))
+  assertEqual "sqrtModPP 16 2 2 = 4" (Just 0) (sqrtModMaybe 16 (fromJustCustom . toFieldCharacteristic $ 2 ^ 2))
 
 sqrtModPPSpecialCase2 :: Assertion
 sqrtModPPSpecialCase2 =
-  assertEqual "sqrtModPP 16 3 2 = 4" (Just 4) (sqrtModMaybe 16 (FieldCharacterictic 3 2))
+  assertEqual "sqrtModPP 16 3 2 = 4" (Just 4) (sqrtModMaybe 16 (fromJustCustom . toFieldCharacteristic $ 3 ^ 2))
 
 sqrtModPPListProperty :: AnySign Integer -> (PrimeWrapper Integer, Power Int) -> Bool
 sqrtModPPListProperty (AnySign n) (unwrapP -> p, Power e) = gcd n p > 1
-  || all (\rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) (sqrtModList n (FieldCharacterictic p e))
+  || all (\rt -> rt ^ 2 `mod` (p ^ e) == n `mod` (p ^ e)) (sqrtModList n (fromJustCustom . toFieldCharacteristic $ p ^ e))
 
 sqrtModFProperty :: AnySign Integer -> [(PrimeWrapper Integer, Power Int)] -> Bool
 sqrtModFProperty (AnySign n) (map unwrapPP -> pes) = case sqrtModF n pes of

--- a/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
@@ -49,25 +49,25 @@ sqrtModPListProperty (AnySign n) (unwrapP -> p'@(unPrime -> p)) = all (\rt -> rt
 sqrtModP'Property :: Positive Integer -> PrimeWrapper Integer -> Bool
 sqrtModP'Property (Positive n) (unwrapP -> p'@(unPrime -> p)) = (p /= 2 && jacobi n p /= One) || rt ^ 2 `mod` p == n `mod` p
   where
-    rt = sqrtModExact n (FieldCharacteristic p' 1)
+    rt = sqrtModExact (QuadraticResidue p' n)
 
 tonelliShanksProperty1 :: Positive Integer -> PrimeWrapper Integer -> Bool
 tonelliShanksProperty1 (Positive n) (unwrapP -> p'@(unPrime -> p)) = p `mod` 4 /= 1 || jacobi n p /= One || rt ^ 2 `mod` p == n `mod` p
   where
-    rt = sqrtModExact n (FieldCharacteristic p' 1)
+    rt = sqrtModExact (QuadraticResidue p' n)
 
 tonelliShanksProperty2 :: PrimeWrapper Integer -> Bool
 tonelliShanksProperty2 (unwrapP -> p'@(unPrime -> p)) = p `mod` 4 /= 1 || rt ^ 2 `mod` p == n `mod` p
   where
     n  = head $ filter (\s -> jacobi s p == One) [2..p-1]
-    rt = sqrtModExact n (FieldCharacteristic p' 1)
+    rt = sqrtModExact (QuadraticResidue p' n)
 
 tonelliShanksSpecialCases :: Assertion
 tonelliShanksSpecialCases =
   assertEqual "OEIS A002224" [6, 32, 219, 439, 1526, 2987, 22193, 11740, 13854, 91168, 326277, 232059, 3230839, 4379725, 11754394, 32020334, 151024619, 345641931, 373671108, 1857111865, 8110112775, 4184367042] rts
   where
     ps = [17, 73, 241, 1009, 2689, 8089, 33049, 53881, 87481, 483289, 515761, 1083289, 3818929, 9257329, 22000801, 48473881, 175244281, 427733329, 898716289, 8114538721, 9176747449, 23616331489]
-    rts = map (\p -> sqrtModExact 2 (fromJust . toFieldCharacteristic $ p)) ps
+    rts = map (\p -> sqrtModExact (fromJust $ toQuadraticResidue (fromJust . isPrime $ (p::Integer)) 2)) ps
 
 sqrtModPPProperty :: AnySign Integer -> (PrimeWrapper Integer, Power Int) -> Bool
 sqrtModPPProperty (AnySign n) (unwrapP -> p'@(unPrime -> p), Power e) =


### PR DESCRIPTION
Covers #87 (Not closes since there is still strange internal design)
Possible workaround here:
- [x] Use `PrimeNat`.
- [x] Check if residue is quadratic also outside and reflect it to types - ideally make type like `data Residue a = Quadratic a | NonQuadratic a`. It looks like reflecting terminology to type system is a good approach.