### PR TITLE
Polymorphic prime sieves

### DIFF
--- a/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
+++ b/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
@@ -8,7 +8,10 @@
 --
 -- Sieve
 --
-{-# LANGUAGE CPP, BangPatterns, FlexibleContexts #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE FlexibleContexts    #-}
+
 {-# OPTIONS_GHC -fspec-constr-count=8 #-}
 {-# OPTIONS_HADDOCK hide #-}
 module Math.NumberTheory.Primes.Sieve.Eratosthenes
@@ -44,6 +47,7 @@ import Data.Word
 import Math.NumberTheory.Powers.Squares (integerSquareRoot)
 import Math.NumberTheory.Unsafe
 import Math.NumberTheory.Utils
+import Math.NumberTheory.Utils.FromIntegral
 import Math.NumberTheory.Primes.Counting.Approximate
 import Math.NumberTheory.Primes.Sieve.Indexing
 
@@ -135,7 +139,7 @@ psieveList = makeSieves plim sqlim 0 0 cache
     plim = 4801     -- prime #647, 644 of them to use
     sqlim = plim*plim
     cache = runSTUArray $ do
-        sieve <- sieveTo 4801
+        sieve <- sieveTo (4801 :: Integer)
         new <- unsafeNewArray_ (0,1287) :: ST s (STUArray s Int CacheWord)
         let fill j indx
               | 1279 < indx = return new    -- index of 4801 = 159*30 + 31 ~> 159*8+7
@@ -404,7 +408,7 @@ nthPrimeCt n
                       bnd = bd0 + bd0 `quot` 32 + 37
                       !sv = primeSieve bnd
                   in countToNth (n-3) [sv]
-  | otherwise   = countToNth (n-3) (psieveFrom (fromIntegral $ fromInteger n .&. (7 :: Int)))
+  | otherwise   = countToNth (n-3) (psieveFrom (intToInteger $ fromInteger n .&. (7 :: Int)))
 
 -- find the n-th set bit in a list of PrimeSieves,
 -- aka find the (n+3)-rd prime

--- a/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
+++ b/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
@@ -120,10 +120,13 @@ primeList (PS vO bs) = [vO + toPrim i
                             , unsafeAt bs i
                             ]
 
--- | List of primes.
---   Since the sieve uses unboxed arrays, overflow occurs at some point.
---   On 64-bit systems, that point is beyond the memory limits, on
---   32-bit systems, it is at about @1.7*10^18@.
+-- | Ascending list of primes.
+--
+-- > > take 10 primes
+-- > [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+--
+-- 'primes' is a monomorphic list, so the results of computations are retained in memory forever.
+-- Use it with caution.
 primes :: [Integer]
 primes = 2:3:5:concat [[vO + toPrim i | i <- [0 .. li], unsafeAt bs i]
                                 | PS vO bs <- psieveList, let (_,li) = bounds bs]

--- a/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
+++ b/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
@@ -341,7 +341,7 @@ sieveFrom n = case psieveFrom n of
 psieveFrom :: Integer -> [PrimeSieve]
 psieveFrom n = makeSieves plim sqlim bitOff valOff cache
     where
-      k0 = max 0 (n-7) `quot` 30
+      k0 = ((n `max` 7) - 7) `quot` 30 -- beware arithmetic underflow
       valOff = 30*k0
       bitOff = 8*k0
       start = valOff+7

--- a/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
+++ b/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
@@ -110,15 +110,15 @@ primeSieve bound = PS 0 (runSTUArray $ sieveTo bound)
 -- | Generate a list of primes for consumption from a
 --   'PrimeSieve'.
 primeList :: Num a => PrimeSieve -> [a]
-primeList (PS 0 bs) = 2:3:5:[toPrim i | let (lo,hi) = bounds bs
-                                      , i <- [lo .. hi]
-                                      , unsafeAt bs i
-                                      ]
-primeList (PS vO bs) = [fromInteger vO + toPrim i
-                            | let (lo,hi) = bounds bs
-                            , i <- [lo .. hi]
-                            , unsafeAt bs i
-                            ]
+primeList ps@(PS 0 _) = 2 : 3 : 5 : primeListInternal ps
+primeList ps          = primeListInternal ps
+
+primeListInternal :: Num a => PrimeSieve -> [a]
+primeListInternal (PS v0 bs)
+  = map ((+ fromInteger v0) . toPrim)
+  $ filter (unsafeAt bs) [lo..hi]
+  where
+    (lo, hi) = bounds bs
 
 -- | Ascending list of primes.
 --
@@ -146,8 +146,7 @@ primeList (PS vO bs) = [fromInteger vO + toPrim i
 -- > 15485867
 -- > (0.02 secs, 336,232 bytes)
 primes :: Num a => [a]
-primes = 2:3:5:concat [[fromInteger vO + toPrim i | i <- [0 .. li], unsafeAt bs i]
-                                | PS vO bs <- psieveList, let (_,li) = bounds bs]
+primes = 2 : 3 : 5 : concatMap primeListInternal psieveList
 
 -- | List of primes in the form of a list of 'PrimeSieve's, more compact than
 --   'primes', thus it may be better to use @'psieveList' >>= 'primeList'@

--- a/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
+++ b/Math/NumberTheory/Primes/Sieve/Eratosthenes.hs
@@ -26,9 +26,7 @@ module Math.NumberTheory.Primes.Sieve.Eratosthenes
     , countFromTo
     , countAll
     , countToNth
-    , sieveBytes
     , sieveBits
-    , sieveWords
     , sieveRange
     , sieveTo
     ) where

--- a/Math/NumberTheory/Primes/Sieve/Indexing.hs
+++ b/Math/NumberTheory/Primes/Sieve/Indexing.hs
@@ -6,6 +6,8 @@
 -- Stability:   Provisional
 -- Portability: Non-portable (GHC extensions)
 --
+-- Auxiliary stuff, conversion between number and index,
+-- remainders modulo 30 and related things.
 {-# OPTIONS_HADDOCK hide #-}
 module Math.NumberTheory.Primes.Sieve.Indexing
     ( idxPr
@@ -18,13 +20,6 @@ import Data.Bits
 
 import Math.NumberTheory.Unsafe
 
--- Auxiliary stuff, conversion between number and index,
--- remainders modulo 30 and related things.
-
--- {-# SPECIALISE idxPr :: Integer -> (Int,Int),
---                         Int -> (Int,Int),
---                         Word -> (Int,Int)
---   #-}
 {-# INLINE idxPr #-}
 idxPr :: Integral a => a -> (Int,Int)
 idxPr n0
@@ -38,11 +33,6 @@ idxPr n0
     rm2 = rm1 `quot` 3
     rm3 = min 7 (if rm2 > 5 then rm2-1 else rm2)
 
--- {-# SPECIALISE toPrim :: Int -> Integer,
---                          Int -> Int,
---                          Int -> Word,
---                          Int -> Word16
---     #-}
 {-# INLINE toPrim #-}
 toPrim :: Integral a => Int -> a
 toPrim ix = 30*fromIntegral k + fromIntegral (rho i)

--- a/Math/NumberTheory/Primes/Sieve/Indexing.hs
+++ b/Math/NumberTheory/Primes/Sieve/Indexing.hs
@@ -34,7 +34,7 @@ idxPr n0
     rm3 = min 7 (if rm2 > 5 then rm2-1 else rm2)
 
 {-# INLINE toPrim #-}
-toPrim :: Integral a => Int -> a
+toPrim :: Num a => Int -> a
 toPrim ix = 30*fromIntegral k + fromIntegral (rho i)
   where
     i = ix .&. 7

--- a/test-suite/Math/NumberTheory/Primes/SieveTests.hs
+++ b/test-suite/Math/NumberTheory/Primes/SieveTests.hs
@@ -8,7 +8,8 @@
 -- Tests for Math.NumberTheory.Primes.Sieve
 --
 
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 {-# OPTIONS_GHC -fno-warn-deprecations  #-}
@@ -21,6 +22,9 @@ import Prelude hiding (words)
 
 import Test.Tasty
 import Test.Tasty.HUnit
+
+import Data.Proxy (Proxy(..))
+import Numeric.Natural (Natural)
 
 import Math.NumberTheory.Primes.Sieve
 import Math.NumberTheory.Primes.Testing
@@ -36,9 +40,9 @@ lim3 :: Num a => a
 lim3 = 1000
 
 -- | Check that 'primes' matches 'isPrime'.
-primesProperty1 :: Assertion
-primesProperty1 = assertEqual "primes matches isPrime"
-  (takeWhile (<= lim1) primes)
+primesProperty1 :: forall a. (Integral a, Show a) => Proxy a -> Assertion
+primesProperty1 _ = assertEqual "primes matches isPrime"
+  (takeWhile (<= lim1) primes :: [a])
   (filter (isPrime . toInteger) [1..lim1])
 
 -- | Check that 'primeList' from 'primeSieve' matches truncated 'primes'.
@@ -50,9 +54,9 @@ primeSieveProperty1 (AnySign highBound')
     highBound = highBound' `rem` lim1
 
 -- | Check that 'primeList' from 'psieveList' matches 'primes'.
-psieveListProperty1 :: Assertion
-psieveListProperty1 = assertEqual "primes == primeList . psieveList"
-  (take lim2 primes)
+psieveListProperty1 :: forall a. (Eq a, Num a, Show a) => Proxy a -> Assertion
+psieveListProperty1 _ = assertEqual "primes == primeList . psieveList"
+  (take lim2 primes :: [a])
   (take lim2 $ concatMap primeList psieveList)
 
 -- | Check that 'sieveFrom' matches 'primeList' of 'psieveFrom'.
@@ -73,9 +77,19 @@ sieveFromProperty2 (AnySign lowBound')
 
 testSuite :: TestTree
 testSuite = testGroup "Sieve"
-  [ testCase "primes" primesProperty1
+  [ testGroup "primes"
+    [ testCase "Int"     (primesProperty1 (Proxy :: Proxy Int))
+    , testCase "Word"    (primesProperty1 (Proxy :: Proxy Word))
+    , testCase "Integer" (primesProperty1 (Proxy :: Proxy Integer))
+    , testCase "Natural" (primesProperty1 (Proxy :: Proxy Natural))
+    ]
   , testSmallAndQuick "primeSieve" primeSieveProperty1
-  , testCase "psieveList" psieveListProperty1
+  , testGroup "psieveList"
+    [ testCase "Int"     (psieveListProperty1 (Proxy :: Proxy Int))
+    , testCase "Word"    (psieveListProperty1 (Proxy :: Proxy Word))
+    , testCase "Integer" (psieveListProperty1 (Proxy :: Proxy Integer))
+    , testCase "Natural" (psieveListProperty1 (Proxy :: Proxy Natural))
+    ]
   , testGroup "sieveFrom"
     [ testSmallAndQuick "psieveFrom"     sieveFromProperty1
     , testSmallAndQuick "isPrime near 0" sieveFromProperty2

--- a/test-suite/Math/NumberTheory/Primes/SieveTests.hs
+++ b/test-suite/Math/NumberTheory/Primes/SieveTests.hs
@@ -23,7 +23,9 @@ import Prelude hiding (words)
 import Test.Tasty
 import Test.Tasty.HUnit
 
+import Data.Int
 import Data.Proxy (Proxy(..))
+import Data.Word
 import Numeric.Natural (Natural)
 
 import Math.NumberTheory.Primes.Sieve
@@ -45,6 +47,11 @@ primesProperty1 _ = assertEqual "primes matches isPrime"
   (takeWhile (<= lim1) primes :: [a])
   (filter (isPrime . toInteger) [1..lim1])
 
+primesProperty2 :: forall a. (Integral a, Bounded a, Show a) => Proxy a -> Assertion
+primesProperty2 _ = assertEqual "primes matches isPrime"
+  (primes :: [a])
+  (filter (isPrime . toInteger) [1..maxBound])
+
 -- | Check that 'primeList' from 'primeSieve' matches truncated 'primes'.
 primeSieveProperty1 :: AnySign Integer -> Bool
 primeSieveProperty1 (AnySign highBound')
@@ -54,10 +61,15 @@ primeSieveProperty1 (AnySign highBound')
     highBound = highBound' `rem` lim1
 
 -- | Check that 'primeList' from 'psieveList' matches 'primes'.
-psieveListProperty1 :: forall a. (Eq a, Num a, Show a) => Proxy a -> Assertion
+psieveListProperty1 :: forall a. (Integral a, Show a) => Proxy a -> Assertion
 psieveListProperty1 _ = assertEqual "primes == primeList . psieveList"
   (take lim2 primes :: [a])
   (take lim2 $ concatMap primeList psieveList)
+
+psieveListProperty2 :: forall a. (Integral a, Bounded a, Show a) => Proxy a -> Assertion
+psieveListProperty2 _ = assertEqual "primes == primeList . psieveList"
+  (primes :: [a])
+  (concat $ takeWhile (not . null) $ map primeList psieveList)
 
 -- | Check that 'sieveFrom' matches 'primeList' of 'psieveFrom'.
 sieveFromProperty1 :: AnySign Integer -> Bool
@@ -82,6 +94,11 @@ testSuite = testGroup "Sieve"
     , testCase "Word"    (primesProperty1 (Proxy :: Proxy Word))
     , testCase "Integer" (primesProperty1 (Proxy :: Proxy Integer))
     , testCase "Natural" (primesProperty1 (Proxy :: Proxy Natural))
+
+    , testCase "Int8"    (primesProperty2 (Proxy :: Proxy Int8))
+    , testCase "Int16"   (primesProperty2 (Proxy :: Proxy Int16))
+    , testCase "Word8"   (primesProperty2 (Proxy :: Proxy Word8))
+    , testCase "Word16"  (primesProperty2 (Proxy :: Proxy Word16))
     ]
   , testSmallAndQuick "primeSieve" primeSieveProperty1
   , testGroup "psieveList"
@@ -89,6 +106,11 @@ testSuite = testGroup "Sieve"
     , testCase "Word"    (psieveListProperty1 (Proxy :: Proxy Word))
     , testCase "Integer" (psieveListProperty1 (Proxy :: Proxy Integer))
     , testCase "Natural" (psieveListProperty1 (Proxy :: Proxy Natural))
+
+    , testCase "Int8"    (psieveListProperty2 (Proxy :: Proxy Int8))
+    , testCase "Int16"   (psieveListProperty2 (Proxy :: Proxy Int16))
+    , testCase "Word8"   (psieveListProperty2 (Proxy :: Proxy Word8))
+    , testCase "Word16"  (psieveListProperty2 (Proxy :: Proxy Word16))
     ]
   , testGroup "sieveFrom"
     [ testSmallAndQuick "psieveFrom"     sieveFromProperty1


### PR DESCRIPTION
This branch resolves #94 by making return type of `primes` and `primeList` polymorphic. Despite of such a humble achievement, it took a significant time to entangle things, to write better tests (including tests on `Natural`, cf. #100) and to cope with finite domains like `Int8`.