### PR TITLE
Euclidean Domains

### DIFF
--- a/Math/NumberTheory/EisensteinIntegers.hs
+++ b/Math/NumberTheory/EisensteinIntegers.hs
@@ -23,7 +23,6 @@ module Math.NumberTheory.EisensteinIntegers
   , ids
 
   , divideByThree
-  , gcdE
 
   -- * Primality functions
   , factorise
@@ -37,7 +36,7 @@ import Data.Maybe                                      (fromMaybe)
 import Data.Ord                                        (comparing)
 import GHC.Generics                                    (Generic)
 
-import qualified Math.NumberTheory.Euclidean      as ED
+import qualified Math.NumberTheory.Euclidean            as ED
 import qualified Math.NumberTheory.Moduli               as Moduli
 import Math.NumberTheory.Moduli.Sqrt                    (FieldCharacteristic(..))
 import qualified Math.NumberTheory.Primes.Factorisation as Factorisation
@@ -163,18 +162,6 @@ divideByThree = go 0
         (q1, r1) = divMod (a + a - b) 3
         (q2, r2) = divMod (a + b) 3
 
--- | Compute the GCD of two Eisenstein integers. The result is always
--- in the first sextant.
-gcdE :: EisensteinInteger -> EisensteinInteger -> EisensteinInteger
-gcdE g h = gcdE' (abs g) (abs h)
-
-gcdE' :: EisensteinInteger -> EisensteinInteger -> EisensteinInteger
-gcdE' g h
-    | h == 0    = g -- done recursing
-    | otherwise = gcdE' h (abs (g `mod'` h))
-  where
-    mod' = ED.mod :: EisensteinInteger -> EisensteinInteger -> EisensteinInteger
-
 -- | Find an Eisenstein integer whose norm is the given prime number
 -- in the form @3k + 1@ using a modification of the
 -- <http://www.ams.org/journals/mcom/1972-26-120/S0025-5718-1972-0314745-6/S0025-5718-1972-0314745-6.pdf Hermite-Serret algorithm>.
@@ -196,7 +183,7 @@ gcdE' g h
 findPrime :: Integer -> EisensteinInteger
 findPrime p = case Moduli.sqrtModMaybe (9*k*k - 1) (FieldCharacteristic (PrimeNat . integerToNatural $ p) 1) of
     Nothing      -> error "findPrime: argument must be prime p = 6k + 1"
-    Just sqrtMod -> gcdE (p :+ 0) ((sqrtMod - 3 * k) :+ 1)
+    Just sqrtMod -> ED.gcd (p :+ 0) ((sqrtMod - 3 * k) :+ 1)
     where
         k :: Integer
         k = p `div` 6

--- a/Math/NumberTheory/EisensteinIntegers.hs
+++ b/Math/NumberTheory/EisensteinIntegers.hs
@@ -22,14 +22,6 @@ module Math.NumberTheory.EisensteinIntegers
   , associates
   , ids
 
-  -- * Division and remainder functions
-  , divE
-  , divModE
-  , modE
-  , quotRemE
-  , quotE
-  , remE
-
   , divideByThree
   , gcdE
 
@@ -45,6 +37,7 @@ import Data.Maybe                                      (fromMaybe)
 import Data.Ord                                        (comparing)
 import GHC.Generics                                    (Generic)
 
+import qualified Math.NumberTheory.EuclideanDomain      as ED
 import qualified Math.NumberTheory.Moduli               as Moduli
 import Math.NumberTheory.Moduli.Sqrt                    (FieldCharacteristic(..))
 import qualified Math.NumberTheory.Primes.Factorisation as Factorisation
@@ -111,41 +104,11 @@ associates e = map (e *) ids
 -- * Does *not* check for this precondition.
 -- * @head@ will fail when supplied a number unsatisfying it.
 primary :: EisensteinInteger -> EisensteinInteger
-primary = head . filter (\p -> p `modE` 3 == 2) . associates
+primary = head . filter (\p -> p `ED.mod` 3 == 2) . associates
 
--- | Simultaneous 'quot' and 'rem'.
-quotRemE
-    :: EisensteinInteger
-    -> EisensteinInteger
-    -> (EisensteinInteger, EisensteinInteger)
-quotRemE = divHelper quot
-
--- | Eisenstein integer division, truncating toward zero.
-quotE :: EisensteinInteger -> EisensteinInteger -> EisensteinInteger
-n `quotE` d = q where (q,_) = quotRemE n d
-
--- | Eisenstein integer remainder, satisfying
---
--- > (x `quotE` y)*y + (x `remE` y) == x
-remE :: EisensteinInteger -> EisensteinInteger -> EisensteinInteger
-n `remE`  d = r where (_,r) = quotRemE n d
-
--- | Simultaneous 'div' and 'mod' of Eisenstein integers.
-divModE
-    :: EisensteinInteger
-    -> EisensteinInteger
-    -> (EisensteinInteger, EisensteinInteger)
-divModE = divHelper div
-
--- | Eisenstein integer division, truncating toward negative infinity.
-divE :: EisensteinInteger -> EisensteinInteger -> EisensteinInteger
-n `divE` d = q where (q,_) = divModE n d
-
--- | Eisenstein integer remainder, satisfying
---
--- > (x `divE` y)*y + (x `modE` y) == x
-modE :: EisensteinInteger -> EisensteinInteger -> EisensteinInteger
-n `modE` d = r where (_,r) = divModE n d
+instance ED.EuclideanDomain EisensteinInteger where
+  quotRem = divHelper quot
+  divMod  = divHelper div
 
 -- | Function that does most of the underlying work for @divMod@ and
 -- @quotRem@, apart from choosing the specific integer division algorithm.
@@ -208,7 +171,7 @@ gcdE g h = gcdE' (abs g) (abs h)
 gcdE' :: EisensteinInteger -> EisensteinInteger -> EisensteinInteger
 gcdE' g h
     | h == 0    = g -- done recursing
-    | otherwise = gcdE' h (abs (g `modE` h)) 
+    | otherwise = gcdE' h (abs (g `ED.mod` h)) 
 
 -- | Find an Eisenstein integer whose norm is the given prime number
 -- in the form @3k + 1@ using a modification of the

--- a/Math/NumberTheory/EisensteinIntegers.hs
+++ b/Math/NumberTheory/EisensteinIntegers.hs
@@ -37,7 +37,7 @@ import Data.Maybe                                      (fromMaybe)
 import Data.Ord                                        (comparing)
 import GHC.Generics                                    (Generic)
 
-import qualified Math.NumberTheory.EuclideanDomain      as ED
+import qualified Math.NumberTheory.Euclidean      as ED
 import qualified Math.NumberTheory.Moduli               as Moduli
 import Math.NumberTheory.Moduli.Sqrt                    (FieldCharacteristic(..))
 import qualified Math.NumberTheory.Primes.Factorisation as Factorisation
@@ -106,7 +106,7 @@ associates e = map (e *) ids
 primary :: EisensteinInteger -> EisensteinInteger
 primary = head . filter (\p -> p `ED.mod` 3 == 2) . associates
 
-instance ED.EuclideanDomain EisensteinInteger where
+instance ED.Euclidean EisensteinInteger where
   quotRem = divHelper quot
   divMod  = divHelper div
 

--- a/Math/NumberTheory/EisensteinIntegers.hs
+++ b/Math/NumberTheory/EisensteinIntegers.hs
@@ -171,7 +171,9 @@ gcdE g h = gcdE' (abs g) (abs h)
 gcdE' :: EisensteinInteger -> EisensteinInteger -> EisensteinInteger
 gcdE' g h
     | h == 0    = g -- done recursing
-    | otherwise = gcdE' h (abs (g `ED.mod` h)) 
+    | otherwise = gcdE' h (abs (g `mod'` h))
+  where
+    mod' = ED.mod :: EisensteinInteger -> EisensteinInteger -> EisensteinInteger
 
 -- | Find an Eisenstein integer whose norm is the given prime number
 -- in the form @3k + 1@ using a modification of the

