### PR TITLE
Faster primitive root

### DIFF
--- a/Math/NumberTheory/Moduli/PrimitiveRoot.hs
+++ b/Math/NumberTheory/Moduli/PrimitiveRoot.hs
@@ -91,7 +91,7 @@ isPrimePower n = (, intToWord k) <$> isPrime m
 -- >>> cyclicGroupToModulo CG4
 -- Prefactored {prefValue = 4, prefFactors = Coprimes {unCoprimes = fromList [(2,2)]}}
 --
--- >>> :set -XGADTs
+-- >>> :set -XTypeFamilies
 -- >>> cyclicGroupToModulo (CGDoubleOddPrimePower (PrimeNat 13) 3)
 -- Prefactored {prefValue = 4394, prefFactors = Coprimes {unCoprimes = fromList [(2,1),(13,3)]}}
 cyclicGroupToModulo

--- a/Math/NumberTheory/Moduli/PrimitiveRoot.hs
+++ b/Math/NumberTheory/Moduli/PrimitiveRoot.hs
@@ -10,6 +10,7 @@
 --
 
 {-# LANGUAGE CPP                  #-}
+{-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE StandaloneDeriving   #-}
@@ -38,6 +39,8 @@ import Math.NumberTheory.Prefactored
 import Math.NumberTheory.UniqueFactorisation
 import Math.NumberTheory.Utils.FromIntegral
 
+import GHC.Generics
+
 -- | A multiplicative group of residues is called cyclic,
 -- if there is a primitive root @g@,
 -- whose powers generates all elements.
@@ -51,7 +54,9 @@ data CyclicGroup a
   | CGDoubleOddPrimePower (Prime a) Word
   -- ^ Residues modulo 2@p@^@k@ for __odd__ prime @p@.
 
-deriving instance Show (Prime a) => Show (CyclicGroup a)
+deriving instance Eq      (Prime a) => Eq      (CyclicGroup a)
+deriving instance Show    (Prime a) => Show    (CyclicGroup a)
+deriving instance Generic (Prime a) => Generic (CyclicGroup a)
 
 -- | Check whether a multiplicative group of residues,
 -- characterized by its modulo, is cyclic and, if yes, return its form.

--- a/Math/NumberTheory/Moduli/PrimitiveRoot.hs
+++ b/Math/NumberTheory/Moduli/PrimitiveRoot.hs
@@ -13,7 +13,6 @@
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TupleSections        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -115,7 +114,7 @@ cyclicGroupToModulo = fromFactors . \case
 -- >>> isPrimitiveRoot' cg 2
 -- True
 isPrimitiveRoot'
-  :: forall a. (Integral a, UniqueFactorisation a)
+  :: (Integral a, UniqueFactorisation a)
   => CyclicGroup a
   -> a
   -> Bool

--- a/Math/NumberTheory/Moduli/PrimitiveRoot.hs
+++ b/Math/NumberTheory/Moduli/PrimitiveRoot.hs
@@ -133,7 +133,6 @@ isPrimitiveRoot' cg r =
     oddPrimePowerTest p 1 g       = oddPrimeTest p (g `mod` p)
     oddPrimePowerTest p _ g       = oddPrimeTest p (g `mod` p) && powMod g (p-1) (p*p) /= 1
     doubleOddPrimePowerTest p k g = odd g && oddPrimePowerTest p k g
-    -- really should be testing odd (g `mod` 2p^k)
 
 -- | Check whether a given modular residue is
 -- a <https://en.wikipedia.org/wiki/Primitive_root_modulo_n primitive root>.

--- a/Math/NumberTheory/Primes/Types.hs
+++ b/Math/NumberTheory/Primes/Types.hs
@@ -10,8 +10,9 @@
 -- Should not be exposed to users.
 --
 
-{-# LANGUAGE CPP          #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP           #-}
+{-# LANGUAGE TypeFamilies  #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 module Math.NumberTheory.Primes.Types
   ( Prime
@@ -20,9 +21,10 @@ module Math.NumberTheory.Primes.Types
   ) where
 
 import Numeric.Natural
+import GHC.Generics
 
 newtype Prm = Prm { unPrm :: Word }
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Generic)
 
 instance Show Prm where
   showsPrec d (Prm p) r = (if d > 10 then "(" ++ s ++ ")" else s) ++ r
@@ -30,7 +32,7 @@ instance Show Prm where
       s = "Prm " ++ show p
 
 newtype PrimeNat = PrimeNat { unPrimeNat :: Natural }
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Generic)
 
 instance Show PrimeNat where
   showsPrec d (PrimeNat p) r = (if d > 10 then "(" ++ s ++ ")" else s) ++ r

--- a/Math/NumberTheory/Primes/Types.hs
+++ b/Math/NumberTheory/Primes/Types.hs
@@ -22,9 +22,12 @@ module Math.NumberTheory.Primes.Types
 
 import Numeric.Natural
 import GHC.Generics
+import Control.DeepSeq
 
 newtype Prm = Prm { unPrm :: Word }
   deriving (Eq, Ord, Generic)
+
+instance NFData Prm
 
 instance Show Prm where
   showsPrec d (Prm p) r = (if d > 10 then "(" ++ s ++ ")" else s) ++ r
@@ -33,6 +36,8 @@ instance Show Prm where
 
 newtype PrimeNat = PrimeNat { unPrimeNat :: Natural }
   deriving (Eq, Ord, Generic)
+
+instance NFData PrimeNat
 
 instance Show PrimeNat where
   showsPrec d (PrimeNat p) r = (if d > 10 then "(" ++ s ++ ")" else s) ++ r

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -189,6 +189,7 @@ benchmark criterion
     Math.NumberTheory.MertensBench
     Math.NumberTheory.PowersBench
     Math.NumberTheory.PrimesBench
+    Math.NumberTheory.PrimitiveRootsBench
     Math.NumberTheory.RecurrenciesBench
     Math.NumberTheory.SieveBlockBench
     Math.NumberTheory.SmoothNumbersBench

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -38,6 +38,7 @@ library
     base >=4.7 && <5,
     array >=0.5 && <0.6,
     containers >=0.5 && <0.7,
+    deepseq,
     exact-pi >=0.4.1.1,
     ghc-prim <0.6,
     integer-gmp <1.1,

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -9,10 +9,12 @@ import Math.NumberTheory.JacobiBench as Jacobi
 import Math.NumberTheory.MertensBench as Mertens
 import Math.NumberTheory.PowersBench as Powers
 import Math.NumberTheory.PrimesBench as Primes
+import Math.NumberTheory.PrimitiveRootsBench as PrimitiveRoots
 import Math.NumberTheory.RecurrenciesBench as Recurrencies
 import Math.NumberTheory.SieveBlockBench as SieveBlock
 import Math.NumberTheory.SmoothNumbersBench as SmoothNumbers
 
+main :: IO ()
 main = defaultMain
   [ ArithmeticFunctions.benchSuite
   , Gaussian.benchSuite
@@ -21,6 +23,7 @@ main = defaultMain
   , Mertens.benchSuite
   , Powers.benchSuite
   , Primes.benchSuite
+  , PrimitiveRoots.benchSuite
   , Recurrencies.benchSuite
   , SieveBlock.benchSuite
   , SmoothNumbers.benchSuite

--- a/benchmark/Math/NumberTheory/PrimitiveRootsBench.hs
+++ b/benchmark/Math/NumberTheory/PrimitiveRootsBench.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns #-}
+
+module Math.NumberTheory.PrimitiveRootsBench
+  ( benchSuite
+  ) where
+
+import Gauge.Main
+import Data.Maybe
+
+import Math.NumberTheory.Moduli.PrimitiveRoot
+import Math.NumberTheory.UniqueFactorisation
+
+primRootWrap :: Integer -> Word -> Integer -> Bool
+primRootWrap p k g = isPrimitiveRoot' (CGOddPrimePower p' k) g
+  where p' = fromJust $ isPrime p
+
+primRootWrap2 :: Integer -> Word -> Integer -> Bool
+primRootWrap2 p k g = isPrimitiveRoot' (CGDoubleOddPrimePower p' k) g
+  where p' = fromJust $ isPrime p
+
+-- contrived function which forces the cyclic group to be fully calculated 
+forceCyclic :: Maybe (CyclicGroup a) -> Int
+forceCyclic Nothing    = 0
+forceCyclic (Just CG2) = -2
+forceCyclic (Just CG4) = -1
+forceCyclic (Just (CGOddPrimePower !_p !_k)) = 1
+forceCyclic (Just (CGDoubleOddPrimePower !_p !_k)) = 2
+
+cyclicWrap :: Integer -> Int
+cyclicWrap = forceCyclic . cyclicGroupFromModulo
+
+benchSuite :: Benchmark
+benchSuite = bgroup "PrimRoot"
+  [ bgroup "groupFromModulo" 
+    [ bench "3^20000"             $ nf cyclicWrap $! (3^20000)             -- prime to large power
+    , bench "10000000000000061"   $ nf cyclicWrap $! (10^16 + 61)          -- large prime
+    , bench "2*3^20000"           $ nf cyclicWrap $! (2*3^20000)           -- twice prime to large power
+    , bench "10000000000000046"   $ nf cyclicWrap $! (10^16 + 46)          -- twice large prime
+    , bench "224403121196654400"  $ nf cyclicWrap $! (224403121196654400)  -- highly composite
+    ]
+  , bgroup "check prim roots"
+    [ bench "3^20000"             $ nf (primRootWrap  3              20000) 2 -- prime to large power
+    , bench "10000000000000061"   $ nf (primRootWrap  (10^16 + 61)   1)     3 -- large prime
+    , bench "10000000000000061^2" $ nf (primRootWrap  (10^16 + 61)   2)     3 -- large prime squared
+    , bench "2*3^20000"           $ nf (primRootWrap2 3              20000) 5 -- twice prime to large power
+    , bench "10000000000000046"   $ nf (primRootWrap2 (5*10^15 + 23) 1)     5 -- twice large prime
+    ]
+  ]

--- a/benchmark/Math/NumberTheory/PrimitiveRootsBench.hs
+++ b/benchmark/Math/NumberTheory/PrimitiveRootsBench.hs
@@ -12,9 +12,7 @@ import Control.DeepSeq
 
 import Math.NumberTheory.Moduli.PrimitiveRoot
 import Math.NumberTheory.UniqueFactorisation
-import Math.NumberTheory.Primes.Types
 
-instance NFData PrimeNat
 instance NFData (CyclicGroup Integer)
 
 primRootWrap :: Integer -> Word -> Integer -> Bool

--- a/benchmark/Math/NumberTheory/PrimitiveRootsBench.hs
+++ b/benchmark/Math/NumberTheory/PrimitiveRootsBench.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans       #-}
 
 module Math.NumberTheory.PrimitiveRootsBench
   ( benchSuite
@@ -7,9 +8,14 @@ module Math.NumberTheory.PrimitiveRootsBench
 
 import Gauge.Main
 import Data.Maybe
+import Control.DeepSeq
 
 import Math.NumberTheory.Moduli.PrimitiveRoot
 import Math.NumberTheory.UniqueFactorisation
+import Math.NumberTheory.Primes.Types
+
+instance NFData PrimeNat
+instance NFData (CyclicGroup Integer)
 
 primRootWrap :: Integer -> Word -> Integer -> Bool
 primRootWrap p k g = isPrimitiveRoot' (CGOddPrimePower p' k) g
@@ -19,16 +25,8 @@ primRootWrap2 :: Integer -> Word -> Integer -> Bool
 primRootWrap2 p k g = isPrimitiveRoot' (CGDoubleOddPrimePower p' k) g
   where p' = fromJust $ isPrime p
 
