### PR TITLE
Implementation of Ramanujan tau-function

### DIFF
--- a/Math/NumberTheory/ArithmeticFunctions/Standard.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/Standard.hs
@@ -153,6 +153,8 @@ jordanHelper pa k = (pa - 1) * pa ^ wordToInt (k - 1)
 ramanujan :: (UniqueFactorisation n, Integral n, Integral m) => n -> m
 ramanujan = runFunction ramanujanA
 
+-- | Calculates the <https://en.wikipedia.org/wiki/Ramanujan_tau_function Ramanujan tau function>
+--   of a positive number @n@, using formulas given <http://www.numbertheory.org/php/tau.html here>
 ramanujanA :: forall n m. (UniqueFactorisation n, Integral n, Integral m) => ArithmeticFunction n m
 ramanujanA = multiplicative $ \((unPrime :: Prime n -> n) -> p) -> ramanujanHelper p
 

--- a/Math/NumberTheory/ArithmeticFunctions/Standard.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/Standard.hs
@@ -26,6 +26,7 @@ module Math.NumberTheory.ArithmeticFunctions.Standard
   , sigma, sigmaA
   , totient, totientA
   , jordan, jordanA
+  , ramanujan, ramanujanA
   , moebius, moebiusA, Moebius(..), runMoebius
   , liouville, liouvilleA
     -- * Additive functions