--- a/Math/NumberTheory/Euclidean.hs
+++ b/Math/NumberTheory/Euclidean.hs
@@ -9,6 +9,10 @@
 -- This module exports a class to represent Euclidean domains.
 --
 
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE MonoLocalBinds       #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Math.NumberTheory.Euclidean
   ( Euclidean (..)
   , div
@@ -18,6 +22,7 @@ module Math.NumberTheory.Euclidean
   ) where
 
 import Prelude hiding (divMod, div, mod, quotRem, quot, rem)
+import qualified Prelude as P
 
 -- | A class to represent a Euclidean domain.
 class Euclidean a where
@@ -46,3 +51,7 @@ div x y = fst (divMod x y)
 -- > (x `div` y) * y + (x `mod` y) == x
 mod :: Euclidean a => a -> a -> a
 mod x y = snd (divMod x y)
+
+instance Integral a => Euclidean a where
+  quotRem = P.quotRem
+  divMod  = P.divMod

--- a/Math/NumberTheory/Euclidean.hs
+++ b/Math/NumberTheory/Euclidean.hs
@@ -52,6 +52,6 @@ div x y = fst (divMod x y)
 mod :: Euclidean a => a -> a -> a
 mod x y = snd (divMod x y)
 
-instance Integral a => Euclidean a where
+instance {-# OVERLAPPABLE #-} Integral a => Euclidean a where
   quotRem = P.quotRem
   divMod  = P.divMod

--- a/Math/NumberTheory/Euclidean.hs
+++ b/Math/NumberTheory/Euclidean.hs
@@ -16,12 +16,13 @@
 module Math.NumberTheory.Euclidean
   ( Euclidean (..)
   , div
+  , gcd
   , mod
   , quot
   , rem
   ) where
 
-import Prelude hiding (divMod, div, mod, quotRem, quot, rem)
+import Prelude hiding (divMod, div, gcd, mod, quotRem, quot, rem)
 import qualified Prelude as P
 
 -- | A class to represent a Euclidean domain.
@@ -55,3 +56,12 @@ mod x y = snd (divMod x y)
 instance {-# OVERLAPPABLE #-} Integral a => Euclidean a where
   quotRem = P.quotRem
   divMod  = P.divMod
+
+-- | Taken from @prelude.gcd@.
+gcd :: (Eq a, Euclidean a, Num a) => a -> a -> a
+{-# NOINLINE [1] gcd #-}
+gcd x y =  gcd' (abs x) (abs y)
+  where
+    gcd' :: (Eq a, Euclidean a, Num a) => a -> a -> a
+    gcd' a 0  =  a
+    gcd' a b  =  gcd' b (abs (a `mod` b))

--- a/Math/NumberTheory/Euclidean.hs
+++ b/Math/NumberTheory/Euclidean.hs
@@ -1,5 +1,5 @@
 -- |
--- Module:      Math.NumberTheory.EuclideanDomain
+-- Module:      Math.NumberTheory.Euclidean
 -- Copyright:   (c) 2018 Alexandre Rodrigues Baldé
 -- Licence:     MIT
 -- Maintainer:  Alexandre Rodrigues Baldé <alexandrer_b@outlook.com>
@@ -9,8 +9,8 @@
 -- This module exports a class to represent Euclidean domains.
 --
 
-module Math.NumberTheory.EuclideanDomain
-  ( EuclideanDomain (..)
+module Math.NumberTheory.Euclidean
+  ( Euclidean (..)
   , div
   , mod
   , quot
@@ -20,7 +20,7 @@ module Math.NumberTheory.EuclideanDomain
 import Prelude hiding (divMod, div, mod, quotRem, quot, rem)
 
 -- | A class to represent a Euclidean domain.
-class EuclideanDomain a where
+class Euclidean a where
   -- | When restriced to a subring of the Euclidean domain @a@ isomorphic to
   -- @Integer@, this function should match @quotRem@ for Integers.
   quotRem :: a -> a -> (a, a)
@@ -28,21 +28,21 @@ class EuclideanDomain a where
   -- @Integer@, this function should match @divMod@ for Integers.
   divMod  :: a -> a -> (a, a)
 
-quot :: EuclideanDomain a => a -> a -> a
+quot :: Euclidean a => a -> a -> a
 quot x y = fst (quotRem x y)
 
 -- | Remainder of Euclidean division, satisfying
 --
 -- > (x `quot` y)*y + (x `rem` y) == x
 -- for @x, y@ in a Euclidean domain @a@.
-rem :: EuclideanDomain a => a -> a -> a
+rem :: Euclidean a => a -> a -> a
 rem x y = snd (quotRem x y)
 
-div :: EuclideanDomain a => a -> a -> a
+div :: Euclidean a => a -> a -> a
 div x y = fst (divMod x y)
 
 -- | Remainder of Euclidean division, satisfying
 --
 -- > (x `div` y) * y + (x `mod` y) == x
-mod :: EuclideanDomain a => a -> a -> a
+mod :: Euclidean a => a -> a -> a
 mod x y = snd (divMod x y)

--- a/Math/NumberTheory/EuclideanDomain.hs
+++ b/Math/NumberTheory/EuclideanDomain.hs
@@ -19,8 +19,13 @@ module Math.NumberTheory.EuclideanDomain
 
 import Prelude hiding (divMod, div, mod, quotRem, quot, rem)
 
+-- | A class to represent a Euclidean domain.
 class EuclideanDomain a where
+  -- | When restriced to a subring of the Euclidean domain @a@ isomorphic to
+  -- @Integer@, this function should match @quotRem@ for Integers.
   quotRem :: a -> a -> (a, a)
+  -- | When restriced to a subring of the Euclidean domain @a@ isomorphic to
+  -- @Integer@, this function should match @divMod@ for Integers.
   divMod  :: a -> a -> (a, a)
 
 quot :: EuclideanDomain a => a -> a -> a

--- a/Math/NumberTheory/EuclideanDomain.hs
+++ b/Math/NumberTheory/EuclideanDomain.hs
@@ -31,11 +31,18 @@ class EuclideanDomain a where
 quot :: EuclideanDomain a => a -> a -> a
 quot x y = fst (quotRem x y)
 
+-- | Remainder of Euclidean division, satisfying
+--
+-- > (x `quot` y)*y + (x `rem` y) == x
+-- for @x, y@ in a Euclidean domain @a@.
 rem :: EuclideanDomain a => a -> a -> a
 rem x y = snd (quotRem x y)
 
 div :: EuclideanDomain a => a -> a -> a
 div x y = fst (divMod x y)
 
+-- | Remainder of Euclidean division, satisfying
+--
+-- > (x `div` y) * y + (x `mod` y) == x
 mod :: EuclideanDomain a => a -> a -> a
 mod x y = snd (divMod x y)

--- a/Math/NumberTheory/EuclideanDomain.hs
+++ b/Math/NumberTheory/EuclideanDomain.hs
@@ -1,0 +1,36 @@
+-- |
+-- Module:      Math.NumberTheory.EuclideanDomain
+-- Copyright:   (c) 2018 Alexandre Rodrigues Baldé
+-- Licence:     MIT
+-- Maintainer:  Alexandre Rodrigues Baldé <alexandrer_b@outlook.com>
+-- Stability:   Provisional
+-- Portability: Non-portable (GHC extensions)
+--
+-- This module exports a class to represent Euclidean domains.
+--
+
+module Math.NumberTheory.EuclideanDomain
+  ( EuclideanDomain (..)
+  , div
+  , mod
+  , quot
+  , rem
+  ) where
+
+import Prelude hiding (divMod, div, mod, quotRem, quot, rem)
+
+class EuclideanDomain a where
+  quotRem :: a -> a -> (a, a)
+  divMod  :: a -> a -> (a, a)
+
+quot :: EuclideanDomain a => a -> a -> a
+quot x y = fst (quotRem x y)
+
+rem :: EuclideanDomain a => a -> a -> a
+rem x y = snd (quotRem x y)
+
+div :: EuclideanDomain a => a -> a -> a
+div x y = fst (divMod x y)
+
+mod :: EuclideanDomain a => a -> a -> a
+mod x y = snd (divMod x y)

--- a/Math/NumberTheory/GaussianIntegers.hs
+++ b/Math/NumberTheory/GaussianIntegers.hs
@@ -34,7 +34,7 @@ import Data.Maybe (fromMaybe)
 import Data.Ord (comparing)
 import GHC.Generics
 
-import qualified Math.NumberTheory.EuclideanDomain as ED
+import qualified Math.NumberTheory.Euclidean as ED
 import qualified Math.NumberTheory.Moduli as Moduli
 import Math.NumberTheory.Moduli.Sqrt (FieldCharacteristic(..))
 import Math.NumberTheory.Powers (integerSquareRoot)
@@ -85,7 +85,7 @@ absSignum z@(a :+ b)
     | a <  0 && b <= 0 = ((-a) :+ (-b), -1)    -- third quadrant: (-inf, 0) x (-inf, 0]i
     | otherwise        = ((-b) :+   a, -ι)     -- fourth quadrant: [0, inf) x (-inf, 0)i
 
-instance ED.EuclideanDomain GaussianInteger where
+instance ED.Euclidean GaussianInteger where
     quotRem = divHelper quot
     divMod  = divHelper div
 

--- a/Math/NumberTheory/GaussianIntegers.hs
+++ b/Math/NumberTheory/GaussianIntegers.hs
@@ -129,14 +129,11 @@ primes = (1 :+ 1): mergeBy (comparing norm) l r
 -- | Compute the GCD of two Gaussian integers. Result is always
 -- in the first quadrant.
 gcdG :: GaussianInteger -> GaussianInteger -> GaussianInteger
-gcdG g h = gcdG' (abs g) (abs h)
+gcdG = ED.gcd
+{-# DEPRECATED gcdG "Use 'Math.NumberTheory.Euclidean.gcd' instead." #-}
 
 gcdG' :: GaussianInteger -> GaussianInteger -> GaussianInteger
-gcdG' g h
-    | h == 0    = g -- done recursing
-    | otherwise = gcdG' h (abs (g `mod'` h))
-  where
-    mod' = ED.mod :: GaussianInteger -> GaussianInteger -> GaussianInteger
+gcdG' = ED.gcd
 {-# DEPRECATED gcdG' "Use 'gcdG' instead." #-}
 
 -- |Find a Gaussian integer whose norm is the given prime number

--- a/Math/NumberTheory/GaussianIntegers.hs
+++ b/Math/NumberTheory/GaussianIntegers.hs
@@ -18,12 +18,6 @@ module Math.NumberTheory.GaussianIntegers (
     ι,
     conjugate,
     norm,
-    divModG,
-    divG,
-    modG,
-    quotRemG,
-    quotG,
-    remG,
     (.^),
     isPrime,
     primes,
@@ -40,6 +34,7 @@ import Data.Maybe (fromMaybe)
 import Data.Ord (comparing)
 import GHC.Generics
 
+import qualified Math.NumberTheory.EuclideanDomain as ED
 import qualified Math.NumberTheory.Moduli as Moduli
 import Math.NumberTheory.Moduli.Sqrt (FieldCharacteristic(..))
 import Math.NumberTheory.Powers (integerSquareRoot)
@@ -90,35 +85,15 @@ absSignum z@(a :+ b)
     | a <  0 && b <= 0 = ((-a) :+ (-b), -1)    -- third quadrant: (-inf, 0) x (-inf, 0]i
     | otherwise        = ((-b) :+   a, -ι)     -- fourth quadrant: [0, inf) x (-inf, 0)i
 
--- |Simultaneous 'quot' and 'rem'.
-quotRemG :: GaussianInteger -> GaussianInteger -> (GaussianInteger, GaussianInteger)
-quotRemG = divHelper quot
+instance ED.EuclideanDomain GaussianInteger where
+    quotRem = divHelper quot
+    divMod  = divHelper div
 
--- |Gaussian integer division, truncating toward zero.
-quotG :: GaussianInteger -> GaussianInteger -> GaussianInteger
-n `quotG` d = q where (q,_) = quotRemG n d
-
--- |Gaussian integer remainder, satisfying
---
--- > (x `quotG` y)*y + (x `remG` y) == x
-remG :: GaussianInteger -> GaussianInteger -> GaussianInteger
-n `remG`  d = r where (_,r) = quotRemG n d
-
--- |Simultaneous 'div' and 'mod'.
-divModG :: GaussianInteger -> GaussianInteger -> (GaussianInteger, GaussianInteger)
-divModG = divHelper div
-
--- |Gaussian integer division, truncating toward negative infinity.
-divG :: GaussianInteger -> GaussianInteger -> GaussianInteger
-n `divG` d = q where (q,_) = divModG n d
-
--- |Gaussian integer remainder, satisfying
---
--- > (x `divG` y)*y + (x `modG` y) == x
-modG :: GaussianInteger -> GaussianInteger -> GaussianInteger
-n `modG` d = r where (_,r) = divModG n d
-
-divHelper :: (Integer -> Integer -> Integer) -> GaussianInteger -> GaussianInteger -> (GaussianInteger, GaussianInteger)
+divHelper
+    :: (Integer -> Integer -> Integer)
+    -> GaussianInteger
+    -> GaussianInteger
+    -> (GaussianInteger, GaussianInteger)
 divHelper divide g h =
     let nr :+ ni = g * conjugate h
         denom = norm h
@@ -159,7 +134,7 @@ gcdG g h = gcdG' (abs g) (abs h)
 gcdG' :: GaussianInteger -> GaussianInteger -> GaussianInteger
 gcdG' g h
     | h == 0    = g -- done recursing
-    | otherwise = gcdG' h (abs (g `modG` h))
+    | otherwise = gcdG' h (abs (g `ED.mod` h))
 {-# DEPRECATED gcdG' "Use 'gcdG' instead." #-}
 
 -- |Find a Gaussian integer whose norm is the given prime number

--- a/Math/NumberTheory/GaussianIntegers.hs
+++ b/Math/NumberTheory/GaussianIntegers.hs
@@ -134,7 +134,9 @@ gcdG g h = gcdG' (abs g) (abs h)
 gcdG' :: GaussianInteger -> GaussianInteger -> GaussianInteger
 gcdG' g h
     | h == 0    = g -- done recursing
-    | otherwise = gcdG' h (abs (g `ED.mod` h))
+    | otherwise = gcdG' h (abs (g `mod'` h))
+  where
+    mod' = ED.mod :: GaussianInteger -> GaussianInteger -> GaussianInteger
 {-# DEPRECATED gcdG' "Use 'gcdG' instead." #-}
 
 -- |Find a Gaussian integer whose norm is the given prime number

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -59,7 +59,7 @@ library
     Math.NumberTheory.ArithmeticFunctions.Standard
     Math.NumberTheory.Curves.Montgomery
     Math.NumberTheory.EisensteinIntegers
-    Math.NumberTheory.EuclideanDomain
+    Math.NumberTheory.Euclidean
     Math.NumberTheory.GaussianIntegers
     Math.NumberTheory.GCD
     Math.NumberTheory.GCD.LowLevel

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -59,6 +59,7 @@ library
     Math.NumberTheory.ArithmeticFunctions.Standard
     Math.NumberTheory.Curves.Montgomery
     Math.NumberTheory.EisensteinIntegers
+    Math.NumberTheory.EuclideanDomain
     Math.NumberTheory.GaussianIntegers
     Math.NumberTheory.GCD
     Math.NumberTheory.GCD.LowLevel

--- a/test-suite/Math/NumberTheory/EisensteinIntegersTests.hs
+++ b/test-suite/Math/NumberTheory/EisensteinIntegersTests.hs
@@ -14,7 +14,7 @@ module Math.NumberTheory.EisensteinIntegersTests
   ( testSuite
   ) where
 
-import qualified Math.NumberTheory.EuclideanDomain    as ED
+import qualified Math.NumberTheory.Euclidean    as ED
 import qualified Math.NumberTheory.EisensteinIntegers as E
 import Math.NumberTheory.Primes                       (primes)
 import Test.Tasty                                     (TestTree, testGroup)

--- a/test-suite/Math/NumberTheory/EisensteinIntegersTests.hs
+++ b/test-suite/Math/NumberTheory/EisensteinIntegersTests.hs
@@ -77,20 +77,20 @@ gcdEProperty1 z1 z2
   = z1 == 0 && z2 == 0
   || z1 `ED.rem` z == 0 && z2 `ED.rem` z == 0 && z == abs z
   where
-    z = E.gcdE z1 z2
+    z = ED.gcd z1 z2
 
--- | Verify that a common divisor of @z1, z2@ is a always divisor of @gcdE z1 z2@.
+-- | Verify that a common divisor of @z1, z2@ is a always divisor of @gcd z1 z2@.
 gcdEProperty2 :: E.EisensteinInteger -> E.EisensteinInteger -> E.EisensteinInteger -> Bool
 gcdEProperty2 z z1 z2
   = z == 0
-  || (E.gcdE z1' z2') `ED.rem` z == 0
+  || (ED.gcd z1' z2') `ED.rem` z == 0
   where
     z1' = z * z1
     z2' = z * z2
 
 -- | A special case that tests rounding/truncating in GCD.
 gcdESpecialCase1 :: Assertion
-gcdESpecialCase1 = assertEqual "gcdE" 1 $ E.gcdE (12 E.:+ 23) (23 E.:+ 34)
+gcdESpecialCase1 = assertEqual "gcd" 1 $ ED.gcd (12 E.:+ 23) (23 E.:+ 34)
 
 findPrimesProperty1 :: Positive Int -> Bool
 findPrimesProperty1 (Positive index) =

--- a/test-suite/Math/NumberTheory/EisensteinIntegersTests.hs
+++ b/test-suite/Math/NumberTheory/EisensteinIntegersTests.hs
@@ -14,6 +14,7 @@ module Math.NumberTheory.EisensteinIntegersTests
   ( testSuite
   ) where
 
+import qualified Math.NumberTheory.EuclideanDomain    as ED
 import qualified Math.NumberTheory.EisensteinIntegers as E
 import Math.NumberTheory.Primes                       (primes)
 import Test.Tasty                                     (TestTree, testGroup)
@@ -41,40 +42,40 @@ absProperty z = isOrigin || (inFirstSextant && isAssociate)
     inFirstSextant = x' > y' && y' >= 0
     isAssociate = z' `elem` map (\e -> z * (1 E.:+ 1) ^ e) [0 .. 5]
 
--- | Verify that @divE@ and @modE@ are what `divModE` produces.
+-- | Verify that @div@ and @mod@ are what `divMod` produces.
 divModProperty1 :: E.EisensteinInteger -> E.EisensteinInteger -> Bool
 divModProperty1 x y = y == 0 || (q == q' && r == r')
   where
-    (q, r) = E.divModE x y
-    q'     = E.divE x y
-    r'     = E.modE x y
+    (q, r) = ED.divMod x y
+    q'     = ED.div x y
+    r'     = ED.mod x y
 
 -- | Verify that @divModE` produces the right quotient and remainder.
 divModProperty2 :: E.EisensteinInteger -> E.EisensteinInteger -> Bool
-divModProperty2 x y = (y == 0) || (x `E.divE` y) * y + (x `E.modE` y) == x
+divModProperty2 x y = (y == 0) || (x `ED.div` y) * y + (x `ED.mod` y) == x
 
 -- | Verify that @divModE@ produces a remainder smaller than the divisor with
 -- regards to the Euclidean domain's function.
 modProperty1 :: E.EisensteinInteger -> E.EisensteinInteger -> Bool
-modProperty1 x y = (y == 0) || (E.norm $ x `E.modE` y) < (E.norm y)
+modProperty1 x y = (y == 0) || (E.norm $ x `ED.mod` y) < (E.norm y)
 
--- | Verify that @quotE@ and @reE@ are what `quotRemE` produces.
+-- | Verify that @quot@ and @rem@ are what `quotRem` produces.
 quotRemProperty1 :: E.EisensteinInteger -> E.EisensteinInteger -> Bool
 quotRemProperty1 x y = (y == 0) || q == q' && r == r'
   where
-    (q, r) = E.quotRemE x y
-    q'     = E.quotE x y
-    r'     = E.remE x y
+    (q, r) = ED.quotRem x y
+    q'     = ED.quot x y
+    r'     = ED.rem x y
 
 -- | Verify that @quotRemE@ produces the right quotient and remainder.
 quotRemProperty2 :: E.EisensteinInteger -> E.EisensteinInteger -> Bool
-quotRemProperty2 x y = (y == 0) || (x `E.quotE` y) * y + (x `E.remE` y) == x
+quotRemProperty2 x y = (y == 0) || (x `ED.quot` y) * y + (x `ED.rem` y) == x
 
 -- | Verify that @gcd z1 z2@ always divides @z1@ and @z2@.
 gcdEProperty1 :: E.EisensteinInteger -> E.EisensteinInteger -> Bool
 gcdEProperty1 z1 z2
   = z1 == 0 && z2 == 0
-  || z1 `E.remE` z == 0 && z2 `E.remE` z == 0 && z == abs z
+  || z1 `ED.rem` z == 0 && z2 `ED.rem` z == 0 && z == abs z
   where
     z = E.gcdE z1 z2
 
@@ -82,7 +83,7 @@ gcdEProperty1 z1 z2
 gcdEProperty2 :: E.EisensteinInteger -> E.EisensteinInteger -> E.EisensteinInteger -> Bool
 gcdEProperty2 z z1 z2
   = z == 0
-  || (E.gcdE z1' z2') `E.remE` z == 0
+  || (E.gcdE z1' z2') `ED.rem` z == 0
   where
     z1' = z * z1
     z2' = z * z2
@@ -145,7 +146,7 @@ factoriseProperty3 z = z == 0 || all ((> 1) . E.norm . fst) (E.factorise z)
 factoriseProperty4 :: E.EisensteinInteger -> Bool
 factoriseProperty4 z =
     z == 0 ||
-    (all (\e -> e `E.modE` 3 == 2) $
+    (all (\e -> e `ED.mod` 3 == 2) $
      filter (\e -> not $ elem e $ E.associates $ 1 E.:+ (-1)) $
      map fst $ E.factorise z)
 

--- a/test-suite/Math/NumberTheory/GaussianIntegersTests.hs
+++ b/test-suite/Math/NumberTheory/GaussianIntegersTests.hs
@@ -19,6 +19,7 @@ import Data.List (groupBy, sort)
 import Test.Tasty
 import Test.Tasty.HUnit
 
+import qualified Math.NumberTheory.EuclideanDomain as ED
 import Math.NumberTheory.GaussianIntegers
 import Math.NumberTheory.Moduli.Sqrt (sqrtModMaybe, FieldCharacteristic(..))
 import Math.NumberTheory.Powers (integerSquareRoot)
@@ -125,14 +126,14 @@ absProperty z = isOrigin || (inFirstQuadrant && isAssociate)
 gcdGProperty1 :: GaussianInteger -> GaussianInteger -> Bool
 gcdGProperty1 z1 z2
   = z1 == 0 && z2 == 0
-  || z1 `remG` z == 0 && z2 `remG` z == 0 && z == abs z
+  || z1 `ED.rem` z == 0 && z2 `ED.rem` z == 0 && z == abs z
   where
     z = gcdG z1 z2
 
 gcdGProperty2 :: GaussianInteger -> GaussianInteger -> GaussianInteger -> Bool
 gcdGProperty2 z z1 z2
   = z == 0
-  || (gcdG z1' z2') `remG` z == 0
+  || (gcdG z1' z2') `ED.rem` z == 0
   where
     z1' = z * z1
     z2' = z * z2

--- a/test-suite/Math/NumberTheory/GaussianIntegersTests.hs
+++ b/test-suite/Math/NumberTheory/GaussianIntegersTests.hs
@@ -19,7 +19,7 @@ import Data.List (groupBy, sort)
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import qualified Math.NumberTheory.EuclideanDomain as ED
+import qualified Math.NumberTheory.Euclidean as ED
 import Math.NumberTheory.GaussianIntegers
 import Math.NumberTheory.Moduli.Sqrt (sqrtModMaybe, FieldCharacteristic(..))
 import Math.NumberTheory.Powers (integerSquareRoot)

--- a/test-suite/Math/NumberTheory/GaussianIntegersTests.hs
+++ b/test-suite/Math/NumberTheory/GaussianIntegersTests.hs
@@ -128,19 +128,19 @@ gcdGProperty1 z1 z2
   = z1 == 0 && z2 == 0
   || z1 `ED.rem` z == 0 && z2 `ED.rem` z == 0 && z == abs z
   where
-    z = gcdG z1 z2
+    z = ED.gcd z1 z2
 
 gcdGProperty2 :: GaussianInteger -> GaussianInteger -> GaussianInteger -> Bool
 gcdGProperty2 z z1 z2
   = z == 0
-  || (gcdG z1' z2') `ED.rem` z == 0
+  || (ED.gcd z1' z2') `ED.rem` z == 0
   where
     z1' = z * z1
     z2' = z * z2
 
 -- | a special case that tests rounding/truncating in GCD.
 gcdGSpecialCase1 :: Assertion
-gcdGSpecialCase1 = assertEqual "gcdG" 1 $ gcdG (12 :+ 23) (23 :+ 34)
+gcdGSpecialCase1 = assertEqual "gcdG" 1 $ ED.gcd (12 :+ 23) (23 :+ 34)
 
 testSuite :: TestTree
 testSuite = testGroup "GaussianIntegers" $
@@ -162,7 +162,7 @@ testSuite = testGroup "GaussianIntegers" $
   , testCase          "counting primes"          numberOfPrimes
   , testSmallAndQuick "signumAbsProperty"        signumAbsProperty
   , testSmallAndQuick "absProperty"              absProperty
-  , testGroup "gcdG"
+  , testGroup "gcd"
     [ testSmallAndQuick "is divisor"            gcdGProperty1
     , testSmallAndQuick "is greatest"           gcdGProperty2
     , testCase          "(12 :+ 23) (23 :+ 34)" gcdGSpecialCase1


### PR DESCRIPTION
Closes #128. Missing:

- [x] Refactor `EisensteinIntegers` module to use `EuclideanDomain`.

- [x] Refactor `GaussianIntegers` module to use `EuclideanDomain`.

~~- [ ] Replace `Integral` with  `Euclidean` in `Math.NumberTheory.GCD`.~~

~~- [ ] Replace `Integral` with  `Euclidean` in `Math.NumberTheory.Prefactored`.~~

~~- [ ] Replace `Integral` with  `Euclidean` in `Math.NumberTheory.SmoothNumbers`.~~