--- contrived function which forces the cyclic group to be fully calculated 
-forceCyclic :: Maybe (CyclicGroup a) -> Int
-forceCyclic Nothing    = 0
-forceCyclic (Just CG2) = -2
-forceCyclic (Just CG4) = -1
-forceCyclic (Just (CGOddPrimePower !_p !_k)) = 1
-forceCyclic (Just (CGDoubleOddPrimePower !_p !_k)) = 2
-
-cyclicWrap :: Integer -> Int
-cyclicWrap = forceCyclic . cyclicGroupFromModulo
+cyclicWrap :: Integer -> Maybe (CyclicGroup Integer)
+cyclicWrap = cyclicGroupFromModulo
 
 benchSuite :: Benchmark
 benchSuite = bgroup "PrimRoot"

--- a/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
@@ -101,8 +101,8 @@ testSuite = testGroup "Primitive root"
     [ testGroup "primitive root is coprime with modulo"
       [ testSmallAndQuick "Integer" (isPrimitiveRoot'Property1 :: AnySign Integer -> CyclicGroup Integer -> Bool)
       , testSmallAndQuick "Natural" (isPrimitiveRoot'Property1 :: AnySign Natural -> CyclicGroup Natural -> Bool)
-      , testSmallAndQuick "Int"     (isPrimitiveRoot'Property1 :: AnySign Int     -> CyclicGroup Int     -> Bool)
-      , testSmallAndQuick "Word"    (isPrimitiveRoot'Property1 :: AnySign Word    -> CyclicGroup Word    -> Bool)
+      , testSmallAndQuick "Int"     (isPrimitiveRoot'Property1 :: AnySign Int     -> CyclicGroup Int     -> Bool) -- dubious test
+      , testSmallAndQuick "Word"    (isPrimitiveRoot'Property1 :: AnySign Word    -> CyclicGroup Word    -> Bool) -- dubious test
       ]
     ]
   , testGroup "isPrimitiveRoot"

--- a/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
@@ -20,7 +20,7 @@ module Math.NumberTheory.Moduli.PrimitiveRootTests
 import Test.Tasty
 
 import qualified Data.Set as S
-import Data.List (genericTake)
+import Data.List (genericTake, genericLength)
 import Data.Maybe
 import Control.Arrow (first)
 import Numeric.Natural
@@ -95,6 +95,13 @@ isPrimitiveRootProperty4 (AnySign n) (Positive m)
     SomeMod n' -> not (isPrimitiveRoot n')
     InfMod{}   -> False
 
+isPrimitiveRootProperty5 :: Positive Natural -> Bool
+isPrimitiveRootProperty5 (Positive m)
+  = isNothing (cyclicGroupFromModulo m)
+  || case 0 `modulo` m of
+       SomeMod (_ :: Mod t) -> genericLength (filter isPrimitiveRoot [(minBound :: Mod t) .. maxBound]) == totient (totient m)
+       InfMod{}             -> False
+
 testSuite :: TestTree
 testSuite = testGroup "Primitive root"
   [ testGroup "CyclicGroup"
@@ -111,9 +118,10 @@ testSuite = testGroup "Primitive root"
       ]
     ]
   , testGroup "isPrimitiveRoot"
-    [ testSmallAndQuick "primitive root is coprime with modulo" isPrimitiveRootProperty1
-    , testSmallAndQuick "cyclic group has a primitive root"     isPrimitiveRootProperty2
-    , testSmallAndQuick "primitive root generates cyclic group" isPrimitiveRootProperty3
-    , testSmallAndQuick "no primitive root in non-cyclic group" isPrimitiveRootProperty4
+    [ testSmallAndQuick "primitive root is coprime with modulo"            isPrimitiveRootProperty1
+    , testSmallAndQuick "cyclic group has a primitive root"                isPrimitiveRootProperty2
+    , testSmallAndQuick "primitive root generates cyclic group"            isPrimitiveRootProperty3
+    , testSmallAndQuick "no primitive root in non-cyclic group"            isPrimitiveRootProperty4
+    , testSmallAndQuick "cyclic group has right number of primitive roots" isPrimitiveRootProperty5
     ]
   ]

--- a/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
@@ -21,12 +21,14 @@ import Test.Tasty
 
 import qualified Data.Set as S
 import Data.List (genericTake, genericLength)
-import Data.Maybe
+import Data.Maybe (isJust, isNothing)
 import Control.Arrow (first)
 import Numeric.Natural
+import Data.Proxy
+import GHC.TypeNats.Compat
 
-import Math.NumberTheory.ArithmeticFunctions (totient)
 import qualified Math.NumberTheory.GCD as GCD
+import Math.NumberTheory.ArithmeticFunctions (totient)
 import Math.NumberTheory.Moduli.Class (Mod, SomeMod(..), modulo)
 import Math.NumberTheory.Moduli.PrimitiveRoot
 import Math.NumberTheory.Prefactored (fromFactors, prefFactors, prefValue, Prefactored)
@@ -77,9 +79,8 @@ isPrimitiveRootProperty1 (AnySign n) (Positive m)
 isPrimitiveRootProperty2 :: Positive Natural -> Bool
 isPrimitiveRootProperty2 (Positive m)
   = isNothing (cyclicGroupFromModulo m)
-  || case 0 `modulo` m of
-    SomeMod (_ :: Mod t) -> any isPrimitiveRoot [(minBound :: Mod t) .. maxBound]
-    InfMod{}             -> False
+  || case someNatVal m of
+    SomeNat (_ :: Proxy t) -> any isPrimitiveRoot [(minBound :: Mod t) .. maxBound]
 
 isPrimitiveRootProperty3 :: AnySign Integer -> Positive Natural -> Bool
 isPrimitiveRootProperty3 (AnySign n) (Positive m)
@@ -98,9 +99,8 @@ isPrimitiveRootProperty4 (AnySign n) (Positive m)
 isPrimitiveRootProperty5 :: Positive Natural -> Bool
 isPrimitiveRootProperty5 (Positive m)
   = isNothing (cyclicGroupFromModulo m)
-  || case 0 `modulo` m of
-       SomeMod (_ :: Mod t) -> genericLength (filter isPrimitiveRoot [(minBound :: Mod t) .. maxBound]) == totient (totient m)
-       InfMod{}             -> False
+  || case someNatVal m of
+       SomeNat (_ :: Proxy t) -> genericLength (filter isPrimitiveRoot [(minBound :: Mod t) .. maxBound]) == totient (totient m)
 
 testSuite :: TestTree
 testSuite = testGroup "Primitive root"
@@ -113,8 +113,8 @@ testSuite = testGroup "Primitive root"
     [ testGroup "primitive root is coprime with modulo"
       [ testSmallAndQuick "Integer" (isPrimitiveRoot'Property1 :: AnySign Integer -> CyclicGroup Integer -> Bool)
       , testSmallAndQuick "Natural" (isPrimitiveRoot'Property1 :: AnySign Natural -> CyclicGroup Natural -> Bool)
-      , testSmallAndQuick "Int"     (isPrimitiveRoot'Property1 :: AnySign Int     -> CyclicGroup Int     -> Bool) -- dubious test
-      , testSmallAndQuick "Word"    (isPrimitiveRoot'Property1 :: AnySign Word    -> CyclicGroup Word    -> Bool) -- dubious test
+      , testSmallAndQuick "Int"     (isPrimitiveRoot'Property1 :: AnySign Int     -> CyclicGroup Int     -> Bool)
+      , testSmallAndQuick "Word"    (isPrimitiveRoot'Property1 :: AnySign Word    -> CyclicGroup Word    -> Bool)
       ]
     ]
   , testGroup "isPrimitiveRoot"

--- a/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
@@ -22,12 +22,14 @@ import Test.Tasty
 import qualified Data.Set as S
 import Data.List (genericTake)
 import Data.Maybe
+import Control.Arrow (first)
 import Numeric.Natural
 
 import Math.NumberTheory.ArithmeticFunctions (totient)
+import qualified Math.NumberTheory.GCD as GCD
 import Math.NumberTheory.Moduli.Class (Mod, SomeMod(..), modulo)
 import Math.NumberTheory.Moduli.PrimitiveRoot
-import Math.NumberTheory.Prefactored (prefValue)
+import Math.NumberTheory.Prefactored (fromFactors, prefFactors, prefValue, Prefactored)
 import Math.NumberTheory.TestUtils
 import Math.NumberTheory.UniqueFactorisation
 
@@ -59,8 +61,11 @@ isPrimitiveRoot'Property1
   :: (Eq a, Integral a, UniqueFactorisation a)
   => AnySign a -> CyclicGroup a -> Bool
 isPrimitiveRoot'Property1 (AnySign n) cg
-  = gcd n (prefValue (cyclicGroupToModulo cg)) == 1
+  = gcd (toInteger n) (prefValue (castPrefactored (cyclicGroupToModulo cg))) == 1
   || not (isPrimitiveRoot' cg n)
+
+castPrefactored :: Integral a => Prefactored a -> Prefactored Integer
+castPrefactored = fromFactors . GCD.splitIntoCoprimes . map (first toInteger) . GCD.toList . prefFactors
 
 isPrimitiveRootProperty1 :: AnySign Integer -> Positive Natural -> Bool
 isPrimitiveRootProperty1 (AnySign n) (Positive m)


### PR DESCRIPTION
(As mentioned in #119)

Unfinished so far, but coprimality tests for Int and Word fail seemingly due to overflow: Is it okay to just remove these tests?  I think the logic in the new `isPrimitiveRoot'` is correct, but sanity checks would be appreciated also; the idea is that to check if g is a primitive root mod p^2 it suffices to check that g is a primitive root mod p and that g^(p-1) mod p^2 is not 1. In addition, these same conditions are exactly the conditions for g to be a primitive root mod p^k for any k. I've kept the method for testing primitive roots mod p as wikipedia describes.  Similarly to check primitive roots mod 2p^k it suffices to check g is a primitive root mod p^k and that g mod 2p^k is odd, so just that g is odd.

I'd also like to add a test counting the number of primitive roots and possibly laziness tests. Are there any other appropriate tests?