### PR TITLE
Singleton types for factors and cyclic groups

### DIFF
--- a/Math/NumberTheory/Moduli/Equations.hs
+++ b/Math/NumberTheory/Moduli/Equations.hs
@@ -15,10 +15,12 @@ module Math.NumberTheory.Moduli.Equations
   , solveQuadratic
   ) where
 
+import Data.Constraint
 import GHC.Integer.GMP.Internals
 
 import Math.NumberTheory.Moduli.Chinese
 import Math.NumberTheory.Moduli.Class
+import Math.NumberTheory.Moduli.Singleton
 import Math.NumberTheory.Moduli.Sqrt
 import Math.NumberTheory.Primes
 import Math.NumberTheory.Utils (recipMod)
@@ -56,21 +58,21 @@ solveLinearCoprime m a b = (\a1 -> negate b * a1 `mod` m) <$> recipMod a m
 -- | Find all solutions of ax² + bx + c ≡ 0 (mod m).
 --
 -- >>> :set -XDataKinds
--- >>> solveQuadratic (1 :: Mod 32) 0 (-17) -- solving x² - 17 ≡ 0 (mod 32)
+-- >>> solveQuadratic sfactors (1 :: Mod 32) 0 (-17) -- solving x² - 17 ≡ 0 (mod 32)
 -- [(9 `modulo` 32),(25 `modulo` 32),(7 `modulo` 32),(23 `modulo` 32)]
 solveQuadratic
-  :: KnownNat m
-  => Mod m   -- ^ a
+  :: SFactors Integer m
+  -> Mod m   -- ^ a
   -> Mod m   -- ^ b
   -> Mod m   -- ^ c
   -> [Mod m] -- ^ list of x