@@ -148,6 +149,17 @@ jordanHelper pa 1 = pa - 1
 jordanHelper pa 2 = (pa - 1) * pa
 jordanHelper pa k = (pa - 1) * pa ^ wordToInt (k - 1)
 {-# INLINE jordanHelper #-}
+
+ramanujan :: (UniqueFactorisation n, Integral n) => n -> n
+ramanujan = runFunction ramanujanA
+
+ramanujanA :: forall n. (UniqueFactorisation n, Integral n) => ArithmeticFunction n n
+ramanujanA = multiplicative $ \((unPrime :: Prime n -> n) -> p) -> ramanujanHelper p
+
+ramanujanHelper :: (UniqueFactorisation n, Integral n) => n -> Word -> n
+ramanujanHelper _ 0 = 1
+ramanujanHelper p 1 = (65 * (p ^ (11 :: Int) + 1) + 691 * (p ^ (5 :: Int) + 1) - 691 * 252 * sum [sigma 5 k * sigma 5 (p-k) | k <- [1..(p-1)]]) `quot` 756
+ramanujanHelper p k = ramanujanHelper p 1 * ramanujanHelper p (k-1) - (p ^ (11 :: Int)) * ramanujanHelper p (k-2)
 
 moebius :: UniqueFactorisation n => n -> Moebius
 moebius = runFunction moebiusA

--- a/Math/NumberTheory/ArithmeticFunctions/Standard.hs
+++ b/Math/NumberTheory/ArithmeticFunctions/Standard.hs
@@ -150,16 +150,16 @@ jordanHelper pa 2 = (pa - 1) * pa
 jordanHelper pa k = (pa - 1) * pa ^ wordToInt (k - 1)
 {-# INLINE jordanHelper #-}
 
-ramanujan :: (UniqueFactorisation n, Integral n) => n -> n
+ramanujan :: (UniqueFactorisation n, Integral n, Integral m) => n -> m
 ramanujan = runFunction ramanujanA
 
-ramanujanA :: forall n. (UniqueFactorisation n, Integral n) => ArithmeticFunction n n
+ramanujanA :: forall n m. (UniqueFactorisation n, Integral n, Integral m) => ArithmeticFunction n m
 ramanujanA = multiplicative $ \((unPrime :: Prime n -> n) -> p) -> ramanujanHelper p
 
-ramanujanHelper :: (UniqueFactorisation n, Integral n) => n -> Word -> n
+ramanujanHelper :: (UniqueFactorisation n, Integral n, Integral m) => n -> Word -> m
 ramanujanHelper _ 0 = 1
-ramanujanHelper p 1 = (65 * (p ^ (11 :: Int) + 1) + 691 * (p ^ (5 :: Int) + 1) - 691 * 252 * sum [sigma 5 k * sigma 5 (p-k) | k <- [1..(p-1)]]) `quot` 756
-ramanujanHelper p k = ramanujanHelper p 1 * ramanujanHelper p (k-1) - (p ^ (11 :: Int)) * ramanujanHelper p (k-2)
+ramanujanHelper p 1 = (fromIntegral (65 * (p ^ (11 :: Int) + 1) + 691 * (p ^ (5 :: Int) + 1)) - fromIntegral (691 * 252 * sum [sigma 5 k * sigma 5 (p-k) | k <- [1..(p-1)]])) `quot` 756
+ramanujanHelper p k = ramanujanHelper p 1 * ramanujanHelper p (k-1) - (fromIntegral $ p ^ (11 :: Int)) * ramanujanHelper p (k-2)
 
 moebius :: UniqueFactorisation n => n -> Moebius
 moebius = runFunction moebiusA

--- a/test-suite/Math/NumberTheory/ArithmeticFunctionsTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctionsTests.hs
@@ -14,7 +14,8 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 module Math.NumberTheory.ArithmeticFunctionsTests
-  where
+  ( testSuite
+  ) where
 
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/test-suite/Math/NumberTheory/ArithmeticFunctionsTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctionsTests.hs
@@ -122,6 +122,15 @@ jordan2Oeis = oeisAssertion "A007434" (jordanA 2)
   , 1728, 1584, 2208, 1536
   ]
 
+-- | ramanujan matches baseline from OEIS.
+ramanujanOeis :: Assertion
+ramanujanOeis = oeisAssertion "A000594" ramanujanA
+  [ 1, -24, 252, -1472, 4830, -6048, -16744, 84480, -113643, -115920
+  , 534612, -370944, -577738, 401856, 1217160, 987136, -6905934, 2727432
+  , 10661420, -7109760, -4219488, -12830688, 18643272, 21288960, -25499225
+  , 13865712, -73279080, 24647168
+  ]
+
 -- | moebius does not require full factorisation
 moebiusLazy :: Assertion
 moebiusLazy = assertEqual "moebius" MoebiusZ (runFunction moebiusA (2^2 * (2^100000-1) :: Natural))
@@ -229,6 +238,9 @@ testSuite = testGroup "ArithmeticFunctions"
     [ testSmallAndQuick "jordan_0 = [== 1]"  jordanProperty1
     , testSmallAndQuick "jordan_1 = totient" jordanProperty2
     , testCase          "OEIS jordan_2"      jordan2Oeis
+    ]
+  , testGroup "Ramanujan"
+    [ testCase          "OEIS ramanujan"      ramanujanOeis
     ]
   , testGroup "Moebius"
     [ testCase          "OEIS"           moebiusOeis

--- a/test-suite/Math/NumberTheory/ArithmeticFunctionsTests.hs
+++ b/test-suite/Math/NumberTheory/ArithmeticFunctionsTests.hs
@@ -14,8 +14,7 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 module Math.NumberTheory.ArithmeticFunctionsTests
-  ( testSuite
-  ) where
+  where
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -121,6 +120,23 @@ jordan2Oeis = oeisAssertion "A007434" (jordanA 2)
   , 768, 960, 864, 1152, 864, 1368, 1080, 1344, 1152, 1680, 1152, 1848, 1440
   , 1728, 1584, 2208, 1536
   ]
+
+-- | congruences 1,2,3,4 from https://en.wikipedia.org/wiki/Ramanujan_tau_function
+ramanujanCongruence1 :: NonZero Natural -> Bool
+ramanujanCongruence1 (NonZero n)
+  | k == 1 = (ramanujan n - sigma 11 n) `mod` (2^11) == 0
+  | k == 3 = (ramanujan n - 1217 * sigma 11 n) `mod` (2^13) == 0
+  | k == 5 = (ramanujan n - 1537 * sigma 11 n) `mod` (2^12) == 0
+  | k == 7 = (ramanujan n - 705 * sigma 11 n) `mod` (2^14) == 0
+  | otherwise = True
+  where k = n `mod` 8
+
+-- | congruences 8,9 from https://en.wikipedia.org/wiki/Ramanujan_tau_function
+ramanujanCongruence2 :: NonZero Natural -> Bool
+ramanujanCongruence2 (NonZero n)
+  | (n `mod` 7) `elem` [0,1,2,4] = m `mod` 7 == 0
+  | otherwise                    = m `mod` 49 == 0
+  where m = ramanujan n - (fromIntegral n) * sigma 9 n :: Integer
 
 -- | ramanujan matches baseline from OEIS.
 ramanujanOeis :: Assertion
@@ -240,7 +256,9 @@ testSuite = testGroup "ArithmeticFunctions"
     , testCase          "OEIS jordan_2"      jordan2Oeis
     ]
   , testGroup "Ramanujan"
-    [ testCase          "OEIS ramanujan"      ramanujanOeis
+    [ testSmallAndQuick "ramanujan mod 8 congruences" ramanujanCongruence1
+    , testSmallAndQuick "ramanujan mod 7 congruences" ramanujanCongruence2
+    , testCase          "OEIS ramanujan"              ramanujanOeis
     ]
   , testGroup "Moebius"
     [ testCase          "OEIS"           moebiusOeis


### PR DESCRIPTION
Fixes #106, using the first formula given [here](http://www.numbertheory.org/php/tau.html) and the second from [here](https://en.wikipedia.org/wiki/Ramanujan_tau_function#Ramanujan's_conjectures). The latter could be improved to the binomial summation formula instead, which would prevent lots of unnecessary recalculation for primes to a large power, but this requires an implementation of binomial coefficients as well. 
Tested against OEIS and congruences 1-4 and 8,9 listed [here](https://en.wikipedia.org/wiki/Ramanujan_tau_function#Congruences_for_the_tau_function): note congruence 10 is automatically satisfied by definition. 
An alternative method is proposed [in equation 10](http://mathworld.wolfram.com/TauFunction.html) or in [Charles 2006](https://link.springer.com/content/pdf/10.1007%2Fs11139-006-6509-y.pdf).