### PR TITLE
Added ordered Gaussian primes

### DIFF
--- a/Math/NumberTheory/GaussianIntegers.hs
+++ b/Math/NumberTheory/GaussianIntegers.hs
@@ -37,7 +37,7 @@ module Math.NumberTheory.GaussianIntegers (
 
 import Data.List (mapAccumL, partition)
 import Data.Maybe (fromMaybe)
-import Data.List.Ordered (merge)
+import Data.Ord (comparing)
 import GHC.Generics
 
 import qualified Math.NumberTheory.Moduli as Moduli
@@ -154,10 +154,20 @@ primes = [ g
 
 -- |An infinite list of Gaussian primes. See 'primes'.
 orderedPrimes :: [GaussianInteger]
-orderedPrimes = (1 :+ 1): merge l r
+orderedPrimes = (1 :+ 1): mergeBy (comparing norm) l r
   where (leftPrimes, rightPrimes) = partition (\p -> p `mod` 4 == 3) (tail Sieve.primes)
         l = [p :+ 0 | p <- leftPrimes]
         r = [g | p <- rightPrimes, let x :+ y = findPrime p, g <- [x :+ y, y :+ x]]
+
+mergeBy :: (a -> a -> Ordering) -> [a] -> [a] -> [a]
+mergeBy cmp = loop
+  where
+    loop [] ys  = ys
+    loop xs []  = xs
+    loop (x:xs) (y:ys)
+      = case cmp x y of
+         GT -> y : loop (x:xs) ys
+         _  -> x : loop xs (y:ys)
 
 -- | Compute the GCD of two Gaussian integers. Result is always
 -- in the first quadrant.

--- a/Math/NumberTheory/GaussianIntegers.hs
+++ b/Math/NumberTheory/GaussianIntegers.hs
@@ -27,7 +27,6 @@ module Math.NumberTheory.GaussianIntegers (
     (.^),
     isPrime,
     primes,
-    orderedPrimes,
     gcdG,
     gcdG',
     findPrime,
@@ -138,23 +137,10 @@ isPrime g@(x :+ y)
     | otherwise        = Testing.isPrime $ norm g
 
 -- |An infinite list of the Gaussian primes. Uses primes in Z to exhaustively
--- generate all Gaussian primes (up to associates), but not quite in order of
--- ascending magnitude. See 'orderedPrimes'.
+-- generate all Gaussian primes (up to associates), in order of ascending
+-- magnitude.
 primes :: [GaussianInteger]
-primes = [ g
-         | p <- Sieve.primes
-         , g <- if p `mod` 4 == 3
-                then [p :+ 0]
-                else
-                    if p == 2
-                    then [1 :+ 1]
-                    else let x :+ y = findPrime p
-                         in [x :+ y, y :+ x]
-         ]
-
--- |An infinite list of Gaussian primes. See 'primes'.
-orderedPrimes :: [GaussianInteger]
-orderedPrimes = (1 :+ 1): mergeBy (comparing norm) l r
+primes = (1 :+ 1): mergeBy (comparing norm) l r
   where (leftPrimes, rightPrimes) = partition (\p -> p `mod` 4 == 3) (tail Sieve.primes)
         l = [p :+ 0 | p <- leftPrimes]
         r = [g | p <- rightPrimes, let x :+ y = findPrime p, g <- [x :+ y, y :+ x]]

--- a/Math/NumberTheory/GaussianIntegers.hs
+++ b/Math/NumberTheory/GaussianIntegers.hs
@@ -27,6 +27,7 @@ module Math.NumberTheory.GaussianIntegers (
     (.^),
     isPrime,
     primes,
+    orderedPrimes,
     gcdG,
     gcdG',
     findPrime,

--- a/Math/NumberTheory/GaussianIntegers.hs
+++ b/Math/NumberTheory/GaussianIntegers.hs
@@ -34,8 +34,9 @@ module Math.NumberTheory.GaussianIntegers (
     factorise,
 ) where
 
-import Data.List (mapAccumL)
+import Data.List (mapAccumL, partition)
 import Data.Maybe (fromMaybe)
+import Data.List.Ordered (merge)
 import GHC.Generics
 
 import qualified Math.NumberTheory.Moduli as Moduli
@@ -136,7 +137,8 @@ isPrime g@(x :+ y)
     | otherwise        = Testing.isPrime $ norm g
 
 -- |An infinite list of the Gaussian primes. Uses primes in Z to exhaustively
--- generate all Gaussian primes, but not quite in order of ascending magnitude.
+-- generate all Gaussian primes (up to associates), but not quite in order of
+-- ascending magnitude. See 'orderedPrimes'.
 primes :: [GaussianInteger]
 primes = [ g
          | p <- Sieve.primes
@@ -148,6 +150,13 @@ primes = [ g
                     else let x :+ y = findPrime p
                          in [x :+ y, y :+ x]
          ]
+
+-- |An infinite list of Gaussian primes. See 'primes'.
+orderedPrimes :: [GaussianInteger]
+orderedPrimes = (1 :+ 1): merge l r
+  where (leftPrimes, rightPrimes) = partition (\p -> p `mod` 4 == 3) (tail Sieve.primes)
+        l = [p :+ 0 | p <- leftPrimes]
+        r = [g | p <- rightPrimes, let x :+ y = findPrime p, g <- [x :+ y, y :+ x]]
 
 -- | Compute the GCD of two Gaussian integers. Result is always
 -- in the first quadrant.

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -38,6 +38,7 @@ library
     base >=4.7 && <5,
     array >=0.5 && <0.6,
     containers >=0.5 && <0.7,
+    data-ordlist >= 0.4,
     exact-pi >=0.4.1.1,
     ghc-prim <0.6,
     integer-gmp <1.1,

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -38,7 +38,6 @@ library
     base >=4.7 && <5,
     array >=0.5 && <0.6,
     containers >=0.5 && <0.7,
-    data-ordlist >= 0.4,
     exact-pi >=0.4.1.1,
     ghc-prim <0.6,
     integer-gmp <1.1,

--- a/test-suite/Math/NumberTheory/GaussianIntegersTests.hs
+++ b/test-suite/Math/NumberTheory/GaussianIntegersTests.hs
@@ -113,6 +113,11 @@ consistentPrimes = assertEqual "ordered primes is primes"
   (sortOn norm $ filter ((<= 1000) . norm) $ takeWhile ((<= 1000000) . norm) primes)
   (takeWhile ((<= 1000) . norm) orderedPrimes)
 
+numberOfOrderedPrimes :: Assertion
+numberOfOrderedPrimes = assertEqual "counting primes: OEIS A091100"
+  [16,100,668,4928,38404,313752,2658344,23046512]
+  [4 * (length $ takeWhile ((<= 10^n) . norm) orderedPrimes) | n <- [1..8]]
+
 -- | signum and abs should satisfy: z == signum z * abs z
 signumAbsProperty :: GaussianInteger -> Bool
 signumAbsProperty z = z == signum z * abs z
@@ -164,6 +169,7 @@ testSuite = testGroup "GaussianIntegers" $
   , testCase          "ordered primes are ordered"   orderingPrimes
   , testSmallAndQuick "ordered primes are primes"    orderedPrimesGeneratesPrimesProperty
   , testCase          "prime lists match"            consistentPrimes
+  , testCase          "counting primes"              numberOfOrderedPrimes
   , testSmallAndQuick "signumAbsProperty"            signumAbsProperty
   , testSmallAndQuick "absProperty"                  absProperty
   , testGroup "gcdG"

--- a/test-suite/Math/NumberTheory/GaussianIntegersTests.hs
+++ b/test-suite/Math/NumberTheory/GaussianIntegersTests.hs
@@ -15,7 +15,7 @@ module Math.NumberTheory.GaussianIntegersTests
   ) where
 
 import Control.Monad (zipWithM_)
-import Data.List (groupBy, sort, sortOn)
+import Data.List (groupBy, sort)
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -89,7 +89,7 @@ isPrimeProperty g
 
 primesSpecialCase1 :: Assertion
 primesSpecialCase1 = assertEqual "primes"
-  (f [1+ι,3,1+2*ι,2+ι,7,11,3+2*ι,2+3*ι,4+ι,1+4*ι,19,23,2+5*ι,5+2*ι,31,6+ι,1+6*ι,5+4*ι,4+5*ι,43,47,2+7*ι,7+2*ι,59,5+6*ι,6+5*ι,67,71,3+8*ι,8+3*ι,79,83,5+8*ι,8+5*ι,4+9*ι,9+4*ι,1+10*ι,10+ι,103,107,3+10*ι,10+3*ι,8+7*ι,7+8*ι,127,131,11+4*ι,4+11*ι,139,10+7*ι,7+10*ι])
+  (f [1+ι,2+ι,1+2*ι,3,3+2*ι,2+3*ι,4+ι,1+4*ι,5+2*ι,2+5*ι,6+ι,1+6*ι,5+4*ι,4+5*ι,7,7+2*ι,2+7*ι,6+5*ι,5+6*ι,8+3*ι,3+8*ι,8+5*ι,5+8*ι,9+4*ι,4+9*ι,10+ι,1+10*ι,10+3*ι,3+10*ι,8+7*ι,7+8*ι,11,11+4*ι,4+11*ι,10+7*ι,7+10*ι,11+6*ι,6+11*ι,13+2*ι,2+13*ι,10+9*ι,9+10*ι,12+7*ι,7+12*ι,14+ι,1+14*ι,15+2*ι,2+15*ι,13+8*ι,8+13*ι,15+4*ι])
   (f $ take 51 primes)
   where
     f :: [GaussianInteger] -> [[GaussianInteger]]
@@ -99,24 +99,15 @@ primesSpecialCase1 = assertEqual "primes"
 primesGeneratesPrimesProperty :: NonNegative Int -> Bool
 primesGeneratesPrimesProperty (NonNegative i) = isPrime (primes !! i)
 
--- | Check that ordered primes generates the primes in order.
+-- | Check that primes generates the primes in order.
 orderingPrimes :: Assertion
-orderingPrimes = assertBool "ordered primes are ordered" (and $ zipWith (<=) xs (tail xs))
-  where xs = map norm $ take 1000 orderedPrimes
+orderingPrimes = assertBool "primes are ordered" (and $ zipWith (<=) xs (tail xs))
+  where xs = map norm $ take 1000 primes
 
--- | The ordered list of primes should include only primes.
-orderedPrimesGeneratesPrimesProperty :: NonNegative Int -> Bool
-orderedPrimesGeneratesPrimesProperty (NonNegative i) = isPrime (orderedPrimes !! i)
-
-consistentPrimes :: Assertion
-consistentPrimes = assertEqual "ordered primes is primes"
-  (sortOn norm $ filter ((<= 1000) . norm) $ takeWhile ((<= 1000000) . norm) primes)
-  (takeWhile ((<= 1000) . norm) orderedPrimes)
-
-numberOfOrderedPrimes :: Assertion
-numberOfOrderedPrimes = assertEqual "counting primes: OEIS A091100"
+numberOfPrimes :: Assertion
+numberOfPrimes = assertEqual "counting primes: OEIS A091100"
   [16,100,668,4928,38404,313752,2658344,23046512]
-  [4 * (length $ takeWhile ((<= 10^n) . norm) orderedPrimes) | n <- [1..8]]
+  [4 * (length $ takeWhile ((<= 10^n) . norm) primes) | n <- [1..8]]
 
 -- | signum and abs should satisfy: z == signum z * abs z
 signumAbsProperty :: GaussianInteger -> Bool
@@ -162,16 +153,14 @@ testSuite = testGroup "GaussianIntegers" $
     map (\x -> testCase ("laziness " ++ show (fst x)) (factoriseSpecialCase2 x))
       lazyCases)
 
-  , testSmallAndQuick "findPrime'"                   findPrimeProperty1
-  , testSmallAndQuick "isPrime"                      isPrimeProperty
-  , testCase          "primes matches reference"     primesSpecialCase1
-  , testSmallAndQuick "primes"                       primesGeneratesPrimesProperty
-  , testCase          "ordered primes are ordered"   orderingPrimes
-  , testSmallAndQuick "ordered primes are primes"    orderedPrimesGeneratesPrimesProperty
-  , testCase          "prime lists match"            consistentPrimes
-  , testCase          "counting primes"              numberOfOrderedPrimes
-  , testSmallAndQuick "signumAbsProperty"            signumAbsProperty
-  , testSmallAndQuick "absProperty"                  absProperty
+  , testSmallAndQuick "findPrime'"               findPrimeProperty1
+  , testSmallAndQuick "isPrime"                  isPrimeProperty
+  , testCase          "primes matches reference" primesSpecialCase1
+  , testSmallAndQuick "primes"                   primesGeneratesPrimesProperty
+  , testCase          "primes are ordered"       orderingPrimes
+  , testCase          "counting primes"          numberOfPrimes
+  , testSmallAndQuick "signumAbsProperty"        signumAbsProperty
+  , testSmallAndQuick "absProperty"              absProperty
   , testGroup "gcdG"
     [ testSmallAndQuick "is divisor"            gcdGProperty1
     , testSmallAndQuick "is greatest"           gcdGProperty2


### PR DESCRIPTION
Resolves #122. 

Added `orderedPrimes` for ordered Gaussian primes. `primes` may still be faster since `Data.List.partition` does not appear to fuse as a producer, even though it does fuse as a consumer and thus `primes` is retained also. That said, it may be hard to do a side-by-side comparison of the two as they have different use cases.

I've also changed the documentation for `primes`: It does not produce all the Gaussian primes (for instance -1-i is never produced), but it does produce them all up to associates.