-solveQuadratic a b c
-  = map fromInteger
-  $ fst
-  $ combine
-  $ map (\(p, n) -> (solveQuadraticPrimePower a' b' c' p n, unPrime p ^ n))
-  $ factorise
-  $ getMod a
+solveQuadratic sm a b c = case proofFromSFactors sm of
+  Sub Dict ->
+    map fromInteger
+    $ fst
+    $ combine
+    $ map (\(p, n) -> (solveQuadraticPrimePower a' b' c' p n, unPrime p ^ n))
+    $ unSFactors sm
   where
     a' = getVal a
     b' = getVal b

--- a/Math/NumberTheory/Moduli/PrimitiveRoot.hs
+++ b/Math/NumberTheory/Moduli/PrimitiveRoot.hs
@@ -14,130 +14,41 @@
 {-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE TupleSections        #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns         #-}
 
-module Math.NumberTheory.Moduli.PrimitiveRoot
-  ( -- * Cyclic groups
-    CyclicGroup(..)
-  , cyclicGroupFromModulo
-  , cyclicGroupToModulo
-  , groupSize
-    -- * Primitive roots
-  , PrimitiveRoot
-  , unPrimitiveRoot
-  , getGroup
-  , isPrimitiveRoot
-  , isPrimitiveRoot'
-  ) where
-
-#if __GLASGOW_HASKELL__ < 803
-import Data.Semigroup
+#if __GLASGOW_HASKELL__ < 801
+{-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
 #endif
 
+module Math.NumberTheory.Moduli.PrimitiveRoot
+  ( -- * Primitive roots
+    PrimitiveRoot
+  , unPrimitiveRoot
+  , isPrimitiveRoot
+  ) where
+
 import Math.NumberTheory.ArithmeticFunctions (totient)
-import qualified Math.NumberTheory.Euclidean as E
-import Math.NumberTheory.Euclidean.Coprimes as Coprimes (singleton)
-import Math.NumberTheory.Moduli.Class (getNatMod, getNatVal, KnownNat, Mod, MultMod, isMultElement)
-import Math.NumberTheory.Powers.General (highestPower)
+import Math.NumberTheory.Moduli.Class hiding (powMod)
+import Math.NumberTheory.Moduli.Singleton
 import Math.NumberTheory.Powers.Modular
-import Math.NumberTheory.Prefactored
 import Math.NumberTheory.Primes
 
-import Control.DeepSeq
 import Control.Monad (guard)
-import GHC.Generics
-import Numeric.Natural
-
--- | A multiplicative group of residues is called cyclic,
--- if there is a primitive root @g@,
--- whose powers generates all elements.
--- Any cyclic multiplicative group of residues
--- falls into one of the following cases.
-data CyclicGroup a
-  = CG2 -- ^ Residues modulo 2.
-  | CG4 -- ^ Residues modulo 4.
-  | CGOddPrimePower       (Prime a) Word
-  -- ^ Residues modulo @p@^@k@ for __odd__ prime @p@.
-  | CGDoubleOddPrimePower (Prime a) Word
-  -- ^ Residues modulo 2@p@^@k@ for __odd__ prime @p@.
-  deriving (Eq, Show, Generic)
-
-instance NFData a => NFData (CyclicGroup a)
-
--- | Check whether a multiplicative group of residues,
--- characterized by its modulo, is cyclic and, if yes, return its form.
---
--- >>> cyclicGroupFromModulo 4
--- Just CG4
--- >>> cyclicGroupFromModulo (2 * 13 ^ 3)
--- Just (CGDoubleOddPrimePower (Prime 13) 3)
--- >>> cyclicGroupFromModulo (4 * 13)
--- Nothing
-cyclicGroupFromModulo
-  :: (Ord a, Integral a, UniqueFactorisation a)
-  => a
-  -> Maybe (CyclicGroup a)
-cyclicGroupFromModulo = \case
-  2 -> Just CG2
-  4 -> Just CG4
-  n
-    | n <= 1    -> Nothing
-    | odd n     -> uncurry CGOddPrimePower       <$> isPrimePower n
-    | odd halfN -> uncurry CGDoubleOddPrimePower <$> isPrimePower halfN
-    | otherwise -> Nothing
-    where
-      halfN = n `quot` 2
-
-isPrimePower
-  :: (Integral a, UniqueFactorisation a)
-  => a
-  -> Maybe (Prime a, Word)
-isPrimePower n = (, k) <$> isPrime m
-  where
-    (m, k) = highestPower n
-
--- | Extract modulo and its factorisation from
--- a cyclic multiplicative group of residues.
---
--- >>> cyclicGroupToModulo CG4
--- Prefactored {prefValue = 4, prefFactors = Coprimes {unCoprimes = [(2,2)]}}
---
--- >>> import Data.Maybe
--- >>> cyclicGroupToModulo (CGDoubleOddPrimePower (fromJust (isPrime 13)) 3)
--- Prefactored {prefValue = 4394, prefFactors = Coprimes {unCoprimes = [(13,3),(2,1)]}}
-cyclicGroupToModulo
-  :: (Eq a, Num a, E.GcdDomain a)
-  => CyclicGroup a
-  -> Prefactored a
-cyclicGroupToModulo = fromFactors . \case
-  CG2                       -> Coprimes.singleton 2 1
-  CG4                       -> Coprimes.singleton 2 2
-  CGOddPrimePower p k       -> Coprimes.singleton (unPrime p) k
-  CGDoubleOddPrimePower p k -> Coprimes.singleton 2 1
-                            <> Coprimes.singleton (unPrime p) k
+import Data.Constraint
 
 -- | 'PrimitiveRoot' m is a type which is only inhabited
 -- by <https://en.wikipedia.org/wiki/Primitive_root_modulo_n primitive roots> of m.
-data PrimitiveRoot m = PrimitiveRoot
+newtype PrimitiveRoot m = PrimitiveRoot
   { unPrimitiveRoot :: MultMod m -- ^ Extract primitive root value.
-  , getGroup        :: CyclicGroup Natural -- ^ Get cyclic group structure.
   }
   deriving (Eq, Show)
 
--- | 'isPrimitiveRoot'' @cg@ @a@ checks whether @a@ is
--- a <https://en.wikipedia.org/wiki/Primitive_root_modulo_n primitive root>
--- of a given cyclic multiplicative group of residues @cg@.
---
--- >>> let Just cg = cyclicGroupFromModulo 13
--- >>> isPrimitiveRoot' cg 1
--- False
--- >>> isPrimitiveRoot' cg 2
--- True
+-- https://en.wikipedia.org/wiki/Primitive_root_modulo_n#Finding_primitive_roots
 isPrimitiveRoot'
   :: (Integral a, UniqueFactorisation a)
-  => CyclicGroup a
+  => CyclicGroup a m
   -> a
   -> Bool
--- https://en.wikipedia.org/wiki/Primitive_root_modulo_n#Finding_primitive_roots
 isPrimitiveRoot' cg r =
   case cg of
     CG2                       -> r == 1
@@ -157,23 +68,18 @@ isPrimitiveRoot' cg r =
 -- a <https://en.wikipedia.org/wiki/Primitive_root_modulo_n primitive root>.
 --
 -- >>> :set -XDataKinds
--- >>> isPrimitiveRoot (1 :: Mod 13)
+-- >>> import Data.Maybe
+-- >>> isPrimitiveRoot (fromJust cyclicGroup) (1 :: Mod 13)
 -- Nothing
--- >>> isPrimitiveRoot (2 :: Mod 13)
--- Just (PrimitiveRoot {unPrimitiveRoot = MultMod {multElement = (2 `modulo` 13)}, getGroup = CGOddPrimePower (Prime 13) 1})
---
--- This function is a convenient wrapper around 'isPrimitiveRoot''. The latter
--- provides better control and performance, if you need them.
+-- >>> isPrimitiveRoot (fromJust cyclicGroup) (2 :: Mod 13)
+-- Just (PrimitiveRoot {unPrimitiveRoot = MultMod {multElement = (2 `modulo` 13)}})
 isPrimitiveRoot
-  :: KnownNat n
-  => Mod n
-  -> Maybe (PrimitiveRoot n)
-isPrimitiveRoot r = do
-  r' <- isMultElement r
-  cg <- cyclicGroupFromModulo (getNatMod r)
-  guard $ isPrimitiveRoot' cg (getNatVal r)
-  return $ PrimitiveRoot r' cg
-
--- | Calculate the size of a given cyclic group.
-groupSize :: (Eq a, E.GcdDomain a, UniqueFactorisation a) => CyclicGroup a -> Prefactored a
-groupSize = totient . cyclicGroupToModulo
+  :: (Integral a, UniqueFactorisation a)
+  => CyclicGroup a m
+  -> Mod m
+  -> Maybe (PrimitiveRoot m)
+isPrimitiveRoot cg r = case proofFromCyclicGroup cg of
+  Sub Dict -> do
+    r' <- isMultElement r
+    guard $ isPrimitiveRoot' cg (fromIntegral (getNatVal r))
+    return $ PrimitiveRoot r'

--- a/Math/NumberTheory/Moduli/Singleton.hs
+++ b/Math/NumberTheory/Moduli/Singleton.hs
@@ -1,0 +1,314 @@
+-- |
+-- Module:      Math.NumberTheory.Moduli.Singleton
+-- Copyright:   (c) 2019 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+--
+-- Singleton data types.
+--
+
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE ViewPatterns        #-}
+
+module Math.NumberTheory.Moduli.Singleton
+  ( -- * SFactors singleton
+    SFactors
+  , sfactors
+  , someSFactors
+  , unSFactors
+  , proofFromSFactors
+    -- * CyclicGroup singleton
+  , CyclicGroup
+  , cyclicGroup
+  , cyclicGroupFromFactors
+  , cyclicGroupFromModulo
+  , proofFromCyclicGroup
+  , pattern CG2
+  , pattern CG4
+  , pattern CGOddPrimePower
+  , pattern CGDoubleOddPrimePower
+    -- * SFactors \<=\> CyclicGroup
+  , cyclicGroupToSFactors
+  , sfactorsToCyclicGroup
+    -- * Some wrapper
+  , Some(..)
+  ) where
+
+import Control.DeepSeq
+import Data.Constraint
+import Data.List
+import qualified Data.Map as M
+import Data.Proxy
+#if __GLASGOW_HASKELL__ < 803
+import Data.Semigroup
+#endif
+import GHC.Generics
+import GHC.TypeNats.Compat
+import Numeric.Natural
+import Unsafe.Coerce
+
+import Math.NumberTheory.Powers
+import Math.NumberTheory.Primes
+import Math.NumberTheory.Primes.Types
+
+-- | Wrapper to hide an unknown type-level natural.
+data Some (a :: Nat -> *) where
+  Some :: a m -> Some a
+
+-- | From "Data.Constraint.Nat".
+newtype Magic n = Magic (KnownNat n => Dict (KnownNat n))
+
+-- | This singleton data type establishes a correspondence
+-- between a modulo @m@ on type level
+-- and its factorisation on term level.
+newtype SFactors a (m :: Nat) = SFactors
+  { unSFactors :: [(Prime a, Word)]
+  -- ^ Factors of @m@.
+  } deriving (Show, Generic)
+
+instance Eq (SFactors a m) where
+  _ == _ = True
+
+instance Ord (SFactors a m) where
+  _ `compare` _ = EQ
+
+instance NFData a => NFData (SFactors a m)
+
+instance Ord a => Eq (Some (SFactors a)) where
+  Some (SFactors xs) == Some (SFactors ys) =
+    xs == ys
+
+instance Ord a => Ord (Some (SFactors a)) where
+  Some (SFactors xs) `compare` Some (SFactors ys) =
+    xs `compare` ys
+
+instance Show a => Show (Some (SFactors a)) where
+  showsPrec p (Some x) = showsPrec p x
+
+instance NFData a => NFData (Some (SFactors a)) where
+  rnf (Some x) = rnf x
+
+-- | Create a singleton from a type-level positive modulo @m@,
+-- passed in a constraint.
+--
+-- >>> :set -XDataKinds
+-- >>> sfactors :: SFactors Integer 13
+-- SFactors {sfactorsFactors = [(Prime 13,1)]}
+sfactors :: forall a m. (Ord a, UniqueFactorisation a, KnownNat m) => SFactors a m
+sfactors = if m == 0
+  then error "sfactors: modulo must be positive"
+  else SFactors (sort (factorise m))
+  where
+    m = fromIntegral (natVal (Proxy :: Proxy m))
+
+-- | Create a singleton from factors of @m@.
+-- Factors must be distinct, as in output of 'factorise'.
+--
+-- >>> import Math.NumberTheory.Primes
+-- >>> someSFactors (factorise 98)
+-- SFactors {sfactorsFactors = [(Prime 2,1),(Prime 7,2)]}
+someSFactors :: (Ord a, Num a) => [(Prime a, Word)] -> Some (SFactors a)
+someSFactors
+  = Some
+  . SFactors
+  -- Just a precaution against ill-formed lists of factors
+  . M.assocs
+  . M.fromListWith (+)
+
+-- | Convert a singleton to a proof that @m@ is known. Usage example:
+--
+-- > toModulo :: SFactors Integer m -> Natural
+-- > toModulo t = case proofFromSFactors t of Sub Dict -> natVal t
+proofFromSFactors :: Integral a => SFactors a m -> (() :- KnownNat m)
+proofFromSFactors (SFactors fs) = Sub $ unsafeCoerce (Magic Dict) (fromIntegral (factorBack fs) :: Natural)
+
+-- | This singleton data type establishes a correspondence
+-- between a modulo @m@ on type level
+-- and a cyclic group of the same order on term level.
+data CyclicGroup a (m :: Nat)
+  = CG2' -- ^ Residues modulo 2.
+  | CG4' -- ^ Residues modulo 4.
+  | CGOddPrimePower'       (Prime a) Word
+  -- ^ Residues modulo @p@^@k@ for __odd__ prime @p@.
+  | CGDoubleOddPrimePower' (Prime a) Word
+  -- ^ Residues modulo 2@p@^@k@ for __odd__ prime @p@.
+  deriving (Show, Generic)
+
+instance Eq (CyclicGroup a m) where
+  _ == _ = True
+
+instance Ord (CyclicGroup a m) where
+  _ `compare` _ = EQ
+
+instance NFData a => NFData (CyclicGroup a m)
+
+instance Eq a => Eq (Some (CyclicGroup a)) where
+  Some CG2' == Some CG2' = True
+  Some CG4' == Some CG4' = True
+  Some (CGOddPrimePower' p1 k1) == Some (CGOddPrimePower' p2 k2) =
+    p1 == p2 && k1 == k2
+  Some (CGDoubleOddPrimePower' p1 k1) == Some (CGDoubleOddPrimePower' p2 k2) =
+    p1 == p2 && k1 == k2
+  _ == _ = False
+
+instance Ord a => Ord (Some (CyclicGroup a)) where
+  compare (Some x) (Some y) = case x of
+    CG2' -> case y of
+      CG2' -> EQ
+      _    -> LT
+    CG4' -> case y of
+      CG2' -> GT
+      CG4' -> EQ
+      _    -> LT
+    CGOddPrimePower' p1 k1 -> case y of
+      CGDoubleOddPrimePower'{} -> LT
+      CGOddPrimePower' p2 k2 ->
+        p1 `compare` p2 <> k1 `compare` k2
+      _ -> GT
+    CGDoubleOddPrimePower' p1 k1 -> case y of
+      CGDoubleOddPrimePower' p2 k2 ->
+        p1 `compare` p2 <> k1 `compare` k2
+      _ -> GT
+
+instance Show a => Show (Some (CyclicGroup a)) where
+  showsPrec p (Some x) = showsPrec p x
+
+instance NFData a => NFData (Some (CyclicGroup a)) where
+  rnf (Some x) = rnf x
+
+-- | Create a singleton from a type-level positive modulo @m@,
+-- passed in a constraint.
+--
+-- >>> :set -XDataKinds
+-- >>> import Data.Maybe
+-- >>> cyclicGroup :: CyclicGroup Integer 169
+-- CGOddPrimePower' (Prime 13) 2
+--
+-- >>> sfactorsToCyclicGroup (fromModulo 4)
+-- Just CG4'
+-- >>> sfactorsToCyclicGroup (fromModulo (2 * 13 ^ 3))
+-- Just (CGDoubleOddPrimePower' (Prime 13) 3)
+-- >>> sfactorsToCyclicGroup (fromModulo (4 * 13))
+-- Nothing
+cyclicGroup
+  :: forall a m.
+     (Integral a, UniqueFactorisation a, KnownNat m)
+  => Maybe (CyclicGroup a m)
+cyclicGroup = fromModuloInternal m
+  where
+    m = fromIntegral (natVal (Proxy :: Proxy m))
+
+cyclicGroupFromFactors
+  :: (Eq a, Num a)
+  => [(Prime a, Word)]
+  -> Maybe (Some (CyclicGroup a))
+cyclicGroupFromFactors = \case
+  [(unPrime -> 2, 1)] -> Just $ Some CG2'
+  [(unPrime -> 2, 2)] -> Just $ Some CG4'
+  [(unPrime -> 2, _)] -> Nothing
+  [(p, k)] -> Just $ Some $ CGOddPrimePower' p k
+  [(unPrime -> 2, 1), (p, k)] -> Just $ Some $ CGDoubleOddPrimePower' p k
+  [(p, k), (unPrime -> 2, 1)] -> Just $ Some $ CGDoubleOddPrimePower' p k
+  _ -> Nothing
+
+-- | Similar to 'cyclicGroupFromFactors' . 'factorise',
+-- but much faster, because it
+-- but performes only one primality test instead of full
+-- factorisation.
+cyclicGroupFromModulo
+  :: (Integral a, UniqueFactorisation a)
+  => a
+  -> Maybe (Some (CyclicGroup a))
+cyclicGroupFromModulo = fmap Some . fromModuloInternal
+
+fromModuloInternal
+  :: (Integral a, UniqueFactorisation a)
+  => a
+  -> Maybe (CyclicGroup a m)
+fromModuloInternal = \case
+  2 -> Just CG2'
+  4 -> Just CG4'
+  n
+    | even n -> uncurry CGDoubleOddPrimePower' <$> isOddPrimePower (n `div` 2)
+    | otherwise -> uncurry CGOddPrimePower' <$> isOddPrimePower n
+
+isOddPrimePower
+  :: (Integral a, UniqueFactorisation a)
+  => a
+  -> Maybe (Prime a, Word)
+isOddPrimePower n
+  | even n    = Nothing
+  | otherwise = (, k) <$> isPrime p
+  where
+    (p, k) = highestPower n
+
+-- | Convert a cyclic group to a proof that @m@ is known. Usage example:
+--
+-- > toModulo :: CyclicGroup Integer m -> Natural
+-- > toModulo t = case proofFromCyclicGroup t of Sub Dict -> natVal t
+proofFromCyclicGroup :: Integral a => CyclicGroup a m -> (() :- KnownNat m)
+proofFromCyclicGroup = proofFromSFactors . cyclicGroupToSFactors
+
+-- | Check whether a multiplicative group of residues,
+-- characterized by its modulo, is cyclic and, if yes, return its form.
+--
+-- >>> sfactorsToCyclicGroup (fromModulo 4)
+-- Just CG4'
+-- >>> sfactorsToCyclicGroup (fromModulo (2 * 13 ^ 3))
+-- Just (CGDoubleOddPrimePower' (Prime 13) 3)
+-- >>> sfactorsToCyclicGroup (fromModulo (4 * 13))
+-- Nothing
+sfactorsToCyclicGroup :: (Eq a, Num a) => SFactors a m -> Maybe (CyclicGroup a m)
+sfactorsToCyclicGroup (SFactors fs) = case fs of
+  [(unPrime -> 2, 1)]         -> Just CG2'
+  [(unPrime -> 2, 2)]         -> Just CG4'
+  [(unPrime -> 2, _)]         -> Nothing
+  [(p, k)]                    -> Just $ CGOddPrimePower' p k
+  [(p, k), (unPrime -> 2, 1)] -> Just $ CGDoubleOddPrimePower' p k
+  [(unPrime -> 2, 1), (p, k)] -> Just $ CGDoubleOddPrimePower' p k
+  _ -> Nothing
+
+-- | Invert 'sfactorsToCyclicGroup'.
+--
+-- >>> import Data.Maybe
+-- >>> cyclicGroupToSFactors (fromJust (sfactorsToCyclicGroup (fromModulo 4)))
+-- SFactors {sfactorsModulo = 4, sfactorsFactors = [(Prime 2,2)]}
+cyclicGroupToSFactors :: Num a => CyclicGroup a m -> SFactors a m
+cyclicGroupToSFactors = SFactors . \case
+  CG2' -> [(Prime 2, 1)]
+  CG4' -> [(Prime 2, 2)]
+  CGOddPrimePower' p k -> [(p, k)]
+  CGDoubleOddPrimePower' p k -> [(Prime 2, 1), (p, k)]
+
+-- | Unidirectional pattern for residues modulo 2.
+pattern CG2 :: CyclicGroup a m
+pattern CG2 <- CG2'
+
+-- | Unidirectional pattern for residues modulo 4.
+pattern CG4 :: CyclicGroup a m
+pattern CG4 <- CG4'
+
+-- | Unidirectional pattern for residues modulo @p@^@k@ for __odd__ prime @p@.
+pattern CGOddPrimePower :: Prime a -> Word -> CyclicGroup a m
+pattern CGOddPrimePower p k <- CGOddPrimePower' p k
+
+-- | Unidirectional pattern for residues modulo 2@p@^@k@ for __odd__ prime @p@.
+pattern CGDoubleOddPrimePower :: Prime a -> Word -> CyclicGroup a m
+pattern CGDoubleOddPrimePower p k <- CGDoubleOddPrimePower' p k
+
+#if __GLASGOW_HASKELL__ > 801
+{-# COMPLETE CG2, CG4, CGOddPrimePower, CGDoubleOddPrimePower #-}
+#endif

--- a/Math/NumberTheory/Moduli/Sqrt.hs
+++ b/Math/NumberTheory/Moduli/Sqrt.hs
@@ -21,23 +21,25 @@ module Math.NumberTheory.Moduli.Sqrt
 
 import Control.Monad (liftM2)
 import Data.Bits
+import Data.Constraint
 
 import Math.NumberTheory.Moduli.Chinese
-import Math.NumberTheory.Moduli.Class (Mod, getVal, getMod, KnownNat)
+import Math.NumberTheory.Moduli.Class hiding (powMod)
 import Math.NumberTheory.Moduli.Jacobi
+import Math.NumberTheory.Moduli.Singleton
 import Math.NumberTheory.Powers.Modular (powMod)
 import Math.NumberTheory.Primes
-import Math.NumberTheory.Primes (factorise)
 import Math.NumberTheory.Utils (shiftToOddCount, splitOff, recipMod)
 import Math.NumberTheory.Utils.FromIntegral
 
 -- | List all modular square roots.
 --
 -- >>> :set -XDataKinds
--- >>> sqrtsMod (1 :: Mod 60)
+-- >>> sqrtsMod sfactors (1 :: Mod 60)
 -- [(1 `modulo` 60),(49 `modulo` 60),(41 `modulo` 60),(29 `modulo` 60),(31 `modulo` 60),(19 `modulo` 60),(11 `modulo` 60),(59 `modulo` 60)]
-sqrtsMod :: KnownNat m => Mod m -> [Mod m]
-sqrtsMod a = map fromInteger $ sqrtsModFactorisation (getVal a) (factorise (getMod a))
+sqrtsMod :: SFactors Integer m -> Mod m -> [Mod m]
+sqrtsMod sm a = case proofFromSFactors sm of
+  Sub Dict -> map fromInteger $ sqrtsModFactorisation (getVal a) (unSFactors sm)
 
 -- | List all square roots modulo a number, the factorisation of which is
 -- passed as a second argument.

--- a/Math/NumberTheory/Primes.hs
+++ b/Math/NumberTheory/Primes.hs
@@ -18,6 +18,7 @@ module Math.NumberTheory.Primes
     , nextPrime
     , precPrime
     , UniqueFactorisation(..)
+    , factorBack
     , -- * Old interface
       primes
     ) where
@@ -97,6 +98,9 @@ instance UniqueFactorisation Integer where
 instance UniqueFactorisation Natural where
   factorise = map (coerce integerToNatural *** id) . F.factorise . naturalToInteger
   isPrime n = if T.isPrime (toInteger n) then Just (Prime n) else Nothing
+
+factorBack :: Num a => [(Prime a, Word)] -> a
+factorBack = product . map (\(p, k) -> unPrime p ^ k)
 
 -- | Smallest prime, greater or equal to argument.
 --

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -38,6 +38,7 @@ library
     base >=4.9 && <5,
     array >=0.5 && <0.6,
     containers >=0.5 && <0.7,
+    constraints,
     deepseq,
     exact-pi >=0.5,
     ghc-prim <0.6,
@@ -65,6 +66,7 @@ library
     Math.NumberTheory.Moduli.Equations
     Math.NumberTheory.Moduli.Jacobi
     Math.NumberTheory.Moduli.PrimitiveRoot
+    Math.NumberTheory.Moduli.Singleton
     Math.NumberTheory.Moduli.Sqrt
     Math.NumberTheory.MoebiusInversion
     Math.NumberTheory.MoebiusInversion.Int
@@ -149,6 +151,7 @@ test-suite spec
     Math.NumberTheory.Moduli.EquationsTests
     Math.NumberTheory.Moduli.JacobiTests
     Math.NumberTheory.Moduli.PrimitiveRootTests
+    Math.NumberTheory.Moduli.SingletonTests
     Math.NumberTheory.Moduli.SqrtTests
     Math.NumberTheory.MoebiusInversionTests
     Math.NumberTheory.Powers.CubesTests
@@ -184,6 +187,7 @@ benchmark criterion
     base,
     arithmoi,
     array,
+    constraints,
     containers,
     deepseq,
     gauge,

--- a/benchmark/Math/NumberTheory/DiscreteLogarithmBench.hs
+++ b/benchmark/Math/NumberTheory/DiscreteLogarithmBench.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TypeApplications          #-}
 
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
@@ -11,6 +12,7 @@ module Math.NumberTheory.DiscreteLogarithmBench
   ) where
 
 import Gauge.Main
+import Control.Monad
 import Data.Maybe
 import GHC.TypeNats.Compat
 import Data.Proxy
@@ -18,7 +20,8 @@ import Numeric.Natural
 
 import Math.NumberTheory.Moduli.Class (isMultElement, KnownNat, MultMod, multElement, getVal,Mod)
 import Math.NumberTheory.Moduli.DiscreteLogarithm (discreteLogarithm)
-import Math.NumberTheory.Moduli.PrimitiveRoot (PrimitiveRoot, isPrimitiveRoot, unPrimitiveRoot, cyclicGroupFromModulo)
+import Math.NumberTheory.Moduli.PrimitiveRoot
+import Math.NumberTheory.Moduli.Singleton
 
 data Case = forall m. KnownNat m => Case (PrimitiveRoot m) (MultMod m) String
 
@@ -31,7 +34,7 @@ makeCase :: (Integer, Integer, Natural, String) -> Maybe Case
 makeCase (a,b,n,s) =
   case someNatVal n of
     SomeNat (_ :: Proxy m) ->
-      Case <$> isPrimitiveRoot a' <*> isMultElement b' <*> pure s
+      Case <$> join (isPrimitiveRoot @Integer <$> cyclicGroup <*> pure a') <*> isMultElement b' <*> pure s
         where a' = fromInteger a :: Mod m
               b' = fromInteger b
 
@@ -45,15 +48,16 @@ cases = mapMaybe makeCase [ (5,  8,  10^9 + 7,  "10^9 + 7")
 rangeCases :: Natural -> Int -> [Case]
 rangeCases start num = take num $ do
   n <- [start..]
-  _cg <- maybeToList $ cyclicGroupFromModulo n
   case someNatVal n of
-    SomeNat (_ :: Proxy m) -> do
-      a <- take 1 $ mapMaybe isPrimitiveRoot [2 :: Mod m .. maxBound]
-      b <- take 1 $ filter (/= unPrimitiveRoot a) $ mapMaybe isMultElement [2 .. maxBound]
-      return $ Case a b (show n)
+    SomeNat (_ :: Proxy m) -> case cyclicGroup :: Maybe (CyclicGroup Integer m) of
+      Nothing -> []
+      Just cg -> do
+        a <- take 1 $ mapMaybe (isPrimitiveRoot cg) [2 :: Mod m .. maxBound]
+        b <- take 1 $ filter (/= unPrimitiveRoot a) $ mapMaybe isMultElement [2 .. maxBound]
+        return $ Case a b (show n)
 
 discreteLogarithm' :: Case -> Natural
-discreteLogarithm' (Case a b _) = discreteLogarithm a b
+discreteLogarithm' (Case a b _) = discreteLogarithm (fromJust cyclicGroup) a b
 
 benchSuite :: Benchmark
 benchSuite = bgroup "Discrete logarithm"

--- a/benchmark/Math/NumberTheory/PrimitiveRootsBench.hs
+++ b/benchmark/Math/NumberTheory/PrimitiveRootsBench.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RankNTypes #-}
+
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 module Math.NumberTheory.PrimitiveRootsBench
@@ -5,20 +7,29 @@ module Math.NumberTheory.PrimitiveRootsBench
   ) where
 
 import Gauge.Main
+import Data.Constraint
 import Data.Maybe
 
 import Math.NumberTheory.Moduli.PrimitiveRoot
+import Math.NumberTheory.Moduli.Singleton
 import Math.NumberTheory.Primes
 
 primRootWrap :: Integer -> Word -> Integer -> Bool
-primRootWrap p k g = isPrimitiveRoot' (CGOddPrimePower p' k) g
-  where p' = fromJust $ isPrime p
+primRootWrap p k g = case fromJust $ cyclicGroupFromFactors [(p', k)] of
+  Some cg -> case proofFromCyclicGroup cg of
+    Sub Dict -> isJust $ isPrimitiveRoot cg (fromInteger g)
+  where
+    p' = fromJust $ isPrime p
 
 primRootWrap2 :: Integer -> Word -> Integer -> Bool
-primRootWrap2 p k g = isPrimitiveRoot' (CGDoubleOddPrimePower p' k) g
-  where p' = fromJust $ isPrime p
+primRootWrap2 p k g = case fromJust $ cyclicGroupFromFactors [(two, 1), (p', k)] of
+  Some cg -> case proofFromCyclicGroup cg of
+    Sub Dict -> isJust $ isPrimitiveRoot cg (fromInteger g)
+  where
+    two = fromJust $ isPrime 2
+    p'  = fromJust $ isPrime p
 
-cyclicWrap :: Integer -> Maybe (CyclicGroup Integer)
+cyclicWrap :: Integer -> Maybe (Some (CyclicGroup Integer))
 cyclicWrap = cyclicGroupFromModulo
 
 benchSuite :: Benchmark

--- a/test-suite/Math/NumberTheory/Moduli/DiscreteLogarithmTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/DiscreteLogarithmTests.hs
@@ -13,10 +13,11 @@ import Data.Semigroup
 import Data.Proxy
 import GHC.TypeNats.Compat
 
-import Math.NumberTheory.Moduli.Class
-import Math.NumberTheory.Moduli.PrimitiveRoot
-import Math.NumberTheory.Moduli.DiscreteLogarithm
 import Math.NumberTheory.ArithmeticFunctions (totient)
+import Math.NumberTheory.Moduli.Class
+import Math.NumberTheory.Moduli.DiscreteLogarithm
+import Math.NumberTheory.Moduli.PrimitiveRoot
+import Math.NumberTheory.Moduli.Singleton
 import Math.NumberTheory.TestUtils
 
 -- | Ensure 'discreteLogarithm' returns in the appropriate range.
@@ -24,27 +25,30 @@ discreteLogRange :: Positive Natural -> Integer -> Integer -> Bool
 discreteLogRange (Positive m) a b =
   case someNatVal m of
     SomeNat (_ :: Proxy m) -> fromMaybe True $ do
-      a' <- isPrimitiveRoot (fromInteger a :: Mod m)
+      cg <- cyclicGroup :: Maybe (CyclicGroup Integer m)
+      a' <- isPrimitiveRoot cg (fromInteger a)
       b' <- isMultElement (fromInteger b)
-      return $ discreteLogarithm a' b' < totient m
+      return $ discreteLogarithm cg a' b' < totient m
 
 -- | Check that 'discreteLogarithm' inverts exponentiation.
 discreteLogarithmProperty :: Positive Natural -> Integer -> Integer -> Bool
 discreteLogarithmProperty (Positive m) a b =
   case someNatVal m of
     SomeNat (_ :: Proxy m) -> fromMaybe True $ do
-      a' <- isPrimitiveRoot (fromInteger a :: Mod m)
+      cg <- cyclicGroup :: Maybe (CyclicGroup Integer m)
+      a' <- isPrimitiveRoot cg (fromInteger a)
       b' <- isMultElement (fromInteger b)
-      return $ discreteLogarithm a' b' `stimes` unPrimitiveRoot a' == b'
+      return $ discreteLogarithm cg a' b' `stimes` unPrimitiveRoot a' == b'
 
 -- | Check that 'discreteLogarithm' inverts exponentiation in the other direction.
 discreteLogarithmProperty' :: Positive Natural -> Integer -> Natural -> Bool
 discreteLogarithmProperty' (Positive m) a k =
   case someNatVal m of
     SomeNat (_ :: Proxy m) -> fromMaybe True $ do
-      a'' <- isPrimitiveRoot (fromInteger a :: Mod m)
+      cg <- cyclicGroup :: Maybe (CyclicGroup Integer m)
+      a'' <- isPrimitiveRoot cg (fromInteger a)
       let a' = unPrimitiveRoot a''
-      return $ discreteLogarithm a'' (k `stimes` a') == k `mod` totient m
+      return $ discreteLogarithm cg a'' (k `stimes` a') == k `mod` totient m
 
 testSuite :: TestTree
 testSuite = testGroup "Discrete logarithm"

--- a/test-suite/Math/NumberTheory/Moduli/EquationsTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/EquationsTests.hs
@@ -20,6 +20,7 @@ import Numeric.Natural
 
 import Math.NumberTheory.Moduli.Class
 import Math.NumberTheory.Moduli.Equations
+import Math.NumberTheory.Moduli.Singleton
 import Math.NumberTheory.TestUtils
 
 solveLinearProp :: KnownNat m => Mod m -> Mod m -> Bool
@@ -31,7 +32,7 @@ solveLinearProperty1 (Positive m) a b = case someNatVal m of
   SomeNat (_ :: Proxy t) -> solveLinearProp (fromInteger a :: Mod t) (fromInteger b)
 
 solveQuadraticProp :: KnownNat m => Mod m -> Mod m -> Mod m -> Bool
-solveQuadraticProp a b c = sort (solveQuadratic a b c) ==
+solveQuadraticProp a b c = sort (solveQuadratic sfactors a b c) ==
   filter (\x -> a * x * x + b * x + c == 0) [minBound .. maxBound]
 
 solveQuadraticProperty1 :: Positive Natural -> Integer -> Integer -> Integer -> Bool

--- a/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
@@ -18,6 +18,7 @@ module Math.NumberTheory.Moduli.PrimitiveRootTests
 
 import Prelude hiding (gcd)
 import Test.Tasty
+import Test.Tasty.HUnit
 
 import qualified Data.Set as S
 import Data.List (genericTake, genericLength)
@@ -53,6 +54,9 @@ cyclicGroupProperty3 (Positive n) = case isPrime n of
   Nothing -> True
   Just _  -> 2 * n < n {- overflow check -}
           || isJust (cyclicGroupFromModulo n)
+
+cyclicGroupSpecialCase1 :: Assertion
+cyclicGroupSpecialCase1 = assertBool "should be non-cyclic" $ isNothing $ fromModulo (8 :: Integer)
 
 allUnique :: Ord a => [a] -> Bool
 allUnique = go S.empty
@@ -109,6 +113,7 @@ testSuite = testGroup "Primitive root"
     [ testIntegralProperty "cyclicGroupToModulo . cyclicGroupFromModulo" cyclicGroupProperty1
     , testIntegralProperty "cyclic group mod p" cyclicGroupProperty2
     , testIntegralProperty "cyclic group mod 2p" cyclicGroupProperty3
+    , testCase "cyclic group mod 8" cyclicGroupSpecialCase1
     ]
   , testGroup "isPrimitiveRoot'"
     [ testGroup "primitive root is coprime with modulo"

--- a/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
@@ -23,24 +23,22 @@ import Test.Tasty.HUnit
 import qualified Data.Set as S
 import Data.List (genericTake, genericLength)
 import Data.Maybe (isJust, isNothing, mapMaybe)
-import Control.Arrow (first)
 import Numeric.Natural
 import Data.Proxy
 import GHC.TypeNats.Compat
 
 import Math.NumberTheory.ArithmeticFunctions (totient)
 import Math.NumberTheory.Euclidean
-import Math.NumberTheory.Euclidean.Coprimes
-import Math.NumberTheory.Moduli.Class (Mod, SomeMod(..), modulo)
+import Math.NumberTheory.Moduli.Class
 import Math.NumberTheory.Moduli.PrimitiveRoot
-import Math.NumberTheory.Prefactored (fromFactors, prefFactors, prefValue, Prefactored)
+import Math.NumberTheory.Moduli.Singleton
 import Math.NumberTheory.Primes
 import Math.NumberTheory.TestUtils
 
-cyclicGroupProperty1 :: (GcdDomain a, Euclidean a, Integral a, UniqueFactorisation a) => AnySign a -> Bool
-cyclicGroupProperty1 (AnySign n) = case cyclicGroupFromModulo n of
+cyclicGroupProperty1 :: (Euclidean a, Integral a, UniqueFactorisation a) => Positive a -> Bool
+cyclicGroupProperty1 (Positive n) = case cyclicGroupFromModulo n of
   Nothing -> True
-  Just cg -> prefValue (cyclicGroupToModulo cg) == n
+  Just (Some cg) -> factorBack (unSFactors (cyclicGroupToSFactors cg)) == n
 
 -- | Multiplicative groups modulo primes are always cyclic.
 cyclicGroupProperty2 :: (Integral a, UniqueFactorisation a) => Positive a -> Bool
@@ -56,7 +54,7 @@ cyclicGroupProperty3 (Positive n) = case isPrime n of
           || isJust (cyclicGroupFromModulo n)
 
 cyclicGroupSpecialCase1 :: Assertion
-cyclicGroupSpecialCase1 = assertBool "should be non-cyclic" $ isNothing $ fromModulo (8 :: Integer)
+cyclicGroupSpecialCase1 = assertBool "should be non-cyclic" $ isNothing $ cyclicGroupFromModulo (8 :: Integer)
 
 allUnique :: Ord a => [a] -> Bool
 allUnique = go S.empty
@@ -65,69 +63,64 @@ allUnique = go S.empty
     go acc (x : xs) = if x `S.member` acc then False else go (S.insert x acc) xs
 
 isPrimitiveRoot'Property1
-  :: (GcdDomain a, Euclidean a, Integral a, UniqueFactorisation a)
-  => AnySign a -> CyclicGroup a -> Bool
-isPrimitiveRoot'Property1 (AnySign n) cg
-  = gcd (toInteger n) (prefValue (castPrefactored (cyclicGroupToModulo cg))) == 1
-  || not (isPrimitiveRoot' cg n)
-
-castPrefactored :: Integral a => Prefactored a -> Prefactored Integer
-castPrefactored = fromFactors . splitIntoCoprimes . map (first toInteger) . unCoprimes . prefFactors
+  :: forall a. (Euclidean a, Integral a, UniqueFactorisation a)
+  => AnySign a
+  -> Positive Natural
+  -> Bool
+isPrimitiveRoot'Property1 (AnySign n) (Positive m) = case someNatVal m of
+  SomeNat (_ :: Proxy m) -> case cyclicGroup :: Maybe (CyclicGroup a m) of
+    Nothing -> True
+    Just cg -> case isPrimitiveRoot cg (fromIntegral n) of
+      Nothing -> True
+      Just rt -> gcd (toInteger m) (getVal (multElement (unPrimitiveRoot rt))) == 1
 
 isPrimitiveRootProperty1 :: AnySign Integer -> Positive Natural -> Bool
-isPrimitiveRootProperty1 (AnySign n) (Positive m)
-  = case n `modulo` m of
-    SomeMod n' -> gcd n (toInteger m) == 1
-               || isNothing (isPrimitiveRoot n')
-    InfMod{}   -> False
+isPrimitiveRootProperty1 (AnySign n) (Positive m) = case someNatVal m of
+  SomeNat (_ :: Proxy m) -> case cyclicGroup :: Maybe (CyclicGroup Integer m) of
+    Nothing -> True
+    Just cg -> gcd n (toInteger m) == 1
+            || isNothing (isPrimitiveRoot cg (fromInteger n))
 
 isPrimitiveRootProperty2 :: Positive Natural -> Bool
-isPrimitiveRootProperty2 (Positive m)
-  = isNothing (cyclicGroupFromModulo m)
-  || case someNatVal m of
-    SomeNat (_ :: Proxy t) -> any (isJust . isPrimitiveRoot) [(minBound :: Mod t) .. maxBound]
+isPrimitiveRootProperty2 (Positive m) = case someNatVal m of
+  SomeNat (_ :: Proxy m) -> case cyclicGroup :: Maybe (CyclicGroup Integer m) of
+    Nothing -> True
+    Just cg -> any (isJust . isPrimitiveRoot cg) [minBound..maxBound]
 
 isPrimitiveRootProperty3 :: AnySign Integer -> Positive Natural -> Bool
-isPrimitiveRootProperty3 (AnySign n) (Positive m)
-  = case n `modulo` m of
-    SomeMod n' -> isNothing (isPrimitiveRoot n')
-               || allUnique (genericTake (totient m - 1) (iterate (* n') 1))
-    InfMod{}   -> False
-
-isPrimitiveRootProperty4 :: AnySign Integer -> Positive Natural -> Bool
-isPrimitiveRootProperty4 (AnySign n) (Positive m)
-  = isJust (cyclicGroupFromModulo m)
-  || case n `modulo` m of
-    SomeMod n' -> isNothing (isPrimitiveRoot n')
-    InfMod{}   -> False
+isPrimitiveRootProperty3 (AnySign n) (Positive m) = case someNatVal m of
+  SomeNat (_ :: Proxy m) -> case cyclicGroup :: Maybe (CyclicGroup Integer m) of
+    Nothing -> True
+    Just cg -> let n' = fromInteger n
+      in isNothing (isPrimitiveRoot cg n')
+      || allUnique (genericTake (totient m - 1) (iterate (* n') 1))
 
 isPrimitiveRootProperty5 :: Positive Natural -> Bool
-isPrimitiveRootProperty5 (Positive m)
-  = isNothing (cyclicGroupFromModulo m)
-  || case someNatVal m of
-       SomeNat (_ :: Proxy t) -> genericLength (mapMaybe isPrimitiveRoot [(minBound :: Mod t) .. maxBound]) == totient (totient m)
+isPrimitiveRootProperty5 (Positive m) = case someNatVal m of
+  SomeNat (_ :: Proxy m) -> case cyclicGroup :: Maybe (CyclicGroup Integer m) of
+    Nothing -> True
+    Just cg -> genericLength (mapMaybe (isPrimitiveRoot cg) [minBound..maxBound]) == totient (totient m)
 
 testSuite :: TestTree
 testSuite = testGroup "Primitive root"
   [ testGroup "CyclicGroup"
-    [ testIntegralProperty "cyclicGroupToModulo . cyclicGroupFromModulo" cyclicGroupProperty1
+    [ testIntegralProperty "cyclicGroupFromModulo" cyclicGroupProperty1
     , testIntegralProperty "cyclic group mod p" cyclicGroupProperty2
     , testIntegralProperty "cyclic group mod 2p" cyclicGroupProperty3
     , testCase "cyclic group mod 8" cyclicGroupSpecialCase1
     ]
   , testGroup "isPrimitiveRoot'"
     [ testGroup "primitive root is coprime with modulo"
-      [ testSmallAndQuick "Integer" (isPrimitiveRoot'Property1 :: AnySign Integer -> CyclicGroup Integer -> Bool)
-      , testSmallAndQuick "Natural" (isPrimitiveRoot'Property1 :: AnySign Natural -> CyclicGroup Natural -> Bool)
-      , testSmallAndQuick "Int"     (isPrimitiveRoot'Property1 :: AnySign Int     -> CyclicGroup Int     -> Bool)
-      , testSmallAndQuick "Word"    (isPrimitiveRoot'Property1 :: AnySign Word    -> CyclicGroup Word    -> Bool)
+      [ testSmallAndQuick "Integer" (isPrimitiveRoot'Property1 :: AnySign Integer -> Positive Natural -> Bool)
+      , testSmallAndQuick "Natural" (isPrimitiveRoot'Property1 :: AnySign Natural -> Positive Natural -> Bool)
+      , testSmallAndQuick "Int"     (isPrimitiveRoot'Property1 :: AnySign Int     -> Positive Natural -> Bool)
+      , testSmallAndQuick "Word"    (isPrimitiveRoot'Property1 :: AnySign Word    -> Positive Natural -> Bool)
       ]
     ]
   , testGroup "isPrimitiveRoot"
     [ testSmallAndQuick "primitive root is coprime with modulo"            isPrimitiveRootProperty1
     , testSmallAndQuick "cyclic group has a primitive root"                isPrimitiveRootProperty2
     , testSmallAndQuick "primitive root generates cyclic group"            isPrimitiveRootProperty3
-    , testSmallAndQuick "no primitive root in non-cyclic group"            isPrimitiveRootProperty4
     , testSmallAndQuick "cyclic group has right number of primitive roots" isPrimitiveRootProperty5
     ]
   ]

--- a/test-suite/Math/NumberTheory/Moduli/SingletonTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/SingletonTests.hs
@@ -1,0 +1,46 @@
+-- |
+-- Module:      Math.NumberTheory.Moduli.SingletonTests
+-- Copyright:   (c) 2019 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+--
+-- Tests for Math.NumberTheory.Moduli.Singleton
+--
+
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+module Math.NumberTheory.Moduli.SingletonTests
+  ( testSuite
+  ) where
+
+import Test.Tasty
+
+import qualified Data.Map as M
+
+import Math.NumberTheory.Moduli.Singleton
+import Math.NumberTheory.Primes
+import Math.NumberTheory.TestUtils
+
+someSFactorsProperty1
+  :: (Ord a, Num a)
+  => [(Prime a, Word)]
+  -> Bool
+someSFactorsProperty1 xs = case someSFactors xs of
+  Some sm -> unSFactors sm == M.assocs (M.fromListWith (+) xs)
+
+cyclicGroupFromModuloProperty1
+  :: (Integral a, UniqueFactorisation a)
+  => Positive a
+  -> Bool
+cyclicGroupFromModuloProperty1 (Positive m) = mcg1 == mcg2
+  where
+    mcg1 = cyclicGroupFromModulo m
+    mcg2 = cyclicGroupFromFactors (factorise m)
+
+testSuite :: TestTree
+testSuite = testGroup "Singleton"
+  [ testSmallAndQuick "unSFactors . someSFactors = id" (someSFactorsProperty1 @Integer)
+  , testIntegralPropertyNoLarge "cyclicGroupFromModulo = cyclicGroupFromFactors . factorise" cyclicGroupFromModuloProperty1
+  ]

--- a/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/SqrtTests.hs
@@ -25,6 +25,7 @@ import Data.Maybe (fromJust)
 import Numeric.Natural
 
 import Math.NumberTheory.Moduli hiding (invertMod)
+import Math.NumberTheory.Moduli.Singleton
 import Math.NumberTheory.Primes (unPrime, isPrime, Prime)
 import Math.NumberTheory.TestUtils
 
@@ -185,7 +186,7 @@ sqrtsModFactorisationSpecialCase2 =
 
 sqrtsModProperty1 :: AnySign Integer -> Positive Natural -> Bool
 sqrtsModProperty1 (AnySign n) (Positive m) = case n `modulo` m of
-  SomeMod x -> sort (sqrtsMod x) == filter (\rt -> rt * rt == x) [minBound .. maxBound]
+  SomeMod x -> sort (sqrtsMod sfactors x) == filter (\rt -> rt * rt == x) [minBound .. maxBound]
   InfMod{} -> True
 
 testSuite :: TestTree

--- a/test-suite/Math/NumberTheory/TestUtils.hs
+++ b/test-suite/Math/NumberTheory/TestUtils.hs
@@ -59,8 +59,7 @@ import Numeric.Natural
 import Math.NumberTheory.Euclidean
 import qualified Math.NumberTheory.Quadratic.EisensteinIntegers as E (EisensteinInteger(..))
 import Math.NumberTheory.Quadratic.GaussianIntegers (GaussianInteger(..))
-import Math.NumberTheory.Moduli.PrimitiveRoot (CyclicGroup(..))
-import Math.NumberTheory.Primes (UniqueFactorisation, Prime, unPrime)
+import Math.NumberTheory.Primes (UniqueFactorisation)
 import qualified Math.NumberTheory.SmoothNumbers as SN
 
 import Math.NumberTheory.TestUtils.MyCompose
@@ -83,37 +82,6 @@ instance Arbitrary GaussianInteger where
 
 instance Monad m => Serial m GaussianInteger where
   series = cons2 (:+)
-
--------------------------------------------------------------------------------
--- Cyclic group
-
-instance (Eq a, Num a, UniqueFactorisation a, Arbitrary a) => Arbitrary (CyclicGroup a) where
-  arbitrary = frequency
-    [ (1, pure CG2)
-    , (1, pure CG4)
-    , (9, CGOddPrimePower
-      <$> (arbitrary :: Gen (Prime a)) `suchThatMap` isOddPrime
-      <*> (getPower <$> arbitrary))
-    , (9, CGDoubleOddPrimePower
-      <$> (arbitrary :: Gen (Prime a)) `suchThatMap` isOddPrime
-      <*> (getPower <$> arbitrary))
-    ]
-
-instance (Monad m, Eq a, Num a, UniqueFactorisation a, Serial m a) => Serial m (CyclicGroup a) where
-  series = pure CG2
-        \/ pure CG4
-        \/ (CGOddPrimePower
-           <$> (series :: Series m (Prime a)) `suchThatMapSerial` isOddPrime
-           <*> (getPower <$> series))
-        \/ (CGDoubleOddPrimePower
-           <$> (series :: Series m (Prime a)) `suchThatMapSerial` isOddPrime
-           <*> (getPower <$> series))
-
-isOddPrime
-  :: forall a. (Eq a, Num a, UniqueFactorisation a)
-  => Prime a
-  -> Maybe (Prime a)
-isOddPrime p = if (unPrime p :: a) == 2 then Nothing else Just p
 
 -------------------------------------------------------------------------------
 -- SmoothNumbers

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -12,6 +12,7 @@ import qualified Math.NumberTheory.Moduli.DiscreteLogarithmTests as ModuliDiscre
 import qualified Math.NumberTheory.Moduli.EquationsTests as ModuliEquations
 import qualified Math.NumberTheory.Moduli.JacobiTests as ModuliJacobi
 import qualified Math.NumberTheory.Moduli.PrimitiveRootTests as ModuliPrimitiveRoot
+import qualified Math.NumberTheory.Moduli.SingletonTests as ModuliSingleton
 import qualified Math.NumberTheory.Moduli.SqrtTests as ModuliSqrt
 
 import qualified Math.NumberTheory.MoebiusInversionTests as MoebiusInversion
@@ -71,6 +72,7 @@ tests = testGroup "All"
     , ModuliEquations.testSuite
     , ModuliJacobi.testSuite
     , ModuliPrimitiveRoot.testSuite
+    , ModuliSingleton.testSuite
     , ModuliSqrt.testSuite
     ]
   , MoebiusInversion.testSuite


### PR DESCRIPTION
This PR introduces singleton types for factors and cyclic groups, which maintain a link between a type-level modulo and a term-level value (factorisation or structure of respective cyclic group). It closes #154 and is a major redesign of cyclic groups and primitive roots API. 

It also affects modular square roots and modular equations, providing an ergonomical way to have a type-level proof that all computations are for the same modulo, without compromising performance by repetitive factorisation of modulo. 

@b-mehta could you please review this in your spare time?